### PR TITLE
feat(lazygit): module dédié avec alias lg, config versionnée et CWD sync

### DIFF
--- a/lazygit/config.yml
+++ b/lazygit/config.yml
@@ -1,0 +1,19 @@
+git:
+  paging:
+    colorArg: always
+  commit:
+    signOff: false
+  merging:
+    manualCommit: false
+
+gui:
+  showIcons: true
+  nerdFontsVersion: "3"
+  border: rounded
+  expandFocusedSidePanel: true
+  mouseEvents: true
+
+keybinding:
+  universal:
+    quit: q
+    return: <esc>

--- a/lazygit/config.yml
+++ b/lazygit/config.yml
@@ -8,7 +8,6 @@ git:
 
 gui:
   showIcons: true
-  nerdFontsVersion: "3"
   border: rounded
   expandFocusedSidePanel: true
   mouseEvents: true

--- a/lazygit/config.yml
+++ b/lazygit/config.yml
@@ -1,6 +1,7 @@
 git:
   paging:
     colorArg: always
+    pager: delta --dark --paging=never
   commit:
     signOff: false
   merging:

--- a/modules/lazygit/completions.zsh
+++ b/modules/lazygit/completions.zsh
@@ -1,0 +1,6 @@
+# Completions lazygit — générées dynamiquement par lazygit
+(( $+functions[compdef] )) || return 0
+
+if command -v lazygit &>/dev/null; then
+    eval "$(lazygit completion zsh 2>/dev/null)"
+fi

--- a/modules/lazygit/init.zsh
+++ b/modules/lazygit/init.zsh
@@ -7,15 +7,16 @@
 
 if command -v lazygit &>/dev/null; then
     export LG_CONFIG_FILE="${ZSH_ENV_DIR}/lazygit/config.yml:${HOME}/.config/lazygit/config-local.yml"
+    export LAZYGIT_NEW_DIR_FILE="${HOME}/.lazygit/newdir"
+    mkdir -p "${HOME}/.lazygit"
 
     lg() {
-        # CWD sync : lazygit écrit le répertoire de sortie dans LAZYGIT_NEW_DIR_FILE
-        export LAZYGIT_NEW_DIR_FILE="${HOME}/.lazygit/newdir"
-        mkdir -p "${HOME}/.lazygit"
         lazygit "$@"
         if [[ -f "${LAZYGIT_NEW_DIR_FILE}" ]]; then
-            cd "$(cat "${LAZYGIT_NEW_DIR_FILE}")"
+            local newdir
+            newdir="$(cat "${LAZYGIT_NEW_DIR_FILE}")"
             rm -f "${LAZYGIT_NEW_DIR_FILE}"
+            [[ -d "${newdir}" ]] && cd "${newdir}"
         fi
     }
 

--- a/modules/lazygit/init.zsh
+++ b/modules/lazygit/init.zsh
@@ -1,0 +1,37 @@
+# ==============================================================================
+# lazygit — TUI Git ergonomique
+# Guard: ZSH_ENV_MODULE_LAZYGIT=true dans config.zsh
+# ==============================================================================
+
+[[ "${ZSH_ENV_MODULE_LAZYGIT:-}" != "true" ]] && return 0
+
+if command -v lazygit &>/dev/null; then
+    export LG_CONFIG_FILE="${ZSH_ENV_DIR}/lazygit/config.yml:${HOME}/.config/lazygit/config-local.yml"
+
+    lg() {
+        # CWD sync : lazygit écrit le répertoire de sortie dans LAZYGIT_NEW_DIR_FILE
+        export LAZYGIT_NEW_DIR_FILE="${HOME}/.lazygit/newdir"
+        mkdir -p "${HOME}/.lazygit"
+        lazygit "$@"
+        if [[ -f "${LAZYGIT_NEW_DIR_FILE}" ]]; then
+            cd "$(cat "${LAZYGIT_NEW_DIR_FILE}")"
+            rm -f "${LAZYGIT_NEW_DIR_FILE}"
+        fi
+    }
+
+    lazygit_setup() {
+        _ui_header "lazygit"
+        _ui_section "Version" "$(lazygit --version 2>/dev/null | head -1)"
+        _ui_section "Config" "${LG_CONFIG_FILE}"
+        echo ""
+        local local_cfg="${HOME}/.config/lazygit/config-local.yml"
+        if [[ -f "${local_cfg}" ]]; then
+            _ui_ok "config-local.yml"
+            echo ""
+        else
+            _ui_warn "config-local.yml"
+            echo ""
+            _ui_section "Créer" "touch ${local_cfg}"
+        fi
+    }
+fi


### PR DESCRIPTION
## Summary
- Nouveau module `modules/lazygit/` activé via guard `ZSH_ENV_MODULE_LAZYGIT=true`
- Alias `lg` avec CWD sync post-exit via `LAZYGIT_NEW_DIR_FILE`
- Config de base dans `lazygit/config.yml`, overrides locaux dans `~/.config/lazygit/config-local.yml`
- Completions zsh dynamiques via `lazygit completion zsh`
- Fonction `lazygit_setup` pour diagnostic (version, chemins config)

## Test plan
- [ ] `type lg` → shell function
- [ ] `lazygit_setup` affiche version + config avec le style _ui_*
- [ ] Navigation dans lazygit puis quit → CWD du shell suit
- [ ] `ZSH_ENV_MODULE_LAZYGIT=false` → `lg` non défini

🤖 Generated with [Claude Code](https://claude.com/claude-code)