### PR TITLE
fix(lazygit): migrer paging → pagers (format v0.50+)

### DIFF
--- a/lazygit/config.yml
+++ b/lazygit/config.yml
@@ -1,18 +1,16 @@
 git:
-  paging:
-    colorArg: always
-    pager: delta --dark --paging=never
+  pagers:
+    - colorArg: always
+      pager: delta --dark --paging=never
   commit:
     signOff: false
   merging:
     manualCommit: false
-
 gui:
   showIcons: true
   border: rounded
   expandFocusedSidePanel: true
   mouseEvents: true
-
 keybinding:
   universal:
     quit: q


### PR DESCRIPTION
## Summary

- Mise à jour du format de config lazygit : `paging` → `pagers`
- Format requis par lazygit v0.50+

## Test plan

- [ ] `ss` sans erreur
- [ ] `lg` ouvre lazygit avec delta comme pager