### PR TITLE
feat: refactor hooks and add direnv/fzf support

### DIFF
--- a/hooks.zsh
+++ b/hooks.zsh
@@ -1,0 +1,142 @@
+# ==============================================================================
+# Hooks & Initialisations d'outils externes
+# ==============================================================================
+# Ce fichier centralise les initialisations d'outils qui utilisent des hooks zsh
+# (eval "$(tool init zsh)", hooks chpwd, etc.)
+# ==============================================================================
+
+# =======================================================
+# FZF (Keybindings & Completion)
+# =======================================================
+# Ctrl+R : recherche historique | Ctrl+T : fichiers | Alt+C : cd
+if command -v fzf &> /dev/null; then
+    # Chemins possibles pour les scripts fzf
+    _fzf_paths=(
+        "/opt/homebrew/opt/fzf/shell"    # MacOS Apple Silicon (Brew)
+        "/usr/local/opt/fzf/shell"       # MacOS Intel (Brew)
+        "/usr/share/fzf"                 # Linux (apt/dnf)
+        "$HOME/.fzf"                     # Installation manuelle
+    )
+
+    for _fzf_path in "${_fzf_paths[@]}"; do
+        if [[ -d "$_fzf_path" ]]; then
+            [[ -f "$_fzf_path/key-bindings.zsh" ]] && source "$_fzf_path/key-bindings.zsh"
+            [[ -f "$_fzf_path/completion.zsh" ]] && source "$_fzf_path/completion.zsh"
+            break
+        fi
+    done
+    unset _fzf_paths _fzf_path
+fi
+
+# =======================================================
+# STARSHIP (Prompt)
+# =======================================================
+if command -v starship &> /dev/null; then
+    eval "$(starship init zsh)"
+else
+    # Fallback minimaliste si starship absent
+    PROMPT='%n@%m %1~ %# '
+fi
+
+# =======================================================
+# NVM (Node Version Manager)
+# =======================================================
+if [ "$ZSH_ENV_MODULE_NVM" = "true" ]; then
+    export NVM_DIR="$HOME/.nvm"
+
+    # Fonction interne pour charger NVM
+    _zsh_env_load_nvm() {
+        local nvm_candidates=(
+            "$NVM_DIR/nvm.sh"                          # Linux / Install Manuelle
+            "/opt/homebrew/opt/nvm/nvm.sh"             # MacOS Apple Silicon (Brew)
+            "/usr/local/opt/nvm/nvm.sh"                # MacOS Intel (Brew)
+            "/usr/share/nvm/init-nvm.sh"               # Arch Linux (AUR)
+        )
+
+        local nvm_path
+        for nvm_path in "${nvm_candidates[@]}"; do
+            if [ -s "$nvm_path" ]; then
+                source "$nvm_path"
+
+                # Chargement de l'autocompletion
+                local nvm_root=$(dirname "$nvm_path")
+                local completion_path="$nvm_root/etc/bash_completion.d/nvm"
+                [ ! -f "$completion_path" ] && completion_path="$NVM_DIR/bash_completion"
+                [ -s "$completion_path" ] && source "$completion_path"
+
+                # Hook automatique pour .nvmrc
+                if command -v nvm &> /dev/null; then
+                    autoload -U add-zsh-hook
+                    add-zsh-hook chpwd load-nvmrc
+                fi
+
+                return 0
+            fi
+        done
+        return 1
+    }
+
+    if [ "$ZSH_ENV_NVM_LAZY" = "true" ]; then
+        # Mode Lazy : wrappers qui chargent NVM au premier appel
+        _zsh_env_lazy_nvm() {
+            unfunction node npm npx yarn pnpm nvm 2>/dev/null
+            if _zsh_env_load_nvm; then
+                "$@"
+            else
+                echo "[zsh_env] NVM non trouve"
+                return 1
+            fi
+        }
+
+        node()  { _zsh_env_lazy_nvm node "$@" }
+        npm()   { _zsh_env_lazy_nvm npm "$@" }
+        npx()   { _zsh_env_lazy_nvm npx "$@" }
+        yarn()  { _zsh_env_lazy_nvm yarn "$@" }
+        pnpm()  { _zsh_env_lazy_nvm pnpm "$@" }
+        nvm()   { _zsh_env_lazy_nvm nvm "$@" }
+    else
+        # Mode normal : charger NVM immediatement
+        if _zsh_env_load_nvm; then
+            load-nvmrc 2>/dev/null
+        fi
+    fi
+fi
+
+# =======================================================
+# SDKMAN (Java, Gradle, Maven, etc.)
+# =======================================================
+export SDKMAN_DIR="$HOME/.sdkman"
+if [ -d "$SDKMAN_DIR" ] && [ -s "$SDKMAN_DIR/bin/sdkman-init.sh" ]; then
+    source "$SDKMAN_DIR/bin/sdkman-init.sh"
+fi
+
+# =======================================================
+# ZOXIDE (Navigation rapide)
+# =======================================================
+# Zoxide utilise un hook chpwd pour enregistrer les repertoires.
+if command -v zoxide &> /dev/null; then
+    export _ZO_DOCTOR=0  # Desactive l'avertissement (direnv charge apres)
+    eval "$(zoxide init zsh)"
+    alias cd="z"
+fi
+
+# =======================================================
+# DIRENV (Charge/decharge les .envrc automatiquement)
+# =======================================================
+if command -v direnv &> /dev/null; then
+    eval "$(direnv hook zsh)"
+fi
+
+# =======================================================
+# KEYBINDINGS
+# =======================================================
+# Fleches haut/bas : recherche historique par prefixe
+# Tape "git" puis fleche haut -> affiche les commandes commencant par "git"
+autoload -U history-search-end
+zle -N history-beginning-search-backward-end history-search-end
+zle -N history-beginning-search-forward-end history-search-end
+
+bindkey '^[[A' history-beginning-search-backward-end  # Fleche haut
+bindkey '^[[B' history-beginning-search-forward-end   # Fleche bas
+bindkey '^[OA' history-beginning-search-backward-end  # Fleche haut (mode application)
+bindkey '^[OB' history-beginning-search-forward-end   # Fleche bas (mode application)

