### PR TITLE
fix(ci): fallback github.token si RELEASE_TOKEN absent

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -17,7 +17,9 @@ jobs:
         with:
           # Token admin (Dr0drigues) : bypass la protection de main (enforce_admins=false).
           # Le GITHUB_TOKEN par defaut est bloque par la regle "require a pull request".
-          token: ${{ secrets.RELEASE_TOKEN }}
+          # Fallback sur github.token si le secret est absent : checkout OK + skip OK,
+          # seul le push du bump echouera (comme avant) tant que RELEASE_TOKEN n'existe pas.
+          token: ${{ secrets.RELEASE_TOKEN || github.token }}
           fetch-depth: 0
           fetch-tags: true
 


### PR DESCRIPTION
## Régression introduite par #78

Avec `token: ${{ secrets.RELEASE_TOKEN }}` et le secret absent, `actions/checkout` échoue immédiatement : `Input required and not supplied: token`. Tout merge sur `main` fait donc échouer le job (run [28095724709]).

## Correctif

`token: ${{ secrets.RELEASE_TOKEN || github.token }}` — fallback sur le `GITHUB_TOKEN` quand le secret n'existe pas :
- **Sans secret** : checkout OK, branches `skip` (chore/*) OK ; seul le push du bump échouerait sur une vraie feature (comportement d'avant le fix, pas de régression).
- **Avec secret** : utilise le PAT admin → release complète fonctionnelle.

Branche `chore/*` → ne déclenche pas de release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)