### PR TITLE
feat(ci): auto-title release PRs

### DIFF
--- a/.github/workflows/release-pr-title.yml
+++ b/.github/workflows/release-pr-title.yml
@@ -1,0 +1,81 @@
+name: Auto-title Release PR
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: [main]
+
+jobs:
+  auto-title:
+    # Seulement pour les PRs depuis develop qui n'ont pas déjà un titre de release
+    if: github.head_ref == 'develop' && !startsWith(github.event.pull_request.title, '🚀 Release')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Calculate next version
+        id: version
+        run: |
+          # Get current tag
+          CURRENT_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          echo "Current version: $CURRENT_TAG"
+
+          # Get commits since last tag
+          if [ "$CURRENT_TAG" = "v0.0.0" ]; then
+            COMMITS=$(git log --pretty=format:"%s" --no-merges)
+          else
+            COMMITS=$(git log ${CURRENT_TAG}..HEAD --pretty=format:"%s" --no-merges)
+          fi
+
+          # Determine bump type
+          if echo "$COMMITS" | grep -qE "^(feat|fix|docs|style|refactor|perf|test|chore)(\(.+\))?!:"; then
+            BUMP="major"
+          elif echo "$COMMITS" | grep -qiE "BREAKING CHANGE"; then
+            BUMP="major"
+          elif echo "$COMMITS" | grep -qE "^feat(\(.+\))?:"; then
+            BUMP="minor"
+          else
+            BUMP="patch"
+          fi
+
+          # Calculate new version
+          VERSION=${CURRENT_TAG#v}
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+
+          case "$BUMP" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+
+          NEW_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "new=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "bump=$BUMP" >> $GITHUB_OUTPUT
+          echo "New version: $NEW_VERSION (bump: $BUMP)"
+
+      - name: Update PR title
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.new }}"
+          gh pr edit ${{ github.event.pull_request.number }} \
+            --title "🚀 Release $NEW_VERSION"
+          echo "PR title updated to: 🚀 Release $NEW_VERSION"


### PR DESCRIPTION
## Summary
Ajoute le workflow manquant `release-pr-title.yml` qui renomme automatiquement les PRs `develop` → `main` en `🚀 Release vX.X.X`.

## Test plan
- [ ] Merger cette PR
- [ ] Fermer et rouvrir PR #14 (ou en créer une nouvelle)
- [ ] Vérifier que le titre est auto-généré

🤖 Generated with [Claude Code](https://claude.com/claude-code)