--- a/install.sh
+++ b/install.sh
@@ -151,6 +151,7 @@ install_tool "zoxide"   "zoxide"    "zoxide"    "zoxide"
 install_tool "fzf"      "fzf"       "fzf"       "fzf"
 install_tool "bat"      "bat"       "bat"       "bat"  # "cat" avec des ailes
 install_tool "nu"       "nushell"   "nushell"   "nushell"
+install_tool "direnv"   "direnv"    "direnv"    "direnv"  # Charge .envrc automatiquement
 # Note: Sur Linux (trash-cli), la commande est souvent 'trash-put'
 install_tool "trash"    "trash"     "trash-cli" "trash-cli"
 

--- a/rc.zsh
+++ b/rc.zsh
@@ -1,49 +1,46 @@
-# Init prompt (Starship)
-# Vérification stricte avant le eval
-if command -v starship &> /dev/null; then
-    eval "$(starship init zsh)"
-else
-    # Fallback minimaliste si starship absent
-    # Affiche: [user@host dir]$ 
-    PROMPT='%n@%m %1~ %# '
-fi
+# ==============================================================================
+# ZSH_ENV - Point d'entree principal
+# ==============================================================================
+# Source par .zshrc via $ZSH_ENV_DIR
+# Ordre de chargement:
+#   1. Configuration (modules, options)
+#   2. Secrets
+#   3. Variables
+#   4. Completions
+#   5. Functions
+#   6. Aliases
+#   7. Plugins
+#   8. Hooks (outils externes: starship, nvm, sdkman, zoxide, direnv)
+# ==============================================================================
 
-# OPTIONAL: Activate AUTO_CD if wanted
-# Uncomment the following line to enable AUTO_CD
-setopt AUTO_CD
-
-# Init Environment
+# --- Verification ZSH_ENV_DIR ---
 if [ -z "$ZSH_ENV_DIR" ]; then
     echo "WARNING: ZSH_ENV_DIR is not set. Assuming default location."
-    export ZSH_ENV_DIR="$HOME/.zsh_env" # Valeur par défaut de sécurité
+    export ZSH_ENV_DIR="$HOME/.zsh_env"
 fi
 
-# Load Configuration (modules actifs/inactifs)
-# Valeurs par defaut (tout actif)
+# --- 1. Configuration ---
+# Valeurs par defaut des modules
 ZSH_ENV_MODULE_GITLAB=${ZSH_ENV_MODULE_GITLAB:-true}
 ZSH_ENV_MODULE_DOCKER=${ZSH_ENV_MODULE_DOCKER:-true}
 ZSH_ENV_MODULE_NVM=${ZSH_ENV_MODULE_NVM:-true}
 ZSH_ENV_MODULE_NUSHELL=${ZSH_ENV_MODULE_NUSHELL:-true}
 
