### PR TITLE
feat: thème signature forge (+ défaut des nouveaux installs)

### DIFF
--- a/docs/superpowers/specs/2026-06-24-forge-theme-design.md
+++ b/docs/superpowers/specs/2026-06-24-forge-theme-design.md
@@ -76,7 +76,8 @@ Toutes les occurrences des séparateurs powerline (`[](fg:X bg:Y)`) doivent voir
 
 - **Pas de variante claire** (`forge-light`) : la forge est intrinsèquement sombre/chaude (YAGNI).
 - Aucun changement au moteur de thèmes, au loader `core/ui.zsh`, ni au CLI.
-- Aucun rename de tuyauterie. Le thème n'est PAS appliqué par défaut (l'utilisateur l'active via `zsh-env-theme apply forge`).
+- Aucun rename de tuyauterie.
+- **MAJ** : forge devient le **thème par défaut des nouveaux installs** (`install.sh` : option recommandée + mode `--default`). Les utilisateurs **existants ne sont pas affectés** (`.current_theme` n'est posé qu'à l'install, jamais par l'auto-update) — ils gardent leur thème et peuvent basculer via `zsh-env-theme apply forge`. Aucune migration.
 - Logos / assets graphiques : hors de ce sous-projet (branding assets séparé).
 
 ## Migration

--- a/install.sh
+++ b/install.sh
@@ -522,10 +522,11 @@ if [[ "$INTERACTIVE" = true ]]; then
     if command -v starship &> /dev/null; then
         echo -e "  Choisissez un theme pour votre prompt:" >&2
         echo -e "    ${CYAN}1)${NC} minimal   - Prompt minimaliste" >&2
-        echo -e "    ${CYAN}2)${NC} default   - Configuration equilibree (recommande)" >&2
+        echo -e "    ${CYAN}2)${NC} forge     - Theme signature zanvil (recommande)" >&2
         echo -e "    ${CYAN}3)${NC} powerline - Style powerline avec separateurs" >&2
         echo -e "    ${CYAN}4)${NC} plain     - Sans icones (compatible tous terminaux)" >&2
         echo -e "    ${CYAN}5)${NC} Garder ma configuration actuelle" >&2
+        echo -e "    ${CYAN}6)${NC} default   - Configuration equilibree" >&2
         printf "  Choix [2]: " >&2
         read -r theme_choice
         case "$theme_choice" in
@@ -533,7 +534,8 @@ if [[ "$INTERACTIVE" = true ]]; then
             3) STARSHIP_THEME="powerline" ;;
             4) STARSHIP_THEME="plain" ;;
             5) STARSHIP_THEME="" ;;
-            *) STARSHIP_THEME="default" ;;
+            6) STARSHIP_THEME="default" ;;
+            *) STARSHIP_THEME="forge" ;;
         esac
     else
         echo -e "  ${YELLOW}Starship non installe, theme ignore${NC}" >&2
@@ -578,7 +580,7 @@ else
     MODULE_MISE="true"
     MODULE_NUSHELL="true"
     MODULE_KUBE="true"
-    STARSHIP_THEME="default"
+    STARSHIP_THEME="forge"
     AUTO_UPDATE="true"
     UPDATE_FREQ=7
     UPDATE_MODE="prompt"

--- a/themes/forge/palette.zsh
+++ b/themes/forge/palette.zsh
@@ -1,0 +1,11 @@
+# Forge - Shell palette (true color)
+# Atelier de forge : fer froid, braise, etincelle, trempe.
+# Couleurs alignees avec le theme Starship forge (prompt.toml).
+_ui_red=$'\033[38;2;226;83;58m'         # #e2533a  feu
+_ui_green=$'\033[38;2;138;154;91m'      # #8a9a5b  patine / laiton oxyde
+_ui_yellow=$'\033[38;2;240;169;59m'     # #f0a93b  ambre / braise
+_ui_blue=$'\033[38;2;125;148;166m'      # #7d94a6  acier froid
+_ui_magenta=$'\033[38;2;168;127;160m'   # #a87fa0  violet trempe
+_ui_cyan=$'\033[38;2;95;174;159m'       # #5fae9f  trempe
+_ui_white=$'\033[38;2;216;205;191m'     # #d8cdbf  cendre claire
+_ui_dim=$'\033[38;2;107;96;85m'         # #6b6055  cendre froide

