### PR TITLE
fix(completion): reduce aggressive matcher-list and add doctor diagnostic

### DIFF
--- a/completions.zsh
+++ b/completions.zsh
@@ -21,4 +21,5 @@ _ZSH_ENV_CUSTOM_COMPLETIONS=(
     # "fly:flyctl completion zsh"
     # "turbo:turbo completion zsh"
     "rustup:rustup completions zsh"
+    "armadai:armadai completion zsh"
 )

--- a/rc.zsh
+++ b/rc.zsh
@@ -69,7 +69,7 @@ zstyle ':completion:*' menu select
 zstyle ':completion:*' list-colors "${(s.:.)LS_COLORS}"
 
 # Case-insensitive + partial-word matching (ex: "doc" complete "Documents")
-zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=*' 'l:|=* r:|=*'
+zstyle ':completion:*' matcher-list 'm:{a-zA-Z}={A-Za-z}' 'r:|[._-]=* r:|=*'
 
 # Groupes avec headers
 zstyle ':completion:*' group-name ''


### PR DESCRIPTION
## Summary

- **Register armadai completion** in `_ZSH_ENV_CUSTOM_COMPLETIONS` (`completions.zsh`)
- **Remove aggressive substring matcher** `'l:|=* r:|=*'` from `matcher-list` (`rc.zsh`) — this was causing clap-generated completions (like armadai) to fall back to file/directory suggestions instead of showing subcommands
- **Add Completions diagnostic section** to `zsh-env-doctor` — checks zcompdump freshness, custom completions registration status, and common tools (docker, kubectl, gh, helm) completion availability

Fixes #53

## Test plan

- [ ] `source ~/.zshrc` — no errors
- [ ] `armadai <TAB>` — should show subcommands (run, new, list, inspect...)
- [ ] `zsh-env-doctor` — should display the Completions section with status for each tool
- [ ] `shellspec spec/zsh_env_commands_spec.sh` — all tests pass
- [ ] `shellspec spec/completions_t2_spec.sh spec/rc_spec.sh` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)