### PR TITLE
ci: add PR-based release workflow and wiki deployment

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,185 @@
+name: Publish Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  publish:
+    # Only run if PR was merged (not just closed) and title starts with release emoji
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, '🚀 Release')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Extract version from PR title
+        id: version
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+          # Extract version (e.g., "🚀 Release v1.2.0" -> "v1.2.0")
+          VERSION=$(echo "$PR_TITLE" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+')
+
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not extract version from PR title: $PR_TITLE"
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION"
+
+      - name: Get previous version
+        id: previous
+        run: |
+          # Get the tag before the current one
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "v0.0.0")
+          echo "tag=$PREV_TAG" >> $GITHUB_OUTPUT
+          echo "Previous version: $PREV_TAG"
+
+      - name: Generate release notes
+        id: notes
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          PREV_TAG="${{ steps.previous.outputs.tag }}"
+
+          echo "## What's Changed in $VERSION" > RELEASE_NOTES.md
+          echo "" >> RELEASE_NOTES.md
+
+          if [ "$PREV_TAG" = "v0.0.0" ]; then
+            RANGE="HEAD"
+          else
+            RANGE="${PREV_TAG}..HEAD"
+          fi
+
+          # Features
+          FEATS=$(git log $RANGE --pretty=format:"- %s" --no-merges | grep -E "^- feat(\(.+\))?:" || true)
+          if [ -n "$FEATS" ]; then
+            echo "### ✨ Features" >> RELEASE_NOTES.md
+            echo "$FEATS" | sed 's/^- feat(\([^)]*\)): /- **\1**: /' | sed 's/^- feat: /- /' >> RELEASE_NOTES.md
+            echo "" >> RELEASE_NOTES.md
+          fi
+
+          # Fixes
+          FIXES=$(git log $RANGE --pretty=format:"- %s" --no-merges | grep -E "^- fix(\(.+\))?:" || true)
+          if [ -n "$FIXES" ]; then
+            echo "### 🐛 Bug Fixes" >> RELEASE_NOTES.md
+            echo "$FIXES" | sed 's/^- fix(\([^)]*\)): /- **\1**: /' | sed 's/^- fix: /- /' >> RELEASE_NOTES.md
+            echo "" >> RELEASE_NOTES.md
+          fi
+
+          # Performance
+          PERFS=$(git log $RANGE --pretty=format:"- %s" --no-merges | grep -E "^- perf(\(.+\))?:" || true)
+          if [ -n "$PERFS" ]; then
+            echo "### ⚡ Performance" >> RELEASE_NOTES.md
+            echo "$PERFS" | sed 's/^- perf(\([^)]*\)): /- **\1**: /' | sed 's/^- perf: /- /' >> RELEASE_NOTES.md
+            echo "" >> RELEASE_NOTES.md
+          fi
+
+          # Docs
+          DOCS=$(git log $RANGE --pretty=format:"- %s" --no-merges | grep -E "^- docs(\(.+\))?:" || true)
+          if [ -n "$DOCS" ]; then
+            echo "### 📚 Documentation" >> RELEASE_NOTES.md
+            echo "$DOCS" | sed 's/^- docs(\([^)]*\)): /- **\1**: /' | sed 's/^- docs: /- /' >> RELEASE_NOTES.md
+            echo "" >> RELEASE_NOTES.md
+          fi
+
+          # CI
+          CI=$(git log $RANGE --pretty=format:"- %s" --no-merges | grep -E "^- ci(\(.+\))?:" || true)
+          if [ -n "$CI" ]; then
+            echo "### 🔧 CI/CD" >> RELEASE_NOTES.md
+            echo "$CI" | sed 's/^- ci(\([^)]*\)): /- **\1**: /' | sed 's/^- ci: /- /' >> RELEASE_NOTES.md
+            echo "" >> RELEASE_NOTES.md
+          fi
+
+          # Others (excluding merge commits)
+          OTHERS=$(git log $RANGE --pretty=format:"- %s" --no-merges | grep -vE "^- (feat|fix|perf|docs|ci|chore\(release\))(\(.+\))?:" | grep -v "^- Merge" || true)
+          if [ -n "$OTHERS" ]; then
+            echo "### 🔨 Other Changes" >> RELEASE_NOTES.md
+            echo "$OTHERS" >> RELEASE_NOTES.md
+            echo "" >> RELEASE_NOTES.md
+          fi
+
+          echo "" >> RELEASE_NOTES.md
+          echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG}...${VERSION}" >> RELEASE_NOTES.md
+
+          cat RELEASE_NOTES.md
+
+      - name: Create tag
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Check if tag already exists
+          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+            echo "Tag $VERSION already exists, skipping tag creation"
+          else
+            git tag -a "$VERSION" -m "Release $VERSION"
+            git push origin "$VERSION"
+            echo "Created and pushed tag $VERSION"
+          fi
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Check if release already exists
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "Release $VERSION already exists, updating..."
+            gh release edit "$VERSION" \
+              --title "$VERSION" \
+              --notes-file RELEASE_NOTES.md
+          else
+            gh release create "$VERSION" \
+              --title "$VERSION" \
+              --notes-file RELEASE_NOTES.md \
+              --target main
+            echo "Created release $VERSION"
+          fi
+
+      - name: Sync main back to develop
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Fetch develop
+          git fetch origin develop
+          git checkout develop
+          git pull origin develop
+
+          # Merge main into develop
+          git merge main --no-ff -m "chore: sync ${{ steps.version.outputs.version }} release to develop"
+
+          # Push develop
+          git push origin develop
+
+          echo "Synced main back to develop"
+
+      - name: Summary
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          echo "## 🎉 Release Published!" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** \`$VERSION\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Release URL:** https://github.com/${{ github.repository }}/releases/tag/$VERSION" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Actions Completed" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Created tag \`$VERSION\`" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Published GitHub Release" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Synced \`main\` back to \`develop\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Release Notes" >> $GITHUB_STEP_SUMMARY
+          cat RELEASE_NOTES.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Create Release
+name: Prepare Release
 
 on:
   workflow_dispatch:
@@ -15,17 +15,40 @@ on:
           - major
 
 jobs:
-  release:
+  prepare-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
-      - name: Checkout
+      - name: Checkout develop branch
         uses: actions/checkout@v4
         with:
+          ref: develop
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Verify branches
+        run: |
+          git fetch origin main develop
+
+          echo "Branches status:"
+          echo "  develop: $(git rev-parse --short origin/develop)"
+          echo "  main:    $(git rev-parse --short origin/main)"
+
+          AHEAD=$(git rev-list origin/main..origin/develop --count)
+          echo "  develop is $AHEAD commit(s) ahead of main"
+
+          if [ "$AHEAD" -eq 0 ]; then
+            echo "::error::develop has no new commits compared to main. Nothing to release."
+            exit 1
+          fi
 
       - name: Get current version
         id: current
@@ -40,18 +63,18 @@ jobs:
           CURRENT_TAG="${{ steps.current.outputs.tag }}"
           BUMP="${{ inputs.bump }}"
 
-          # Get commits since last tag
           if [ "$CURRENT_TAG" = "v0.0.0" ]; then
-            COMMITS=$(git log --pretty=format:"%s" --no-merges)
+            COMMITS=$(git log origin/develop --pretty=format:"%s" --no-merges)
           else
-            COMMITS=$(git log ${CURRENT_TAG}..HEAD --pretty=format:"%s" --no-merges)
+            COMMITS=$(git log ${CURRENT_TAG}..origin/develop --pretty=format:"%s" --no-merges)
           fi
 
-          echo "Commits since $CURRENT_TAG:"
+          echo "Commits to be released:"
           echo "$COMMITS"
-          echo ""
 
-          # Auto-detect bump type from conventional commits
+          COMMIT_COUNT=$(echo "$COMMITS" | grep -c "." || echo "0")
+          echo "commit_count=$COMMIT_COUNT" >> $GITHUB_OUTPUT
+
           if [ "$BUMP" = "auto" ]; then
             if echo "$COMMITS" | grep -qE "^(feat|fix|docs|style|refactor|perf|test|chore)(\(.+\))?!:"; then
               BUMP="major"
@@ -73,13 +96,9 @@ jobs:
           CURRENT="${{ steps.current.outputs.tag }}"
           BUMP="${{ steps.analyze.outputs.bump }}"
 
-          # Remove 'v' prefix
           VERSION=${CURRENT#v}
-
-          # Split version
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
 
-          # Bump version
           case "$BUMP" in
             major)
               MAJOR=$((MAJOR + 1))
@@ -105,14 +124,14 @@ jobs:
           CURRENT_TAG="${{ steps.current.outputs.tag }}"
           NEW_VERSION="${{ steps.version.outputs.new }}"
 
+          # Create changelog file
           echo "## What's Changed in $NEW_VERSION" > CHANGELOG.md
           echo "" >> CHANGELOG.md
 
-          # Get commits since last tag, grouped by type
           if [ "$CURRENT_TAG" = "v0.0.0" ]; then
-            RANGE="HEAD"
+            RANGE="origin/develop"
           else
-            RANGE="${CURRENT_TAG}..HEAD"
+            RANGE="${CURRENT_TAG}..origin/develop"
           fi
 
           # Features
@@ -131,8 +150,24 @@ jobs:
             echo "" >> CHANGELOG.md
           fi
 
-          # Other changes
-          OTHERS=$(git log $RANGE --pretty=format:"- %s" --no-merges | grep -vE "^- (feat|fix)(\(.+\))?:" || true)
+          # Performance
+          PERFS=$(git log $RANGE --pretty=format:"- %s" --no-merges | grep -E "^- perf(\(.+\))?:" || true)
+          if [ -n "$PERFS" ]; then
+            echo "### Performance" >> CHANGELOG.md
+            echo "$PERFS" | sed 's/^- perf(\([^)]*\)): /- **\1**: /' | sed 's/^- perf: /- /' >> CHANGELOG.md
+            echo "" >> CHANGELOG.md
+          fi
+
+          # Docs
+          DOCS=$(git log $RANGE --pretty=format:"- %s" --no-merges | grep -E "^- docs(\(.+\))?:" || true)
+          if [ -n "$DOCS" ]; then
+            echo "### Documentation" >> CHANGELOG.md
+            echo "$DOCS" | sed 's/^- docs(\([^)]*\)): /- **\1**: /' | sed 's/^- docs: /- /' >> CHANGELOG.md
+            echo "" >> CHANGELOG.md
+          fi
+
+          # Others
+          OTHERS=$(git log $RANGE --pretty=format:"- %s" --no-merges | grep -vE "^- (feat|fix|perf|docs)(\(.+\))?:" || true)
           if [ -n "$OTHERS" ]; then
             echo "### Other Changes" >> CHANGELOG.md
             echo "$OTHERS" >> CHANGELOG.md
@@ -143,20 +178,59 @@ jobs:
 
           cat CHANGELOG.md
 
-      - name: Create tag and release
+      - name: Create release PR
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           NEW_VERSION="${{ steps.version.outputs.new }}"
 
-          # Create tag
-          git tag "$NEW_VERSION"
-          git push origin "$NEW_VERSION"
+          # Build PR body
+          PR_BODY=$(cat CHANGELOG.md)
+          PR_BODY="${PR_BODY}
 
-          # Create GitHub Release
-          gh release create "$NEW_VERSION" \
-            --title "$NEW_VERSION" \
-            --notes-file CHANGELOG.md \
-            --target ${{ github.sha }}
+          ---
 
-          echo "Release $NEW_VERSION created!"
+          > **Auto-generated release PR**
+          > Merging this PR will automatically create tag \`${NEW_VERSION}\` and publish the release.
+          >
+          > Version bump: **${{ steps.analyze.outputs.bump }}** (${{ steps.current.outputs.tag }} → ${NEW_VERSION})"
+
+          # Check if PR already exists
+          EXISTING_PR=$(gh pr list --base main --head develop --json number --jq '.[0].number' 2>/dev/null || echo "")
+
+          if [ -n "$EXISTING_PR" ] && [ "$EXISTING_PR" != "null" ]; then
+            echo "Release PR #$EXISTING_PR already exists. Updating..."
+            gh pr edit "$EXISTING_PR" \
+              --title "🚀 Release $NEW_VERSION" \
+              --body "$PR_BODY"
+            echo "pr_url=https://github.com/${{ github.repository }}/pull/$EXISTING_PR" >> $GITHUB_OUTPUT
+            echo "PR updated: https://github.com/${{ github.repository }}/pull/$EXISTING_PR"
+          else
+            echo "Creating new release PR..."
+            PR_URL=$(gh pr create \
+              --base main \
+              --head develop \
+              --title "🚀 Release $NEW_VERSION" \
+              --body "$PR_BODY")
+            echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+            echo "PR created: $PR_URL"
+          fi
+
+      - name: Summary
+        run: |
+          echo "## 🚀 Release Preparation Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Item | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Current version | \`${{ steps.current.outputs.tag }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| New version | \`${{ steps.version.outputs.new }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Bump type | ${{ steps.analyze.outputs.bump }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Commits | ${{ steps.analyze.outputs.commit_count }} |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### 📋 Next Steps" >> $GITHUB_STEP_SUMMARY
+          echo "1. Review the release PR" >> $GITHUB_STEP_SUMMARY
+          echo "2. Approve and merge the PR" >> $GITHUB_STEP_SUMMARY
+          echo "3. The release will be automatically published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### 📝 Changelog Preview" >> $GITHUB_STEP_SUMMARY
+          cat CHANGELOG.md >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -1,0 +1,75 @@
+name: Deploy Wiki
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'wiki/**'
+  workflow_dispatch:
+
+jobs:
+  deploy-wiki:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Clone wiki repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.wiki.git" wiki-repo
+
+      - name: Sync wiki content
+        run: |
+          # Remove old wiki content (except .git)
+          find wiki-repo -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
+
+          # Copy new wiki content
+          cp -r wiki/* wiki-repo/
+
+          # List what will be deployed
+          echo "Wiki files to deploy:"
+          ls -la wiki-repo/
+
+      - name: Push to wiki
+        run: |
+          cd wiki-repo
+
+          # Check if there are changes
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "No changes to wiki, skipping push"
+            exit 0
+          fi
+
+          # Add and commit
+          git add -A
+          git commit -m "docs: sync wiki from main repository
+
+          Source commit: ${{ github.sha }}
+          Triggered by: ${{ github.event_name }}"
+
+          # Push
+          git push origin master
+
+          echo "Wiki deployed successfully!"
+
+      - name: Summary
+        run: |
+          echo "## 📚 Wiki Deployed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Wiki URL:** https://github.com/${{ github.repository }}/wiki" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Pages Updated" >> $GITHUB_STEP_SUMMARY
+          for f in wiki/*.md; do
+            name=$(basename "$f" .md)
+            echo "- [$name](https://github.com/${{ github.repository }}/wiki/$name)" >> $GITHUB_STEP_SUMMARY
+          done


### PR DESCRIPTION
## Changes

### Release workflow improvements
- `release.yml`: Creates a PR from develop to main instead of direct push
- `release-publish.yml`: Triggers on merged release PRs, creates tag and GitHub release
- Respects branch protection rules (no direct push to main)
- Automatically syncs main back to develop after release

### New wiki deployment
- `wiki.yml`: Deploys `wiki/` folder to GitHub Wiki
- Triggered automatically when wiki files change on main/develop
- Can be manually triggered via workflow_dispatch

## Next Steps
After merging:
1. Enable Wiki in repo settings (if not already)
2. Create first wiki page manually (to initialize wiki repo)
3. Run "Deploy Wiki" workflow

---
🤖 Generated with [Claude Code](https://claude.ai/code)