-# Auto-update (valeurs par defaut)
+# Auto-update
 ZSH_ENV_AUTO_UPDATE=${ZSH_ENV_AUTO_UPDATE:-true}
 ZSH_ENV_UPDATE_FREQUENCY=${ZSH_ENV_UPDATE_FREQUENCY:-7}
 ZSH_ENV_UPDATE_MODE=${ZSH_ENV_UPDATE_MODE:-prompt}
 
-# NVM Lazy loading (true = charge NVM au premier appel node/npm)
+# NVM Lazy loading
 ZSH_ENV_NVM_LAZY=${ZSH_ENV_NVM_LAZY:-true}
 
 # Charger config personnalisee si presente
-if [ -f "$ZSH_ENV_DIR/config.zsh" ]; then
-    source "$ZSH_ENV_DIR/config.zsh"
-fi
+[ -f "$ZSH_ENV_DIR/config.zsh" ] && source "$ZSH_ENV_DIR/config.zsh"
 
-# Load Secrets (Ignored by git)
-if [ -f "$HOME/.secrets" ]; then
-    source "$HOME/.secrets"
-fi
+# --- 2. Secrets ---
+[ -f "$HOME/.secrets" ] && source "$HOME/.secrets"
 
-# Load variables (Critique : Doit être chargé en premier)
+# --- 3. Variables ---
 if [ -f "$ZSH_ENV_DIR/variables.zsh" ]; then
     source "$ZSH_ENV_DIR/variables.zsh"
 else
@@ -52,127 +49,30 @@ fi
 
 export PATH="$SCRIPTS_DIR:$PATH"
 
-# =======================================================
-# COMPLETION SYSTEM (doit etre avant functions.zsh)
-# =======================================================
-# Initialiser compinit avec cache pour performance
+# --- 4. Completions ---
 autoload -Uz compinit
