### PR TITLE
fix(migrate): backup leger sans ACL + reecriture sed portable

### DIFF
--- a/core/lifecycle/migrate_zanvil.zsh
+++ b/core/lifecycle/migrate_zanvil.zsh
@@ -10,24 +10,41 @@ _zanvil_migrate_from_zsh_env() {
     [[ -d "$old" && ! -d "$new" ]] || return 0
 
     local ts; ts=$(date +%Y%m%d-%H%M%S)
+    local bak="${old}.bak-${ts}"
     echo "zanvil: migration depuis ~/.zsh_env vers ~/.zanvil ..."
-    cp -a "$old" "${old}.bak-${ts}" || { echo "zanvil: backup echoue, abandon"; return 1; }
+    # Backup leger : exclut les dossiers lourds regenerables (node_modules, build
+    # Rust, sorties/cache de build, .git) et NE preserve PAS les ACL/xattr. cp -a
+    # echouait sur site/node_modules sous macOS (failed to copy ACLs) et dupliquait
+    # plusieurs Go inutiles. rsync sinon repli sur cp -R.
+    if command -v rsync &>/dev/null; then
+        rsync -a \
+            --exclude='.git' --exclude='node_modules' --exclude='target' \
+            --exclude='dist' --exclude='.astro' \
+            "$old/" "$bak/" || { echo "zanvil: backup echoue, abandon"; return 1; }
+    else
+        cp -R "$old" "$bak" || { echo "zanvil: backup echoue, abandon"; return 1; }
+    fi
     mv "$old" "$new"                || { echo "zanvil: deplacement echoue, abandon"; return 1; }
 
+    # Reecriture in-place portable (BSD/macOS + GNU/Linux) : pas de sed -i (la
+    # syntaxe du suffixe differe entre les deux). On passe par un fichier temporaire.
     local zshrc="$HOME/.zshrc"
     if [[ -f "$zshrc" ]]; then
         cp "$zshrc" "${zshrc}.bak-${ts}" || { echo "zanvil: backup .zshrc echoue, abandon"; return 1; }
-        sed -i '' -e 's/ZSH_ENV_DIR/ZANVIL_DIR/g' -e 's#\.zsh_env#.zanvil#g' "$zshrc" \
+        sed -e 's/ZSH_ENV_DIR/ZANVIL_DIR/g' -e 's#\.zsh_env#.zanvil#g' "$zshrc" > "${zshrc}.tmp" \
+            && mv "${zshrc}.tmp" "$zshrc" \
             || echo "zanvil: avertissement: reecriture .zshrc echouee"
     fi
 
     local cfg="$new/config.zsh"
     if [[ -f "$cfg" ]]; then
         cp "$cfg" "${cfg}.bak-${ts}"
-        sed -i '' 's/ZSH_ENV_/ZANVIL_/g' "$cfg"
+        sed 's/ZSH_ENV_/ZANVIL_/g' "$cfg" > "${cfg}.tmp" \
+            && mv "${cfg}.tmp" "$cfg" \
+            || echo "zanvil: avertissement: reecriture config.zsh echouee"
     fi
 
-    echo "zanvil: migration terminee (backup: ${old}.bak-${ts}). Rechargement..."
+    echo "zanvil: migration terminee (backup: ${bak}). Rechargement..."
     export ZANVIL_DIR="$new"
     [[ -n "$ZANVIL_MIGRATE_NO_EXEC" ]] && return 0
     exec zsh


### PR DESCRIPTION
## Contexte

La migration auto `zsh_env → zanvil` (v4.0.0) a **échoué sur une vraie install** : le backup `cp -a "$old" "$old.bak-TS"` copiait tout l'arbre `~/.zsh_env`, dont `site/node_modules` (centaines de Mo) et `.git`. Sous macOS, `cp -a` plantait avec des centaines de `failed to copy ACLs / unable to copy extended attributes`, dupliquait **~6 Go** et abortait la migration (`backup echoue, abandon`).

## Correctif

- **Backup léger** : `rsync -a` (sans `-A/-X` → pas d'ACL/xattr), excluant les dossiers lourds régénérables (`.git`, `node_modules`, `target`, `dist`, `.astro`). Repli `cp -R` si `rsync` absent. Le contenu lourd n'est pas perdu : il suit via le `mv "$old" "$new"`.
- **Réécriture portable** : abandon de `sed -i ''` (syntaxe BSD-only qui casse sur GNU/Linux) au profit d'un fichier temporaire `> .tmp && mv` — corrige un bug Linux latent sur la réécriture de `.zshrc`/`config.zsh`.

## Tests

Sandbox (HOME factice + `~/.zsh_env` simulé avec `node_modules`/`.git`/`target`/`dist`) : ✅
- `.zsh_env` déplacé, `.zanvil` créé avec contenu
- backup créé **excluant** node_modules / cli/target / .git / dist
- `.zshrc` + `config.zsh` réécrits (`ZANVIL_*`, `.zanvil`), pas de `.tmp` résiduel
- idempotence préservée (re-run silencieux)

## Doc

Comportement visible utilisateur inchangé (la migration aboutit, sans planter) — `ROADMAP.md` reste exact, rien à mettre à jour. Pas de `migrations/NNN_*.zsh` requis (fix de la migration one-shot d'install, pas d'une migration de config runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)