### PR TITLE
docs(roadmap): rename de repo en v4.0.0 + versions corrigées

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,7 +1,8 @@
 # Roadmap — zanvil
 
 > Programme de rebranding (`zsh_env` → **zanvil**) + nouvelles fonctionnalités.
-> Chaque item = une PR (`feature/*` → minor, `hotfix/*` → patch) = une release auto via `auto-release.yml`.
+> Chaque item = une PR (`feature/*`/`feat/*` → minor, `hotfix/*` → patch) = une release auto via `auto-release.yml`.
+> ⚠️ Pas encore de chemin **major** dans le workflow (cf. #3b) — requis pour la v4.0.0.
 > Version actuelle : voir `core/ui.zsh` (`ZSH_ENV_VERSION`).
 
 ## Livré
@@ -10,17 +11,17 @@
 |------|---------|-------|
 | Modern CLI replacements (rg/fd/dust/duf/procs/btop/gping/tldr) | v3.8.0 | hybride : drop-in + outils sous nom propre |
 | Identité visuelle zanvil (logo ASCII, bannière, tagline « craft your shell ») | v3.9.0 | cosmétique, non-breaking |
-| Site de doc Astro Starlight (incrément 1) | v4.0.0 | déployé sur GitHub Pages, thème forge, pages essentielles migrées |
+| Branding assets (logos SVG sombre/clair/mono + favicon + en-tête README) | v3.10.0 | mark vectoriel reconstruit depuis l'export design |
+| Thème signature **forge** | v3.11.0 | défaut des nouveaux installs ; existants non affectés |
+| Site de doc Astro Starlight — **incrément 1** | v3.12.0 | Pages live, thème forge, landing + 3 pages migrées |
 
 ## Backlog
 
 | # | Item | Version visée | Type | Statut | Breaking |
 |---|------|---------------|------|--------|----------|
-| 2 | Thème signature **forge** | v3.10.0 | feat | 📝 spec prêt (`specs/2026-06-24-forge-theme-design.md`) | non |
-| 3 | Branding assets (logos repo + README) | v3.11.0 | feat | 🎨 mark vectoriel récupéré (sombre+clair) ; wordmark/pixel à ré-exporter | non |
 | 3b | Prérequis CI : chemin de bump **major** dans `auto-release.yml` | v3.x | feat | 🧠 à faire avant le #4 | non |
-| 4 | **🔴 Rename technique complet** | **v4.0.0** | major | 🧠 à brainstormer | **OUI** |
-| 5 | Refonte wiki / **site GitHub Pages** | v4.x | feat | 🧠 à brainstormer (cf. ci-dessous) | non |
+| 4 | **🔴 Rename technique complet (+ repo GitHub)** | **v4.0.0** | major | 🧠 à brainstormer | **OUI** |
+| 5 | Site Pages — **incrément 2** (migration complète + audit doc + retrait `wiki.yml`) | v4.x | feat | 🧠 inc1 ✅, inc2 à brainstormer | non |
 | 6 | Piste A — productivité shell (×7) | v4.x | feat | 💡 idées | non |
 | 7 | Piste B — onboarding / DX (×3) | v4.x | feat | 💡 idées | non |
 | 8 | Piste D — méta / écosystème (×2) | v4.x | feat | 💡 idées | non |
@@ -30,24 +31,39 @@
 - **B — onboarding/DX** : wizard `zanvil init` · dashboard / MOTD · `zanvil profile` (breakdown startup)
 - **D — méta** : registre de modules + `module install` · profils/presets (work / perso / minimal)
 
-## 🔴 Passage en 4.0.0 (rename technique)
+## 🔴 Passage en v4.0.0 (rename technique)
 
 **Périmètre breaking :**
-- `~/.zsh_env` → `~/.zanvil`
-- variables `ZSH_ENV_*` → `ZANVIL_*` (guards de modules, `ZSH_ENV_DIR`, etc.)
+- `~/.zsh_env` → `~/.zanvil` (dossier d'install)
+- variables `ZSH_ENV_*` → `ZANVIL_*` (guards de modules, `ZSH_ENV_DIR`, `ZSH_ENV_STARTUP_BANNER`, etc.)
 - binaire `zsh-env-cli` → `zanvil` ; commandes `zsh-env-*` → `zanvil-*`
-- repo GitHub `zsh_env` → `zanvil`
+- **repo GitHub `Dr0drigues/zsh_env` → `Dr0drigues/zanvil`** (action manuelle, propriétaire uniquement, réversible)
 - **script de migration** (renommer le dossier, réécrire `.zshrc`, migrer `config.zsh`) + **shims de compat** (alias dépréciés `zsh-env-*` → `zanvil-*` avec avertissement)
 
-**Prérequis CI (#3b)** : `auto-release.yml` ne gère que `minor` (`feature/*`) et `patch` (`hotfix/*`) — **aucun chemin major**. Avant le 4.0.0 : ajouter un déclencheur major (ex. préfixe `breaking/*` ou label PR `major`), sinon tag manuel.
+### Rename du repo GitHub — effets en cascade
+
+**Géré automatiquement par GitHub (redirections) :**
+- Les anciennes URLs (`…/zsh_env`, `…/zsh_env.git`) redirigent vers `zanvil` — git clone/push, web et API continuent de fonctionner. Forks/stars/issues/PRs suivent.
+- Le secret **`RELEASE_TOKEN`** (PAT fine-grained) est scopé par **ID de repo**, pas par nom → survit au rename (à confirmer rapidement après l'opération).
+- Les workflows (`auto-release.yml`, `pages.yml`, `wiki.yml`) utilisent `github.repository` **dynamique** → s'adaptent seuls.
+
+**À mettre à jour explicitement (cassent sinon) :**
+- **GitHub Pages** : l'URL devient `dr0drigues.github.io/zanvil/` → changer `base: '/zsh_env/'` → `/zanvil/` dans `site/astro.config.mjs`, **tous les liens du site** (hero actions, favicon), le lien site du `README` et la **social preview**.
+- **Wiki** : URL `…/zanvil/wiki`.
+- **Instructions d'install** : `git clone …/zanvil.git ~/.zanvil` (couplé au rename du dossier).
+- **Docs/README/ROADMAP** : toutes les URLs `Dr0drigues/zsh_env` codées en dur.
+
+**Séquencement :** le rename de repo est **interdépendant** avec le reste (le base path Pages dépend du nom du repo) → à faire **dans le même sous-projet v4.0.0**, pas isolément. Le **prérequis CI #3b** (chemin major) doit être livré **avant**.
+
+**Prérequis CI (#3b) :** `auto-release.yml` ne gère que `minor` (`feature/*`/`feat/*`) et `patch` (`hotfix/*`) — **aucun chemin major**. Avant la 4.0.0 : ajouter un déclencheur major (ex. préfixe `breaking/*` ou label PR `major`), sinon tag manuel.
 
 ## Ordre conseillé
 
-Livrer les **non-breaking d'abord** (forge #2, assets #3, prérequis CI #3b), **puis le rename #4 en capstone v4.0.0** — après quoi A/B/D se construisent directement avec le nommage zanvil (plus de couches transitionnelles). Le site/wiki (#5) peut s'intercaler dès que l'identité visuelle est figée.
+Livrer le **prérequis CI #3b** d'abord, puis le **rename #4 en capstone v4.0.0** — après quoi les pistes A/B/D se construisent directement avec le nommage zanvil (plus de couches transitionnelles). Le site Pages incrément 2 (#5) peut s'intercaler avant ou après le rename (s'il passe après, sa migration intègre directement le nouveau nommage).
 
-## Site / Wiki (#5) — en cours
+## Site / Wiki (#5)
 
-État actuel : dossier `wiki/` synchronisé vers le GitHub Wiki par `.github/workflows/wiki.yml` (déclenché sur push `wiki/**`). Site GitHub Pages (Astro Starlight) en construction :
-- **Incrément 1 ✅** : site déployé sur GitHub Pages via `.github/workflows/pages.yml`, pages essentielles migrées, thème forge.
-- **Incrément 2** : migration des 13 pages restantes du wiki, **audit de complétude documentaire** (vérifier que toutes les pages wiki sont migrées et à jour, rien d'obsolète, liens valides), puis retrait du `wiki.yml`.
+État actuel : dossier `wiki/` synchronisé vers le GitHub Wiki par `.github/workflows/wiki.yml` (déclenché sur push `wiki/**`). Site GitHub Pages (Astro Starlight, `site/`) en construction :
+- **Incrément 1 ✅ (v3.12.0)** : site déployé sur GitHub Pages via `.github/workflows/pages.yml`, landing + 3 pages migrées, thème forge.
+- **Incrément 2** : migration des 13 pages restantes du wiki, **audit de complétude documentaire** (toutes les pages migrées et à jour, rien d'obsolète — ex. section Tmux du module supprimé, chemin CLI `~/.zsh_env/cli`, liens valides, renvois inter-pages restaurés), puis retrait du `wiki.yml`.
 - Décision finale : Pages **remplace** le wiki une fois l'audit terminé et approuvé.


### PR DESCRIPTION
Détaille le rename du repo GitHub (`zsh_env` → `zanvil`) dans le périmètre v4.0.0 et ses effets en cascade (Pages base path, wiki/install URLs, RELEASE_TOKEN par ID, workflows dynamiques). Corrige aussi les versions du tableau Livré (site = v3.12.0, pas v4.0.0 ; forge/assets re-versionnés). Branche `docs/*` → pas de release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)