### PR TITLE
fix(ci): auto-release via RELEASE_TOKEN (bypass main protégée) + feat/*

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # Token admin (Dr0drigues) : bypass la protection de main (enforce_admins=false).
+          # Le GITHUB_TOKEN par defaut est bloque par la regle "require a pull request".
+          token: ${{ secrets.RELEASE_TOKEN }}
           fetch-depth: 0
           fetch-tags: true
 
@@ -27,10 +30,10 @@ jobs:
 
           if [[ "$BRANCH" == hotfix/* ]]; then
             echo "type=patch" >> $GITHUB_OUTPUT
-          elif [[ "$BRANCH" == feature/* ]]; then
+          elif [[ "$BRANCH" == feature/* || "$BRANCH" == feat/* ]]; then
             echo "type=minor" >> $GITHUB_OUTPUT
           else
-            echo "Branch '$BRANCH' does not match feature/* or hotfix/* — skipping release."
+            echo "Branch '$BRANCH' does not match feature/*, feat/* or hotfix/* — skipping release."
             echo "type=skip" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
## Problème

`auto-release.yml` échoue à chaque release : il calcule la version et bump `core/ui.zsh`, mais `git push origin main` est **rejeté car `main` est protégée** (« Changes must be made through a pull request »). Résultat : aucun tag ni release n'est publié (cf. la v3.8.0 qui a dû être faite manuellement).

## Correctif

1. **Push via `secrets.RELEASE_TOKEN`** — le workflow checkout avec un PAT admin (Dr0drigues). Comme `enforce_admins=false` sur la protection de `main`, le push direct du commit de bump et du tag bypasse la règle. Le `GITHUB_TOKEN` par défaut, lui, est bloqué.
2. **`feat/*` matche aussi minor** — en plus de `feature/*`, pour éviter le skip silencieux rencontré (la branche `feat/modern-cli-replacements` n'avait pas déclenché de release).

## ⚠️ Action requise avant que ça fonctionne

Créer le secret `RELEASE_TOKEN` :
- PAT fine-grained sur ce repo, permission **Contents: Read and write**
- `gh secret set RELEASE_TOKEN`

Tant que le secret n'existe pas, `token:` sera vide → retour au comportement actuel (push rejeté). Aucune régression.

## Validation

- YAML valide (ruby YAML.load_file)
- Logique de bump simulée : `feat/`/`feature/` → minor, `hotfix/` → patch, `chore/` → skip
- Branche `chore/*` volontaire → cette PR ne déclenche pas de release
- Validation réelle au prochain merge de feature (une fois le secret créé)

🤖 Generated with [Claude Code](https://claude.com/claude-code)