### PR TITLE
ci: chemin de bump major (breaking/*) dans auto-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -30,12 +30,14 @@ jobs:
         run: |
           echo "Source branch: $BRANCH"
 
-          if [[ "$BRANCH" == hotfix/* ]]; then
+          if [[ "$BRANCH" == breaking/* ]]; then
+            echo "type=major" >> $GITHUB_OUTPUT
+          elif [[ "$BRANCH" == hotfix/* ]]; then
             echo "type=patch" >> $GITHUB_OUTPUT
           elif [[ "$BRANCH" == feature/* || "$BRANCH" == feat/* ]]; then
             echo "type=minor" >> $GITHUB_OUTPUT
           else
-            echo "Branch '$BRANCH' does not match feature/*, feat/* or hotfix/* — skipping release."
+            echo "Branch '$BRANCH' does not match breaking/*, feature/*, feat/* or hotfix/* — skipping release."
             echo "type=skip" >> $GITHUB_OUTPUT
           fi
 
@@ -48,6 +50,7 @@ jobs:
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
 
           case "${{ steps.bump.outputs.type }}" in
+            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
             minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
             patch) PATCH=$((PATCH + 1)) ;;
           esac

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,8 +1,7 @@
 # Roadmap — zanvil
 
 > Programme de rebranding (`zsh_env` → **zanvil**) + nouvelles fonctionnalités.
-> Chaque item = une PR (`feature/*`/`feat/*` → minor, `hotfix/*` → patch) = une release auto via `auto-release.yml`.
-> ⚠️ Pas encore de chemin **major** dans le workflow (cf. #3b) — requis pour la v4.0.0.
+> Chaque item = une PR (`feature/*`/`feat/*` → minor, `hotfix/*` → patch, `breaking/*` → major) = une release auto via `auto-release.yml`.
 > Version actuelle : voir `core/ui.zsh` (`ZSH_ENV_VERSION`).
 
 ## Livré
@@ -14,12 +13,12 @@
 | Branding assets (logos SVG sombre/clair/mono + favicon + en-tête README) | v3.10.0 | mark vectoriel reconstruit depuis l'export design |
 | Thème signature **forge** | v3.11.0 | défaut des nouveaux installs ; existants non affectés |
 | Site de doc Astro Starlight — **incrément 1** | v3.12.0 | Pages live, thème forge, landing + 3 pages migrées |
+| Chemin de bump major (`breaking/*`) dans `auto-release.yml` | v3.13.0 | prérequis #3b pour la v4.0.0 |
 
 ## Backlog
 
 | # | Item | Version visée | Type | Statut | Breaking |
 |---|------|---------------|------|--------|----------|
-| 3b | Prérequis CI : chemin de bump **major** dans `auto-release.yml` | v3.x | feat | 🧠 à faire avant le #4 | non |
 | 4 | **🔴 Rename technique complet (+ repo GitHub)** | **v4.0.0** | major | 🧠 à brainstormer | **OUI** |
 | 5 | Site Pages — **incrément 2** (migration complète + audit doc + retrait `wiki.yml`) | v4.x | feat | 🧠 inc1 ✅, inc2 à brainstormer | non |
 | 6 | Piste A — productivité shell (×7) | v4.x | feat | 💡 idées | non |
@@ -55,7 +54,7 @@
 
 **Séquencement :** le rename de repo est **interdépendant** avec le reste (le base path Pages dépend du nom du repo) → à faire **dans le même sous-projet v4.0.0**, pas isolément. Le **prérequis CI #3b** (chemin major) doit être livré **avant**.
 
-**Prérequis CI (#3b) :** `auto-release.yml` ne gère que `minor` (`feature/*`/`feat/*`) et `patch` (`hotfix/*`) — **aucun chemin major**. Avant la 4.0.0 : ajouter un déclencheur major (ex. préfixe `breaking/*` ou label PR `major`), sinon tag manuel.
+**Prérequis CI (#3b) :** ✅ Livré en v3.13.0 — `auto-release.yml` gère désormais `major` (`breaking/*`), `minor` (`feature/*`/`feat/*`) et `patch` (`hotfix/*`). Une PR sur branche `breaking/*` déclenche automatiquement un bump major.
 
 ## Ordre conseillé
 

--- a/docs/superpowers/plans/2026-06-25-auto-release-major.md
+++ b/docs/superpowers/plans/2026-06-25-auto-release-major.md
@@ -1,0 +1,159 @@
+# auto-release major bump (#3b) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ajouter un chemin de bump *major* (`breaking/*` → major) à `auto-release.yml`, prérequis de la v4.0.0.
+
+**Architecture:** Modification additive d'un seul fichier workflow : une condition de branche + un cas dans le `case` de calcul de version. Le reste du pipeline (bump, push via RELEASE_TOKEN, tag, release) est inchangé.
+
+**Tech Stack:** GitHub Actions (bash dans le workflow), pas de framework de test — vérification par simulation bash + validation YAML.
+
+## Global Constraints
+
+- Déclencheur major = préfixe de branche `breaking/*`.
+- Additif uniquement : ne PAS modifier les chemins `minor`/`patch`/`skip` existants.
+- Un major incrémente MAJOR, remet MINOR et PATCH à 0.
+- **Doc avant PR** (règle standing) : mettre à jour `docs/ROADMAP.md` (#3b livré) avant de créer la PR.
+- `$SCRATCHPAD` = `/private/tmp/claude-502/-Users-bl209054--zsh-env/518614f2-a551-4e43-9135-dfc256ae2d6e/scratchpad`
+
+---
+
+### Task 1: Ajouter le chemin major dans auto-release.yml
+
+**Files:**
+- Modify: `.github/workflows/auto-release.yml` (étapes « Determine bump type from branch name » et « Calculate new version »)
+- Test: `$SCRATCHPAD/test_major.sh`
+
+**Interfaces:**
+- Produces: le workflow déduit `type=major` pour une branche `breaking/*` et calcule `MAJOR+1`, `MINOR=0`, `PATCH=0`.
+
+- [ ] **Step 1: Écrire le test de simulation (doit échouer)**
+
+Créer `$SCRATCHPAD/test_major.sh` :
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+F="$HOME/.zsh_env/.github/workflows/auto-release.yml"
+
+# 1. Le workflow doit contenir le chemin breaking/* -> major et le cas major)
+grep -q 'BRANCH" == breaking/\*' "$F" || { echo "FAIL: pas de condition breaking/*"; exit 1; }
+grep -qE 'major\).*MAJOR=\$\(\(MAJOR \+ 1\)\)' "$F" || { echo "FAIL: pas de cas major) dans le calcul de version"; exit 1; }
+
+# 2. Simulation de la logique de bump (réplique des conditions)
+bump() {
+  local BRANCH="$1"
+  if [[ "$BRANCH" == breaking/* ]]; then echo major
+  elif [[ "$BRANCH" == hotfix/* ]]; then echo patch
+  elif [[ "$BRANCH" == feature/* || "$BRANCH" == feat/* ]]; then echo minor
+  else echo skip; fi
+}
+[[ "$(bump breaking/rename-zanvil)" == major ]] || { echo "FAIL: breaking/ != major"; exit 1; }
+[[ "$(bump hotfix/x)" == patch ]] || { echo "FAIL: hotfix/ != patch"; exit 1; }
+[[ "$(bump feature/x)" == minor ]] || { echo "FAIL: feature/ != minor"; exit 1; }
+[[ "$(bump feat/x)" == minor ]] || { echo "FAIL: feat/ != minor"; exit 1; }
+[[ "$(bump chore/x)" == skip ]] || { echo "FAIL: chore/ != skip"; exit 1; }
+
+# 3. Simulation du calcul de version : major sur v3.12.0 -> v4.0.0
+calc() {
+  local type="$1" CURRENT="$2"
+  local VERSION=${CURRENT#v}; local MAJOR MINOR PATCH
+  IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+  case "$type" in
+    major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+    minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+    patch) PATCH=$((PATCH + 1)) ;;
+  esac
+  echo "v${MAJOR}.${MINOR}.${PATCH}"
+}
+[[ "$(calc major v3.12.0)" == v4.0.0 ]] || { echo "FAIL: major v3.12.0 != v4.0.0"; exit 1; }
+[[ "$(calc minor v3.12.0)" == v3.13.0 ]] || { echo "FAIL: minor v3.12.0 != v3.13.0"; exit 1; }
+[[ "$(calc patch v3.12.0)" == v3.12.1 ]] || { echo "FAIL: patch v3.12.0 != v3.12.1"; exit 1; }
+
+# 4. YAML valide
+ruby -ryaml -e "YAML.load_file('$F')" >/dev/null || { echo "FAIL: YAML invalide"; exit 1; }
+echo "PASS"
+```
+
+- [ ] **Step 2: Lancer le test pour vérifier qu'il échoue**
+
+Run: `bash "$SCRATCHPAD/test_major.sh"`
+Expected: `FAIL: pas de condition breaking/*` (le workflow n'a pas encore le chemin major).
+
+- [ ] **Step 3: Ajouter la condition `breaking/*` → major**
+
+Dans `.github/workflows/auto-release.yml`, étape « Determine bump type from branch name », remplacer le bloc `if/elif/else` par :
+```bash
+          if [[ "$BRANCH" == breaking/* ]]; then
+            echo "type=major" >> $GITHUB_OUTPUT
+          elif [[ "$BRANCH" == hotfix/* ]]; then
+            echo "type=patch" >> $GITHUB_OUTPUT
+          elif [[ "$BRANCH" == feature/* || "$BRANCH" == feat/* ]]; then
+            echo "type=minor" >> $GITHUB_OUTPUT
+          else
+            echo "Branch '$BRANCH' does not match breaking/*, feature/*, feat/* or hotfix/* — skipping release."
+            echo "type=skip" >> $GITHUB_OUTPUT
+          fi
+```
+
+- [ ] **Step 4: Ajouter le cas `major` au calcul de version**
+
+Dans l'étape « Calculate new version », remplacer le `case` par :
+```bash
+          case "${{ steps.bump.outputs.type }}" in
+            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+            patch) PATCH=$((PATCH + 1)) ;;
+          esac
+```
+
+- [ ] **Step 5: Lancer le test pour vérifier qu'il passe**
+
+Run: `bash "$SCRATCHPAD/test_major.sh"`
+Expected: `PASS`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/auto-release.yml
+git commit -m "ci: ajouter le chemin de bump major (breaking/*) à auto-release"
+```
+
+---
+
+### Task 2: Documentation (OBLIGATOIRE avant la PR)
+
+**Files:**
+- Modify: `docs/ROADMAP.md` (#3b livré + mention du déclencheur `breaking/*`)
+
+**Interfaces:**
+- Consumes: le chemin major livré (Task 1).
+
+- [ ] **Step 1: Mettre à jour la ROADMAP**
+
+Dans `docs/ROADMAP.md` :
+- Déplacer la ligne **#3b** du tableau Backlog vers le tableau **Livré** (version v3.13.0), libellé : « Chemin de bump major (`breaking/*`) dans `auto-release.yml` ».
+- Dans la section « 🔴 Passage en v4.0.0 », mettre à jour le paragraphe « Prérequis CI (#3b) » pour indiquer qu'il est **livré** : une PR sur branche `breaking/*` déclenche désormais un bump major automatique.
+- Dans le bloc d'intro en tête de fichier, ajouter `breaking/*` → major à la liste des préfixes.
+
+- [ ] **Step 2: Vérifier**
+
+```bash
+cd /Users/bl209054/.zsh_env
+grep -q "breaking/\*" docs/ROADMAP.md && echo "ROADMAP OK"
+```
+Expected: `ROADMAP OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/ROADMAP.md
+git commit -m "docs(roadmap): #3b livré — chemin de bump major breaking/*"
+```
+
+---
+
+## Notes d'exécution
+
+- Branche : `feature/auto-release-major` (préfixe `feature/*` → la modif elle-même se publie en **v3.13.0**). Elle portera aussi le commit local du spec (`c2fb8e1`).
+- ⚠️ NE PAS nommer la branche `breaking/*` (sinon cette PR déclencherait elle-même un major v4.0.0 prématuré).
+- Le major ne s'activera réellement qu'au futur merge d'une PR `breaking/rename-zanvil` (v4.0.0).

--- a/docs/superpowers/specs/2026-06-25-auto-release-major-design.md
+++ b/docs/superpowers/specs/2026-06-25-auto-release-major-design.md
@@ -1,0 +1,58 @@
+# auto-release.yml — chemin de bump major (#3b) — Design
+
+**Date** : 2026-06-25
+**Statut** : Validé (en attente d'implémentation)
+**Release cible** : minor (v3.13.0)
+
+## Contexte
+
+Prérequis de la v4.0.0 (rename technique). `.github/workflows/auto-release.yml` déduit le type de bump du nom de branche de la PR mergée : `hotfix/*`→patch, `feature/*`/`feat/*`→minor, sinon skip. **Il n'existe aucun chemin major** → le passage en v4.0.0 ne pourrait pas se publier automatiquement. Ce sous-projet ajoute le déclencheur major.
+
+## Décision
+
+Déclencheur major = **préfixe de branche `breaking/*`** (cohérent avec le pattern branche-nom existant).
+
+## Modification (un seul fichier : `.github/workflows/auto-release.yml`)
+
+### Étape « Determine bump type from branch name »
+Ajouter `breaking/*` → `major` en **première** condition :
+```bash
+if [[ "$BRANCH" == breaking/* ]]; then
+  echo "type=major" >> $GITHUB_OUTPUT
+elif [[ "$BRANCH" == hotfix/* ]]; then
+  echo "type=patch" >> $GITHUB_OUTPUT
+elif [[ "$BRANCH" == feature/* || "$BRANCH" == feat/* ]]; then
+  echo "type=minor" >> $GITHUB_OUTPUT
+else
+  echo "Branch '$BRANCH' does not match breaking/*, feature/*, feat/* or hotfix/* — skipping release."
+  echo "type=skip" >> $GITHUB_OUTPUT
+fi
+```
+
+### Étape « Calculate new version »
+Ajouter le cas `major` au `case` existant :
+```bash
+case "${{ steps.bump.outputs.type }}" in
+  major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+  minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+  patch) PATCH=$((PATCH + 1)) ;;
+esac
+```
+
+Le reste du workflow (bump `core/ui.zsh`, push via `RELEASE_TOKEN`, tag, release) est inchangé et fonctionne identiquement pour un major.
+
+## Périmètre / sûreté
+
+- Un seul fichier modifié. **Additif** : ne modifie pas les chemins minor/patch/skip existants.
+- N'exécute rien de lui-même : un major ne se déclenche que sur le merge d'une PR dont la branche est `breaking/*`.
+- Hors périmètre : le rename v4.0.0 lui-même (#4), tout autre mécanisme (label PR, conventional commits).
+
+## Migration
+
+Aucune (modification de workflow CI, aucun état utilisateur).
+
+## Tests
+
+- Simulation de la logique de bump (bash) : `breaking/x`→major, `hotfix/x`→patch, `feature/x`/`feat/x`→minor, `chore/x`→skip.
+- Simulation du calcul de version : type `major` sur `CURRENT=v3.12.0` → `v4.0.0` (MAJOR+1, MINOR/PATCH=0).
+- `ruby -ryaml -e "YAML.load_file('.github/workflows/auto-release.yml')"` → YAML valide.


### PR DESCRIPTION
## Résumé

Prérequis #3b de la v4.0.0 : ajoute un chemin de bump **major** à `auto-release.yml`. Une PR mergée depuis une branche **`breaking/*`** déclenche désormais un bump major (MAJOR+1, MINOR=0, PATCH=0) — ex. `breaking/rename-zanvil` → v4.0.0.

- Logique de bump : `breaking/*` testé en premier (précédence), puis hotfix/feature/feat inchangés
- Calcul de version : cas `major)` ajouté
- `docs/ROADMAP.md` : #3b marqué livré

## Sûreté

- Additif : minor/patch/skip inchangés ; étapes downstream (bump/push/tag/release) déjà major-compatibles
- Cette PR est sur `feature/*` → se publie en **v3.13.0** (pas de major prématuré)
- Le major ne s'activera qu'au futur `breaking/rename-zanvil`

🤖 Generated with [Claude Code](https://claude.com/claude-code)