--- a/themes/forge/prompt.toml
+++ b/themes/forge/prompt.toml
@@ -1,0 +1,110 @@
+# Starship Theme: Forge
+#######################################################################
+### Theme signature zanvil — atelier de forge                      ###
+### Fer froid + details chauds (braise, etincelle, trempe)         ###
+#######################################################################
+"$schema" = 'https://starship.rs/config-schema.json'
+command_timeout = 3000
+
+format = """
+[░▒▓](#8896a3)\
+${custom.work}\
+[  ](bg:#8896a3 fg:#1a1613)\
+[](bg:#8896a3 fg:#8896a3)\
+$directory\
+[](fg:#8896a3 bg:#2f2620)\
+$git_branch\
+$git_status\
+[](fg:#2f2620 bg:#241d18)\
+$java\
+$nodejs\
+$rust\
+$golang\
+$php\
+\$kubernetes\\\n${custom.zproject}${custom.zsh_env_context}\\
+[](fg:#241d18 bg:#1a1613)\
+$time\
+[ ](fg:#1a1613)\
+\n$character"""
+
+[directory]
+style = "fg:#1a1613 bg:#8896a3"
+format = "[ $path ]($style)"
+truncation_length = 3
+truncation_symbol = "…/"
+
+[directory.substitutions]
+"Documents" = "󰈙 "
+"Downloads" = " "
+"Music" = " "
+"Pictures" = " "
+
+[git_branch]
+symbol = ""
+style = "bg:#2f2620"
+format = '[[ $symbol $branch ](fg:#ff8a3d bg:#2f2620)]($style)'
+
+[git_status]
+style = "bg:#2f2620"
+format = '[[($all_status$ahead_behind )](fg:#ff8a3d bg:#2f2620)]($style)'
+
+[nodejs]
+symbol = ""
+style = "bg:#241d18"
+format = '[[ $symbol ($version) ](fg:#8896a3 bg:#241d18)]($style)'
+
+[rust]
+symbol = ""
+style = "bg:#241d18"
+format = '[[ $symbol ($version) ](fg:#8896a3 bg:#241d18)]($style)'
+
+[golang]
+symbol = ""
+style = "bg:#241d18"
+format = '[[ $symbol ($version) ](fg:#8896a3 bg:#241d18)]($style)'
+
+[php]
+symbol = ""
+style = "bg:#241d18"
+format = '[[ $symbol ($version) ](fg:#8896a3 bg:#241d18)]($style)'
+
+[time]
+disabled = false
+time_format = "%R" # Hour:Minute Format
+style = "bg:#1a1613"
+format = '[[  $time ](fg:#ffd479 bg:#1a1613)]($style)'
+
+[java]
+symbol = "☕"
+style = "bg:#241d18"
+format = '[[ $symbol ($version) ](fg:#e2533a bg:#241d18)]($style)'
+detect_files = ["pom.xml", "build.gradle", "build.gradle.kts", ".java-version"]
+
+# Kubernetes natif desactive — remplace par [custom.zsh_env_context] (plus rapide, plus compact)
+[kubernetes]
+disabled = true
+
+# === Module Custom: Contexte Work ===
+[custom.work]
+description = "Indicateur contexte Work"
+command = "echo '󰋜'"
+when = "test -f ~/.zsh_env/.work_context_cache && tail -1 ~/.zsh_env/.work_context_cache | grep -q true"
+format = "[$output ](bg:#8896a3 fg:#ffd479)"
+shell = ["bash", "--noprofile", "--norc"]
+
+# === Module Custom: Projet actif (zproject) ===
+[custom.zproject]
+description = "Projet zproject actif"
+command = 'echo "${ZPROJECT_NAME}${ZPROJECT_ENV:+/${ZPROJECT_ENV}}"'
+when = 'test -n "$ZPROJECT_NAME"'
+format = "[ 󰏗 $output ](fg:#a87fa0 bg:#241d18)"
+shell = ["bash", "--noprofile", "--norc"]
+
+# === Module Custom: Contexte Dev (Kube) ===
+[custom.zsh_env_context]
+description = "Kubernetes context and namespace via zsh-env-cli"
+command = "zsh-env-cli context"
+when = "test -x ${HOME}/.local/bin/zsh-env-cli"
+format = "[[ $output ](fg:#5fae9f bg:#241d18)]($style)"
+style = "bg:#241d18"
+shell = ["bash", "--noprofile", "--norc"]


### PR DESCRIPTION
## Résumé

Thème signature **forge** (atelier de forge : fer froid + détails chauds), aligné avec l'identité visuelle zanvil et les logos.

- `themes/forge/palette.zsh` — 8 slots `_ui_*` (feu/patine/braise/acier/violet trempé/trempe/cendre)
- `themes/forge/prompt.toml` — dérivé de `tokyo-night-pro` (même layout powerline), recolorisé **schéma C** : segment dir acier, git **braise** `#ff8a3d`, heure **étincelle** `#ffd479`, java rouge feu, context trempe
- `install.sh` — forge devient l'option **recommandée** du menu + le défaut du mode `--default`

## Impact / sûreté

- **Nouveaux installs** : forge par défaut.
- **Utilisateurs existants** : non affectés (`.current_theme` posé seulement à l'install, jamais par l'auto-update). Bascule manuelle via `zsh-env-theme apply forge`. **Aucune migration.**
- Transitionnel : `prompt.toml` garde `zsh-env-cli context` et les chemins `~/.zsh_env/...` (rename = v4.0.0).

## Vérifications

- `starship config` **valide** `themes/forge/prompt.toml` (le vrai parseur)
- Aucune couleur tokyo résiduelle ; tous les accents schéma C contrôlés
- `palette.zsh` source proprement (8 `_ui_*` corrects) ; `bash -n install.sh` OK
- (note : `tomllib` Python rejette la ligne `format` à cause des échappements de Starship — quirk identique sur le tokyo-night-pro d'origine, pas un défaut)

`feature/*` → bump **minor v3.11.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)