### PR TITLE
feat(kube): intégration stern — wrapper ks() avec completions

### DIFF
--- a/modules/kube/completions.zsh
+++ b/modules/kube/completions.zsh
@@ -113,3 +113,13 @@ _klog() {
         '2:container:($(kubectl get pod ${words[2]} -n '"$current_ns"' -o jsonpath="{.spec.containers[*].name}" 2>/dev/null))'
 }
 compdef _klog klog
+
+# Stern — completions natives + _ks
+if command -v stern &>/dev/null; then
+    source <(stern --completion zsh 2>/dev/null)
+fi
+
+_ks() {
+    (( $+functions[_stern] )) && _stern "$@"
+}
+compdef _ks ks

--- a/modules/kube/init.zsh
+++ b/modules/kube/init.zsh
@@ -1,2 +1,3 @@
 source "$ZSH_ENV_DIR/modules/kube/kube_config.zsh"
 source "$ZSH_ENV_DIR/modules/kube/klog.zsh"
+source "$ZSH_ENV_DIR/modules/kube/stern.zsh"

--- a/modules/kube/stern.zsh
+++ b/modules/kube/stern.zsh
@@ -1,0 +1,9 @@
+[[ "${ZSH_ENV_MODULE_KUBE:-}" != "true" ]] && return 0
+
+if command -v stern &>/dev/null; then
+    ks() {
+        stern --timestamps --color always --tail 50 "$@"
+    }
+else
+    echo "[zsh-env] stern: module kube actif mais binaire absent — brew install stern"
+fi


### PR DESCRIPTION
## Summary

- Ajoute `modules/kube/stern.zsh` : wrapper `ks()` avec defaults opinionnés (`--timestamps --color always --tail 50`)
- Wire dans `modules/kube/init.zsh`
- Completions zsh dans `modules/kube/completions.zsh` : stern natives + `_ks()` délégant à `_stern`
- Hérite du guard `ZSH_ENV_MODULE_KUBE` (pas de nouveau guard)
- Binary absent → warning au démarrage

## Test plan

- [ ] `ks payment.*` → logs multi-pod avec timestamps et couleurs
- [ ] `ks . -n prod -n staging` → logs multi-namespace
- [ ] Guard OFF (`ZSH_ENV_MODULE_KUBE=false`) → `ks` non définie, pas d'erreur
- [ ] Binary absent → warning `[zsh-env] stern: module kube actif mais binaire absent`
- [ ] Tab completion `ks <Tab>` → flags stern disponibles

🤖 Generated with [Claude Code](https://claude.com/claude-code)