### PR TITLE
feat(tools): intégration posting — TUI HTTP client avec config versionnée

### DIFF
--- a/config.zsh.example
+++ b/config.zsh.example
@@ -13,6 +13,7 @@ ZSH_ENV_MODULE_DOCKER=true      # Utilitaires Docker (dex, etc.)
 ZSH_ENV_MODULE_MISE=true        # Gestionnaire de versions (Node, Java, Maven)
 ZSH_ENV_MODULE_NUSHELL=true     # Integration Nushell
 ZSH_ENV_MODULE_KUBE=true        # Gestionnaire de configs Kubernetes
+ZSH_ENV_MODULE_POSTING=true     # Client HTTP TUI (posting)
 
 # ==============================================================================
 # Mise Configuration

--- a/install.sh
+++ b/install.sh
@@ -252,6 +252,7 @@ if [[ -f "${_config_file}" ]]; then
         "ZSH_ENV_MODULE_ATUIN:atuin:atuin:atuin:atuin"
         "ZSH_ENV_MODULE_LAZYGIT:lazygit:lazygit:lazygit:lazygit"
         "ZSH_ENV_MODULE_DELTA:delta:git-delta:git-delta:git-delta"
+        "ZSH_ENV_MODULE_POSTING:posting:posting:posting:posting"
     )
     for _entry in "${_optional_tools[@]}"; do
         _guard=$(echo "$_entry" | cut -d: -f1)

--- a/modules/tools/posting/completions.zsh
+++ b/modules/tools/posting/completions.zsh
@@ -1,0 +1,5 @@
+(( $+functions[compdef] )) || return 0
+
+if command -v posting &>/dev/null; then
+    source <(posting --completion-script-zsh 2>/dev/null) 2>/dev/null || true
+fi

--- a/modules/tools/posting/init.zsh
+++ b/modules/tools/posting/init.zsh
@@ -1,0 +1,25 @@
+[[ "${ZSH_ENV_MODULE_POSTING:-}" != "true" ]] && return 0
+
+if command -v posting &>/dev/null; then
+    posting_setup() {
+        _ui_header "posting"
+        local config_src="${ZSH_ENV_DIR}/posting/config.yaml"
+        local config_dst="${HOME}/.config/posting/config.yaml"
+
+        if [[ ! -f "${config_src}" ]]; then
+            _ui_msg_fail "Source manquante: ${config_src}"
+            return 1
+        fi
+
+        mkdir -p "${HOME}/.config/posting"
+        cp "${config_src}" "${config_dst}"
+        _ui_msg_ok "config.yaml déployée"
+
+        _ui_section "Version" "$(posting --version 2>/dev/null)"
+        _ui_section "Config" "${config_dst}"
+    }
+
+    alias po='posting'
+else
+    echo "[zsh-env] posting: module activé mais binaire absent — pipx install posting"
+fi

--- a/posting/config.yaml
+++ b/posting/config.yaml
@@ -1,0 +1,9 @@
+theme: galaxy
+text_area_theme: monokai
+layout: vertical
+use_host_environment: false
+
+heading_level: 2
+
+animation:
+  enabled: false


### PR DESCRIPTION
## Summary

- Ajoute `posting/config.yaml` : config versionnée (theme galaxy, layout vertical, sécurité use_host_environment=false)
- Ajoute `modules/tools/posting/init.zsh` : guard + `posting_setup` + alias `po`
- Ajoute `modules/tools/posting/completions.zsh` : completions si posting les supporte
- Active `ZSH_ENV_MODULE_POSTING=true` dans `config.zsh.example`
- Ajoute posting dans `install.sh` optional tools

## Test plan

- [ ] `po` lance posting (si installé)
- [ ] `posting_setup` déploie `posting/config.yaml` → `~/.config/posting/config.yaml`
- [ ] Guard OFF (`ZSH_ENV_MODULE_POSTING=false`) → `po` et `posting_setup` non définis
- [ ] Binary absent → warning `[zsh-env] posting: module activé mais binaire absent — pipx install posting`
- [ ] `install.sh` propose d'installer posting si guard actif et binaire absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)