-# Cache quotidien pour eviter la lenteur au demarrage
+# Cache quotidien pour performance
 if [[ -n ${ZDOTDIR}/.zcompdump(#qN.mh+24) ]]; then
     compinit
 else
     compinit -C
 fi
 
-# Load functions
-if [ -f "$ZSH_ENV_DIR/functions.zsh" ]; then
-    source "$ZSH_ENV_DIR/functions.zsh"
-fi
+# --- 5. Functions ---
+[ -f "$ZSH_ENV_DIR/functions.zsh" ] && source "$ZSH_ENV_DIR/functions.zsh"
 
-# Load aliases
-if [ -f "$ZSH_ENV_DIR/aliases.zsh" ]; then
-    source "$ZSH_ENV_DIR/aliases.zsh"
-fi
+# --- 6. Aliases ---
+[ -f "$ZSH_ENV_DIR/aliases.zsh" ] && source "$ZSH_ENV_DIR/aliases.zsh"
+[ -f "$ZSH_ENV_DIR/aliases.local.zsh" ] && source "$ZSH_ENV_DIR/aliases.local.zsh"
 
-# Load plugins
-if [ -f "$ZSH_ENV_DIR/plugins.zsh" ]; then
-    source "$ZSH_ENV_DIR/plugins.zsh"
-fi
+# --- 7. Plugins ---
+[ -f "$ZSH_ENV_DIR/plugins.zsh" ] && source "$ZSH_ENV_DIR/plugins.zsh"
 
-# Load local aliases (non versionnes)
-if [ -f "$ZSH_ENV_DIR/aliases.local.zsh" ]; then
-    source "$ZSH_ENV_DIR/aliases.local.zsh"
-fi
+# --- 8. Hooks (outils externes) ---
+[ -f "$ZSH_ENV_DIR/hooks.zsh" ] && source "$ZSH_ENV_DIR/hooks.zsh"
 
-# =======================================================
-# NVM INIT (Cross-Platform avec Lazy Loading optionnel)
-# =======================================================
+# --- Options ZSH ---
+setopt AUTO_CD
 
-if [ "$ZSH_ENV_MODULE_NVM" = "true" ]; then
-    export NVM_DIR="$HOME/.nvm"
-
-    # Fonction interne pour charger NVM
-    _zsh_env_load_nvm() {
-        # Liste priorisée des chemins (définie localement pour robustesse)
-        local nvm_candidates=(
-            "$NVM_DIR/nvm.sh"                          # Linux / Install Manuelle
-            "/opt/homebrew/opt/nvm/nvm.sh"             # MacOS Apple Silicon (Brew)
-            "/usr/local/opt/nvm/nvm.sh"                # MacOS Intel (Brew)
-            "/usr/share/nvm/init-nvm.sh"               # Arch Linux (AUR)
-        )
-
-        local nvm_path
-        for nvm_path in "${nvm_candidates[@]}"; do
-            if [ -s "$nvm_path" ]; then
-                source "$nvm_path"
-
-                # Chargement de l'autocomplétion
-                local nvm_root=$(dirname "$nvm_path")
-                local completion_path="$nvm_root/etc/bash_completion.d/nvm"
-                [ ! -f "$completion_path" ] && completion_path="$NVM_DIR/bash_completion"
-                [ -s "$completion_path" ] && source "$completion_path"
-
-                # Hook automatique pour .nvmrc
-                if command -v nvm &> /dev/null; then
-                    autoload -U add-zsh-hook
-                    add-zsh-hook chpwd load-nvmrc
-                fi
-
-                return 0
-            fi
-        done
-        return 1
-    }
-
-    if [ "$ZSH_ENV_NVM_LAZY" = "true" ]; then
-        # Mode Lazy : créer des wrappers qui chargent NVM au premier appel
-        _zsh_env_lazy_nvm() {
-            # Supprimer les wrappers
-            unfunction node npm npx yarn pnpm nvm 2>/dev/null
-
-            # Charger NVM
-            if _zsh_env_load_nvm; then
-                # Exécuter la commande originale
-                "$@"
-            else
-                echo "[zsh_env] NVM non trouvé"
-                return 1
-            fi
-        }
-
-        # Créer les wrappers
-        node()  { _zsh_env_lazy_nvm node "$@" }
-        npm()   { _zsh_env_lazy_nvm npm "$@" }
-        npx()   { _zsh_env_lazy_nvm npx "$@" }
-        yarn()  { _zsh_env_lazy_nvm yarn "$@" }
-        pnpm()  { _zsh_env_lazy_nvm pnpm "$@" }
-        nvm()   { _zsh_env_lazy_nvm nvm "$@" }
-    else
-        # Mode normal : charger NVM immédiatement
-        if _zsh_env_load_nvm; then
-            load-nvmrc # Exécution au démarrage
-        fi
-    fi
-fi
-
-# SDKMAN (Optimisé et Silencieux)
-# On vérifie d'abord que le dossier existe avant de tester le fichier
-export SDKMAN_DIR="$HOME/.sdkman"
-if [ -d "$SDKMAN_DIR" ] && [ -s "$SDKMAN_DIR/bin/sdkman-init.sh" ]; then
-    source "$SDKMAN_DIR/bin/sdkman-init.sh"
-fi
-
-# PATH Final (Déduplication)
-# Empêche d'avoir le PATH qui grandit à l'infini si on reload le .zshrc
+# --- PATH Final (Deduplication) ---
 typeset -U PATH
-
-# =======================================================
-# ZOXIDE (doit etre charge en dernier)
-# =======================================================
-# Zoxide utilise un hook chpwd pour enregistrer les repertoires.
-# Le charger en dernier garantit que son hook s'execute apres
-# tous les autres (nvm, proj, etc.) et capture le repertoire final.
-if command -v zoxide &> /dev/null; then
-    eval "$(zoxide init zsh)"
-    alias cd="z"
-fi


### PR DESCRIPTION
## Summary
- Create `hooks.zsh` to centralize external tool initializations (starship, nvm, sdkman, zoxide, direnv, fzf)
- Simplify `rc.zsh` from ~180 lines to ~60 lines for better readability
- Add direnv support with automatic `.envrc` loading
- Add fzf keybindings (Ctrl+R, Ctrl+T, Alt+C)
- Add history prefix search on arrow keys

## Changes
- **hooks.zsh** (new): All external tool initializations in one place
- **rc.zsh**: Simplified orchestrator with clear loading order
- **install.sh**: Added direnv to installed tools

## Test plan
- [x] `source ~/.zshrc` loads without errors
- [x] `kube_select` works and persists selection across shells
- [x] Ctrl+R opens fzf history search
- [x] Arrow up after typing prefix searches history
- [x] direnv loads `.envrc` files automatically

🤖 Generated with [Claude Code](https://claude.ai/code)