### PR TITLE
ci(site): Node 22 pour le build Pages (Astro 7)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: site/package-lock.json
       - run: npm ci


### PR DESCRIPTION
Le déploiement Pages (run du merge #85) a échoué : Astro 7 exige Node >=22.12.0, or pages.yml utilisait node-version: 20 (build local OK car Node 24). Bump à 22. Branche `ci/*` → pas de release ; le merge re-déclenche pages.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)