### PR TITLE
feat(atuin): module tools/atuin + install.sh tools/* guards

### DIFF
--- a/atuin/config.toml
+++ b/atuin/config.toml
@@ -1,0 +1,24 @@
+# atuin config — local uniquement, pas de sync
+dialect = "unix"
+auto_sync = false
+update_check = false
+sync_frequency = "0"
+
+[daemon]
+enabled = false
+
+[stats]
+common_prefix = ["sudo"]
+
+[keys]
+scroll_exits = true
+
+[preview]
+strategy = "auto"
+
+[search]
+search_mode = "fuzzy"
+filter_mode = "global"
+filter_mode_shell_up_arrow = "session"
+show_preview = true
+exit_mode = "return-query"

--- a/core/hooks.zsh
+++ b/core/hooks.zsh
@@ -182,3 +182,12 @@ bindkey '^[[A' history-beginning-search-backward-end  # Fleche haut
 bindkey '^[[B' history-beginning-search-forward-end   # Fleche bas
 bindkey '^[OA' history-beginning-search-backward-end  # Fleche haut (mode application)
 bindkey '^[OB' history-beginning-search-forward-end   # Fleche bas (mode application)
+
+# =======================================================
+# ATUIN (Historique enrichi — remplace Ctrl+R de fzf)
+# =======================================================
+# Chargé en dernier pour que Ctrl+R override celui de fzf.
+# --disable-up-arrow : les flèches ↑↓ restent en recherche par préfixe.
+if [[ "${ZSH_ENV_MODULE_ATUIN:-}" == "true" ]] && command -v atuin &>/dev/null; then
+    eval "$(atuin init zsh --disable-up-arrow)"
+fi

--- a/install.sh
+++ b/install.sh
@@ -110,32 +110,6 @@ if [[ "${CHECK_MODE:-false}" = true ]]; then
     exit 0
 fi
 
-# --- Installation optionnelle des outils modules/tools/* ---
-# Si un module est activé dans config.zsh mais que le binaire est absent, on installe.
-_config_file="${ZSH_ENV_DIR:-$HOME/.zsh_env}/config.zsh"
-if [[ -f "${_config_file}" ]]; then
-    # Format: "GUARD_VAR:binary:brew_pkg:apt_pkg:dnf_pkg"
-    _optional_tools=(
-        "ZSH_ENV_MODULE_ATUIN:atuin:atuin:atuin:atuin"
-        "ZSH_ENV_MODULE_LAZYGIT:lazygit:lazygit:lazygit:lazygit"
-        "ZSH_ENV_MODULE_DELTA:delta:git-delta:git-delta:git-delta"
-    )
-    for _entry in "${_optional_tools[@]}"; do
-        _guard=$(echo "$_entry" | cut -d: -f1)
-        _bin=$(echo "$_entry"   | cut -d: -f2)
-        _brew=$(echo "$_entry"  | cut -d: -f3)
-        _apt=$(echo "$_entry"   | cut -d: -f4)
-        _dnf=$(echo "$_entry"   | cut -d: -f5)
-        _val=$(grep "^${_guard}=" "${_config_file}" 2>/dev/null | cut -d= -f2 | tr -d '"'"'"' ')
-        if [[ "${_val}" == "true" ]] && ! command -v "${_bin}" &>/dev/null; then
-            log_warn "${_bin} requis par ${_guard} mais absent — installation..."
-            install_tool "${_bin}" "${_brew}" "${_apt}" "${_dnf}"
-        fi
-    done
-    unset _entry _guard _bin _brew _apt _dnf _val _optional_tools
-fi
-unset _config_file
-
 # --- Détection OS & Package Manager ---
 OS="$(uname -s)"
 PKG_MANAGER=""
@@ -269,6 +243,31 @@ install_tool "kubectl"    "kubectl"     "kubectl"     "kubectl"
 install_tool "kubelogin"  "kubelogin"   ""            ""
 install_tool "az"         "azure-cli"   ""            ""
 install_tool "helm"       "helm"        "helm"        "helm"
+
+# --- Outils optionnels modules/tools/* ---
+# Installés automatiquement si le module est activé dans config.zsh mais le binaire absent.
+_config_file="${ZSH_ENV_DIR:-$HOME/.zsh_env}/config.zsh"
+if [[ -f "${_config_file}" ]]; then
+    _optional_tools=(
+        "ZSH_ENV_MODULE_ATUIN:atuin:atuin:atuin:atuin"
+        "ZSH_ENV_MODULE_LAZYGIT:lazygit:lazygit:lazygit:lazygit"
+        "ZSH_ENV_MODULE_DELTA:delta:git-delta:git-delta:git-delta"
+    )
+    for _entry in "${_optional_tools[@]}"; do
+        _guard=$(echo "$_entry" | cut -d: -f1)
+        _bin=$(echo "$_entry"   | cut -d: -f2)
+        _brew=$(echo "$_entry"  | cut -d: -f3)
+        _apt=$(echo "$_entry"   | cut -d: -f4)
+        _dnf=$(echo "$_entry"   | cut -d: -f5)
+        _val=$(grep "^${_guard}=" "${_config_file}" 2>/dev/null | cut -d= -f2 | tr -d '"'"'"' ')
+        if [[ "${_val}" == "true" ]] && ! command -v "${_bin}" &>/dev/null; then
+            log_warn "${_bin} requis par ${_guard} mais absent — installation..."
+            install_tool "${_bin}" "${_brew}" "${_apt}" "${_dnf}"
+        fi
+    done
+    unset _entry _guard _bin _brew _apt _dnf _val _optional_tools
+fi
+unset _config_file
 
 # --- Installation manuelle pour les outils souvent absents d'APT/DNF ---
 

--- a/install.sh
+++ b/install.sh
@@ -91,6 +91,7 @@ if [[ "${CHECK_MODE:-false}" = true ]]; then
         eza starship zoxide fzf bat nu direnv trash mise
         sops age
         kubectl kubelogin az helm
+        atuin lazygit delta
     )
 
     for _dep in "${_check_deps[@]}"; do
@@ -108,6 +109,32 @@ if [[ "${CHECK_MODE:-false}" = true ]]; then
     echo -e "${BOLD}Resume :${NC} ${GREEN}${_check_installed} installes${NC}, ${RED}${_check_missing} manquants${NC}"
     exit 0
 fi
+
+# --- Installation optionnelle des outils modules/tools/* ---
+# Si un module est activé dans config.zsh mais que le binaire est absent, on installe.
+_config_file="${ZSH_ENV_DIR:-$HOME/.zsh_env}/config.zsh"
+if [[ -f "${_config_file}" ]]; then
+    # Format: "GUARD_VAR:binary:brew_pkg:apt_pkg:dnf_pkg"
+    _optional_tools=(
+        "ZSH_ENV_MODULE_ATUIN:atuin:atuin:atuin:atuin"
+        "ZSH_ENV_MODULE_LAZYGIT:lazygit:lazygit:lazygit:lazygit"
+        "ZSH_ENV_MODULE_DELTA:delta:git-delta:git-delta:git-delta"
+    )
+    for _entry in "${_optional_tools[@]}"; do
+        _guard=$(echo "$_entry" | cut -d: -f1)
+        _bin=$(echo "$_entry"   | cut -d: -f2)
+        _brew=$(echo "$_entry"  | cut -d: -f3)
+        _apt=$(echo "$_entry"   | cut -d: -f4)
+        _dnf=$(echo "$_entry"   | cut -d: -f5)
+        _val=$(grep "^${_guard}=" "${_config_file}" 2>/dev/null | cut -d= -f2 | tr -d '"'"'"' ')
+        if [[ "${_val}" == "true" ]] && ! command -v "${_bin}" &>/dev/null; then
+            log_warn "${_bin} requis par ${_guard} mais absent — installation..."
+            install_tool "${_bin}" "${_brew}" "${_apt}" "${_dnf}"
+        fi
+    done
+    unset _entry _guard _bin _brew _apt _dnf _val _optional_tools
+fi
+unset _config_file
 
 # --- Détection OS & Package Manager ---
 OS="$(uname -s)"

--- a/modules/tools/atuin/completions.zsh
+++ b/modules/tools/atuin/completions.zsh
@@ -1,0 +1,6 @@
+# Completions atuin — générées dynamiquement
+(( $+functions[compdef] )) || return 0
+
+if command -v atuin &>/dev/null; then
+    eval "$(atuin gen-completions --shell zsh 2>/dev/null)"
+fi

--- a/modules/tools/atuin/init.zsh
+++ b/modules/tools/atuin/init.zsh
@@ -1,0 +1,32 @@
+# ==============================================================================
+# atuin — Historique shell enrichi (SQLite local, TUI fuzzy)
+# Guard: ZSH_ENV_MODULE_ATUIN=true dans config.zsh
+# Note: atuin init zsh est dans core/hooks.zsh (après fzf et keybindings)
+# ==============================================================================
+
+[[ "${ZSH_ENV_MODULE_ATUIN:-}" != "true" ]] && return 0
+
+if command -v atuin &>/dev/null; then
+    atuin_setup() {
+        _ui_header "atuin"
+        local config_src="${ZSH_ENV_DIR}/atuin/config.toml"
+        local config_dst="${HOME}/.config/atuin/config.toml"
+
+        if [[ ! -f "${config_src}" ]]; then
+            _ui_msg_fail "Source manquante: ${config_src}"
+            return 1
+        fi
+
+        mkdir -p "${HOME}/.config/atuin"
+        cp "${config_src}" "${config_dst}"
+        _ui_msg_ok "config.toml déployée"
+
+        _ui_section "Version" "$(atuin --version 2>/dev/null)"
+        _ui_section "Config" "${config_dst}"
+        local db_path
+        db_path="$(atuin info 2>/dev/null | grep -i 'database' | head -1 | cut -d: -f2- | xargs)"
+        [[ -n "${db_path}" ]] && _ui_section "DB" "${db_path}"
+    }
+else
+    echo "[zsh-env] atuin: module activé mais binaire absent — brew install atuin"
+fi


### PR DESCRIPTION
## Summary
- Nouveau module `modules/tools/atuin/` (guard `ZSH_ENV_MODULE_ATUIN`)
- `atuin/config.toml` versionné : local uniquement, fuzzy, pas de sync
- `core/hooks.zsh` : bloc atuin en fin de fichier (override Ctrl+R après fzf, `--disable-up-arrow` préserve les flèches ↑↓)
- `install.sh` : `atuin`, `lazygit`, `delta` ajoutés dans `_check_deps` + bloc d'installation automatique si module activé et binaire absent

## Test plan
- [ ] `Ctrl+R` → TUI atuin (pas fzf)
- [ ] Flèches ↑↓ → recherche par préfixe session (inchangé)
- [ ] `atuin_setup` → config.toml déployée dans `~/.config/atuin/`
- [ ] `ZSH_ENV_MODULE_ATUIN=false` → atuin non chargé, `atuin_setup` non défini
- [ ] `./install.sh --check` → atuin/lazygit/delta visibles dans la liste

🤖 Generated with [Claude Code](https://claude.com/claude-code)