### PR TITLE
fix: add history configuration and plugin keybindings

### DIFF
--- a/plugins.zsh
+++ b/plugins.zsh
@@ -236,3 +236,15 @@ unset _plugin
 
 # Recharger les completions si des plugins en ont ajouté
 (( $+functions[compinit] )) || autoload -Uz compinit
+
+# =======================================================
+# KEYBINDINGS POUR PLUGINS
+# =======================================================
+
+# zsh-history-substring-search : fleches haut/bas pour chercher dans l'historique
+if (( $+functions[history-substring-search-up] )); then
+    bindkey '^[[A' history-substring-search-up      # Fleche haut
+    bindkey '^[[B' history-substring-search-down    # Fleche bas
+    bindkey '^[OA' history-substring-search-up      # Fleche haut (mode application)
+    bindkey '^[OB' history-substring-search-down    # Fleche bas (mode application)
+fi

--- a/variables.zsh
+++ b/variables.zsh
@@ -1,6 +1,21 @@
 export WORK_DIR="$HOME/work"
 export SCRIPTS_DIR="$ZSH_ENV_DIR/scripts"
 
+# =======================================================
+# HISTORIQUE ZSH
+# =======================================================
+export HISTFILE="$HOME/.zsh_history"
+export HISTSIZE=50000
+export SAVEHIST=50000
+
+# Options d'historique
+setopt EXTENDED_HISTORY          # Enregistrer le timestamp
+setopt HIST_EXPIRE_DUPS_FIRST    # Supprimer les doublons en premier si limite atteinte
+setopt HIST_IGNORE_DUPS          # Ignorer les commandes consecutives identiques
+setopt HIST_IGNORE_SPACE         # Ignorer les commandes commencant par espace
+setopt HIST_VERIFY               # Montrer la commande avant execution depuis l'historique
+setopt SHARE_HISTORY             # Partager l'historique entre sessions
+
 # SOPS/Age - Chemin vers la cle de chiffrement
 export SOPS_AGE_KEY_FILE="$HOME/.config/sops/age/keys.txt"
 


### PR DESCRIPTION
## Summary
- Add missing zsh history configuration (HISTFILE, HISTSIZE, SAVEHIST)
- Enable history options: timestamps, deduplication, shared history between sessions
- Add keybindings for `zsh-history-substring-search` plugin (arrow up/down)

## Test plan
- [ ] Reload shell with `ss` or `source ~/.zshrc`
- [ ] Verify history persists between sessions
- [ ] Verify arrow keys navigate history with substring search
- [ ] Verify syntax highlighting works (requires plugins enabled in `config.zsh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)