### PR TITLE
feat: outillage Elasticsearch du module work + gclone (gitlab)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ web/docs/superpowers
 
 # Faux HOME des tests de chargement (test_load.sh)
 .fakehome/
+modules/work/logs/

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ cli/target/
 secrets/work/settings.xml
 secrets/work/certificates_unix.sh
 .work_context_cache
+.work_es_apps_cache
 
 # Superpowers files
 web/docs/superpowers

--- a/examples/env.d/work.zsh
+++ b/examples/env.d/work.zsh
@@ -6,8 +6,11 @@ export ZANVIL_WORK_NEXUS_URL="${ZANVIL_WORK_NEXUS_URL:-}"
 export ZANVIL_WORK_CACHE_TTL="${ZANVIL_WORK_CACHE_TTL:-300}"
 export ZANVIL_WORK_TIMEOUT="${ZANVIL_WORK_TIMEOUT:-2}"
 
-# Elasticsearch observability (utilise par work_fetch_logs)
+# Elasticsearch observability (work_fetch_logs, work_es_query/apps/count/tail)
 export ZANVIL_WORK_ES_URL="${ZANVIL_WORK_ES_URL:-}"
+export ZANVIL_WORK_ES_INDEX="${ZANVIL_WORK_ES_INDEX:-es-apis-*}"
+export ZANVIL_WORK_ES_APPS_TTL="${ZANVIL_WORK_ES_APPS_TTL:-3600}"   # TTL cache work_es_apps (s)
+export ZANVIL_WORK_ES_MAX_DOCS="${ZANVIL_WORK_ES_MAX_DOCS:-100000}" # seuil garde-fou work_fetch_logs
 export ES_USER="${ES_USER:-}"
 # ES_PASSWORD a definir dans ~/.secrets ou via SOPS, jamais ici en clair
 # export ES_PASSWORD=""

--- a/modules/gitlab/completions.zsh
+++ b/modules/gitlab/completions.zsh
@@ -1,8 +1,34 @@
 # ==============================================================================
-# GitLab Completions - Completions pour les alias gc-*
+# GitLab Completions - Completions pour gclone et les alias gc-*
 # ==============================================================================
 
 (( $+functions[compdef] )) || return 0
+
+# gclone : cles GITLAB_PROJECTS en premier argument, options du script ensuite
+_gclone() {
+    local -a keys opts
+    local key id
+
+    if (( CURRENT == 2 )); then
+        for key id in "${(@kv)GITLAB_PROJECTS}"; do
+            keys+=("$key:groupe $id")
+        done
+        _describe 'groupe GitLab' keys
+        return
+    fi
+
+    opts=(
+        'ssh:clone via SSH'
+        'https:clone via HTTPS (defaut)'
+        'full:clone complet (defaut)'
+        'shallow:clone --depth 1'
+        '--parallel:N projets en parallele'
+        '--dry-run:liste sans cloner'
+        '--help:affiche l'"'"'aide'
+    )
+    _describe 'option' opts
+}
+compdef _gclone gclone
 
 _gc_gitlab_alias() {
     local -a gc_cmds

--- a/modules/gitlab/gitlab_logic.zsh
+++ b/modules/gitlab/gitlab_logic.zsh
@@ -39,13 +39,136 @@ function load_gitlab_aliases() {
         # Ex: ptf-frontco devient gc-frontco-ptf
         alias_name="gc-${component}-${env}"
 
-        # Création de l'alias
-        alias "$alias_name"="cd $WORK_DIR && clone-projects.sh $id $GITLAB_TOKEN"
+        # Création de l'alias (délègue à gclone : pas de token dans la définition)
+        alias "$alias_name"="gclone $key"
     done
 }
 
 # Exécution de la génération
 load_gitlab_aliases
+
+### CLONE DE GROUPE ###
+
+# Liste les clés GITLAB_PROJECTS configurées (usage interne : aide + erreurs)
+function _gclone_list_keys() {
+    local key id
+    if (( ${#GITLAB_PROJECTS[@]} == 0 )); then
+        echo "    (aucune — définir GITLAB_PROJECTS dans env.d/gitlab.zsh)"
+        return
+    fi
+    for key id in "${(@kv)GITLAB_PROJECTS}"; do
+        printf "    %-24s groupe %s\n" "$key" "$id"
+    done | sort
+}
+
+function _gclone_usage() {
+    echo -e "${_ui_bold}USAGE${_ui_nc}"
+    echo "    gclone <clé|group-id> [options de clone-projects.sh]"
+    echo ""
+    echo -e "${_ui_bold}DESCRIPTION${_ui_nc}"
+    echo "    Clone ou met à jour tous les projets d'un groupe GitLab depuis \$WORK_DIR,"
+    echo "    puis positionne le shell dans le répertoire du groupe."
+    echo ""
+    echo -e "${_ui_bold}CLÉS DISPONIBLES${_ui_nc}"
+    _gclone_list_keys
+    echo ""
+    echo -e "${_ui_bold}OPTIONS${_ui_nc}"
+    echo "    Transmises telles quelles à clone-projects.sh :"
+    echo "    ssh | https, full | shallow, --parallel N, --dry-run"
+    echo "    Voir 'clone-projects.sh --help' pour le détail."
+    echo ""
+    echo -e "${_ui_bold}EXEMPLES${_ui_nc}"
+    echo "    gclone ptf-frontco ssh --parallel 8"
+    echo "    gclone 35621 --dry-run"
+}
+
+###
+# Clone tous les projets d'un groupe GitLab depuis $WORK_DIR.
+#
+# Résout la clé GITLAB_PROJECTS (ou un ID numérique brut), se place dans
+# $WORK_DIR pour lancer clone-projects.sh, puis positionne le shell dans le
+# répertoire du groupe cloné ($WORK_DIR/<full_path>).
+###
+function gclone() {
+    local target="$1"
+    local group_id script full_path start_dir api_url rc
+    local -a curl_opts
+
+    if [[ -z "$target" ]]; then
+        _ui_msg_fail "Argument manquant : clé GITLAB_PROJECTS ou group-id"
+        echo ""
+        _gclone_usage
+        return 1
+    fi
+
+    if [[ "$target" == "--help" || "$target" == "-h" ]]; then
+        _gclone_usage
+        return 0
+    fi
+    shift
+
+    # Résolution de l'ID de groupe : numérique = ID brut, sinon clé GITLAB_PROJECTS
+    if [[ "$target" == <-> ]]; then
+        group_id="$target"
+    else
+        group_id="${GITLAB_PROJECTS[$target]}"
+        if [[ -z "$group_id" ]]; then
+            _ui_msg_fail "Clé inconnue : $target"
+            echo -e "${_ui_bold}Clés disponibles :${_ui_nc}"
+            _gclone_list_keys
+            return 1
+        fi
+    fi
+
+    # Préconditions
+    if [[ -z "$GITLAB_TOKEN" ]]; then
+        _ui_msg_fail "GITLAB_TOKEN non défini (voir ~/.gitlab_secrets)"
+        return 1
+    fi
+    if [[ -z "${GITLAB_BASE_DOMAIN:-}" ]]; then
+        _ui_msg_fail "GITLAB_BASE_DOMAIN non défini (voir env.d/gitlab.zsh)"
+        return 1
+    fi
+    if [[ -z "${WORK_DIR:-}" || ! -d "$WORK_DIR" ]]; then
+        _ui_msg_fail "WORK_DIR invalide ou inexistant : ${WORK_DIR:-<non défini>}"
+        return 1
+    fi
+    if [[ -x "$SCRIPTS_DIR/clone-projects.sh" ]]; then
+        script="$SCRIPTS_DIR/clone-projects.sh"
+    elif command -v clone-projects.sh &>/dev/null; then
+        script="clone-projects.sh"
+    else
+        _ui_msg_fail "clone-projects.sh introuvable (\$SCRIPTS_DIR ou \$PATH)"
+        return 1
+    fi
+
+    # Résolution du sous-répertoire du groupe (best-effort : sert au cd final)
+    api_url="https://${GITLAB_BASE_DOMAIN}/api/v4"
+    curl_opts=(-s --max-time 5)
+    [[ "${GITLAB_IGNORE_SSL:-false}" == "true" ]] && curl_opts+=(-k)
+
+    if command -v jq &>/dev/null; then
+        full_path=$(curl "${curl_opts[@]}" --header "PRIVATE-TOKEN: $GITLAB_TOKEN" \
+            "$api_url/groups/$group_id" 2>/dev/null | jq -r '.full_path // empty' 2>/dev/null)
+    fi
+
+    # Exécution depuis WORK_DIR
+    start_dir="$PWD"
+    cd "$WORK_DIR" || { _ui_msg_fail "Impossible d'accéder à $WORK_DIR"; return 1 }
+
+    "$script" "$group_id" "$GITLAB_TOKEN" "$@"
+    rc=$?
+
+    if (( rc != 0 )); then
+        cd "$start_dir"
+        return $rc
+    fi
+
+    # Positionnement final dans le groupe cloné
+    if [[ -n "$full_path" && -d "$WORK_DIR/$full_path" ]]; then
+        cd "$WORK_DIR/$full_path"
+    fi
+}
 
 # Fonction utilitaire pour lister les alias générés
 function list-gitlab-cmds() {

--- a/modules/work/.lazy
+++ b/modules/work/.lazy
@@ -3,3 +3,7 @@ work_refresh
 work_init
 work_status
 work_fetch_logs
+work_es_query
+work_es_apps
+work_es_count
+work_es_tail

--- a/modules/work/completions.zsh
+++ b/modules/work/completions.zsh
@@ -7,9 +7,11 @@
 _work_fetch_logs() {
     _arguments \
         '--app[Application a interroger]:app:' \
-        '--since[Plage relative: Xm/Xh/Xd (ex: 30m, 2h, 7d)]:duration:' \
-        '--from[Debut UTC+1 (YYYY-mm-ddTHH:MM:SS)]:date:' \
-        '--to[Fin UTC+1 (YYYY-mm-ddTHH:MM:SS)]:date:' \
+        '--since[Plage relative: Xs/Xm/Xh/Xd (ex: 30s, 2h, 7d)]:duration:' \
+        '--from[Debut, heure locale Europe/Paris avec DST auto (YYYY-mm-ddTHH:MM:SS)]:date:' \
+        '--to[Fin, heure locale Europe/Paris avec DST auto (YYYY-mm-ddTHH:MM:SS)]:date:' \
+        '--search[Recherche TEXT dans .message, restreint la fenetre aux matches]:text:' \
+        '--margin[Padding autour des matches --search (defaut: 1m)]:duration:' \
         '--target-dir[Repertoire de sortie]:directory:_directories' \
         '--format[Format de sortie]:format:(ndjson json text)' \
         '(-h --help)'{-h,--help}'[Afficher l aide]'

--- a/modules/work/completions.zsh
+++ b/modules/work/completions.zsh
@@ -11,6 +11,7 @@ _work_es_cached_apps() {
     if [[ -f "$cache" ]]; then
         local -a apps
         apps=(${(f)"$(tail -n +3 "$cache" 2>/dev/null | cut -f1)"})
+        apps=("${apps[@]//:/\\:}")
         if (( ${#apps} )); then
             _describe -t applications 'application' apps
             return

--- a/modules/work/completions.zsh
+++ b/modules/work/completions.zsh
@@ -46,7 +46,7 @@ compdef _work_es_query work_es_query
 _work_es_apps() {
     _arguments \
         '--refresh[Forcer le rafraichissement du cache]' \
-        '1:plage Xm/Xh/Xd (defaut 24h):(1h 6h 24h 7d)'
+        '1:plage Xs/Xm/Xh/Xd (defaut 24h):(1h 6h 24h 7d)'
 }
 compdef _work_es_apps work_es_apps
 

--- a/modules/work/completions.zsh
+++ b/modules/work/completions.zsh
@@ -4,9 +4,24 @@
 
 (( $+functions[compdef] )) || return 0
 
+# Applications depuis le cache de work_es_apps — lecture fichier uniquement,
+# JAMAIS d'appel reseau pendant la completion. Cache perime accepte.
+_work_es_cached_apps() {
+    local cache="${ZANVIL_DIR:-$HOME/.zanvil}/.work_es_apps_cache"
+    if [[ -f "$cache" ]]; then
+        local -a apps
+        apps=(${(f)"$(tail -n +3 "$cache" 2>/dev/null | cut -f1)"})
+        if (( ${#apps} )); then
+            _describe -t applications 'application' apps
+            return
+        fi
+    fi
+    _message 'application (lancer work_es_apps pour alimenter la completion)'
+}
+
 _work_fetch_logs() {
     _arguments \
-        '--app[Application a interroger]:app:' \
+        '--app[Application a interroger]:app:_work_es_cached_apps' \
         '--since[Plage relative: Xs/Xm/Xh/Xd (ex: 30s, 2h, 7d)]:duration:' \
         '--from[Debut, heure locale Europe/Paris avec DST auto (YYYY-mm-ddTHH:MM:SS)]:date:' \
         '--to[Fin, heure locale Europe/Paris avec DST auto (YYYY-mm-ddTHH:MM:SS)]:date:' \
@@ -14,6 +29,40 @@ _work_fetch_logs() {
         '--margin[Padding autour des matches --search (defaut: 1m)]:duration:' \
         '--target-dir[Repertoire de sortie]:directory:_directories' \
         '--format[Format de sortie]:format:(ndjson json text)' \
+        '--yes[Passer le garde-fou volumetrique]' \
         '(-h --help)'{-h,--help}'[Afficher l aide]'
 }
 compdef _work_fetch_logs work_fetch_logs
+
+_work_es_query() {
+    _arguments \
+        '1:methode ou chemin:(GET POST PUT DELETE HEAD)' \
+        '2:chemin ES (ex es-apis-*/_search):' \
+        '3:body JSON ou - pour stdin:'
+}
+compdef _work_es_query work_es_query
+
+_work_es_apps() {
+    _arguments \
+        '--refresh[Forcer le rafraichissement du cache]' \
+        '1:plage Xm/Xh/Xd (defaut 24h):(1h 6h 24h 7d)'
+}
+compdef _work_es_apps work_es_apps
+
+_work_es_count() {
+    _arguments \
+        '--app[Application a interroger]:app:_work_es_cached_apps' \
+        '--since[Plage relative: Xs/Xm/Xh/Xd]:duration:' \
+        '--from[Debut, heure locale Europe/Paris avec DST auto]:date:' \
+        '--to[Fin, heure locale Europe/Paris avec DST auto]:date:' \
+        '--search[Phrase a chercher dans .message]:text:'
+}
+compdef _work_es_count work_es_count
+
+_work_es_tail() {
+    _arguments \
+        '--app[Application a suivre]:app:_work_es_cached_apps' \
+        '--search[Phrase a chercher dans .message]:text:' \
+        '--interval[Intervalle de poll en secondes (defaut 5, min 2)]:secondes:(2 5 10 30)'
+}
+compdef _work_es_tail work_es_tail

--- a/modules/work/elasticsearch.zsh
+++ b/modules/work/elasticsearch.zsh
@@ -400,6 +400,75 @@ _work_es_status_section() {
     return 0
 }
 
+# Suivi quasi temps reel. Usage: work_es_tail --app APP [--search TEXT] [--interval N]
+# Poll toutes les N secondes (defaut 5, min 2) via search_after sur @timestamp asc.
+# Aucun fichier temporaire: Ctrl-C interrompt proprement la boucle.
+work_es_tail() {
+    emulate -L zsh
+    _work_es_require || return 1
+
+    local app="" search="" interval=5
+    while (( $# > 0 )); do
+        case "$1" in
+            --app)      app="${2:-}" ;;
+            --search)   search="${2:-}" ;;
+            --interval) interval="${2:-}" ;;
+            *) _ui_msg_fail "Option inconnue: $1"; return 1 ;;
+        esac
+        if (( $# >= 2 )); then shift 2; else shift; fi
+    done
+    if [[ -z "$app" ]]; then
+        _ui_msg_fail "usage: work_es_tail --app APP [--search TEXT] [--interval N]"
+        return 1
+    fi
+    if [[ ! "$interval" == <-> ]]; then
+        _ui_msg_fail "--interval doit etre un entier (secondes)"
+        return 1
+    fi
+    (( interval < 2 )) && interval=2
+
+    local search_clause=""
+    if [[ -n "$search" ]]; then
+        local esc="${search//\\/\\\\}"
+        esc="${esc//\"/\\\"}"
+        search_clause=", { \"match_phrase\": { \"message\": \"$esc\" }}"
+    fi
+
+    # Demarrage a now-1m (sort value = epoch millis)
+    local last_sort=$(( ($(date -u +%s) - 60) * 1000 ))
+    _ui_msg_info "Tail de $app — interval ${interval}s, Ctrl-C pour quitter"
+
+    local resp count width
+    while true; do
+        resp=$(_work_es_json POST "$(_work_es_index)/_search" "{
+          \"size\": 1000,
+          \"sort\": [{\"@timestamp\": \"asc\"}],
+          \"search_after\": [$last_sort],
+          \"query\": { \"bool\": { \"must\": [
+            { \"term\": { \"application\": \"$app\" }}$search_clause
+          ]}}
+        }" "$interval") || {
+            _ui_msg_warn "ES injoignable — nouvel essai dans ${interval}s"
+            sleep "$interval"
+            continue
+        }
+
+        count=$(print -r -- "$resp" | jq -r '.hits.hits | length' 2>/dev/null)
+        if [[ "$count" == <-> ]] && (( count > 0 )); then
+            width=${COLUMNS:-120}
+            print -r -- "$resp" | jq -r '.hits.hits[]._source
+                | "\(.["@timestamp"] // "" | .[11:19]) [\(.level // "-")] \(.message // "" | gsub("[\r\n]+"; " "))"' \
+                2>/dev/null | cut -c1-$width
+            last_sort=$(print -r -- "$resp" | jq -r '.hits.hits[-1].sort[0]')
+            if (( count >= 1000 )); then
+                _ui_msg_warn "Filtre trop large (>= 1000 docs/iteration) — saut a now"
+                last_sort=$(( $(date -u +%s) * 1000 ))
+            fi
+        fi
+        sleep "$interval"
+    done
+}
+
 work_fetch_logs() {
     emulate -L zsh
     if [[ ! -x "$_WORK_FETCH_LOGS_SCRIPT" ]]; then

--- a/modules/work/elasticsearch.zsh
+++ b/modules/work/elasticsearch.zsh
@@ -73,6 +73,108 @@ _work_es_json() {
     return 0
 }
 
+# --- Dates et durees ---
+# Duplication annotee de modules/work/fetch_es_logs.sh (bash, BASH_REMATCH) :
+# reecrit en zsh ($match). Garder les deux versions synchronisees.
+
+typeset -g _WORK_ES_DATE_FLAVOR=""
+_work_es_date_flavor() {
+    if [[ -z "$_WORK_ES_DATE_FLAVOR" ]]; then
+        if date --version &>/dev/null; then
+            _WORK_ES_DATE_FLAVOR=gnu
+        else
+            _WORK_ES_DATE_FLAVOR=bsd
+        fi
+    fi
+    echo "$_WORK_ES_DATE_FLAVOR"
+}
+
+# Xs/Xm/Xh/Xd -> secondes
+_work_es_parse_duration() {
+    local d=$1
+    if [[ "$d" =~ '^([0-9]+)([smhd])$' ]]; then
+        local num=$match[1] unit=$match[2]
+        case $unit in
+            s) echo $num ;;
+            m) echo $((num * 60)) ;;
+            h) echo $((num * 3600)) ;;
+            d) echo $((num * 86400)) ;;
+        esac
+    else
+        return 1
+    fi
+}
+
+_work_es_epoch_to_iso() {
+    local epoch=$1
+    if [[ $(_work_es_date_flavor) == gnu ]]; then
+        date -u -d "@$epoch" +"%Y-%m-%dT%H:%M:%S.000Z"
+    else
+        date -u -j -f "%s" "$epoch" +"%Y-%m-%dT%H:%M:%S.000Z"
+    fi
+}
+
+# ISO UTC ("2026-05-30T14:00:00.000Z" ou sans ms) -> epoch
+_work_es_iso_to_epoch() {
+    local ts=$1
+    if [[ $(_work_es_date_flavor) == gnu ]]; then
+        date -u -d "$ts" +%s
+    else
+        local clean="${ts%.*}"
+        clean="${clean%Z}"
+        TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean" +%s 2>/dev/null
+    fi
+}
+
+# Date Europe/Paris "YYYY-mm-ddTHH:MM:SS" -> epoch UTC (DST gere)
+_work_es_paris_to_epoch() {
+    local dt=$1
+    if [[ $(_work_es_date_flavor) == gnu ]]; then
+        TZ=Europe/Paris date -d "$dt" +%s
+    else
+        TZ=Europe/Paris date -j -f "%Y-%m-%dT%H:%M:%S" "$dt" +%s 2>/dev/null
+    fi
+}
+
+# Calcule la fenetre temporelle depuis --since / --from / --to.
+# Remplit les globales _work_es_gte, _work_es_lte (ISO UTC), _work_es_display.
+_work_es_window() {
+    local since="${1:-}" from="${2:-}" to="${3:-}"
+    typeset -g _work_es_gte="" _work_es_lte="" _work_es_display=""
+    if [[ -n "$since" ]]; then
+        local seconds now
+        seconds=$(_work_es_parse_duration "$since") || {
+            _ui_msg_fail "--since invalide: $since (attendu: Xs/Xm/Xh/Xd)"
+            return 1
+        }
+        now=$(date -u +%s)
+        _work_es_gte=$(_work_es_epoch_to_iso $((now - seconds)))
+        _work_es_lte=$(_work_es_epoch_to_iso $now)
+        _work_es_display="depuis $since (-> now)"
+    else
+        local from_epoch to_epoch
+        from_epoch=$(_work_es_paris_to_epoch "$from")
+        [[ "$from_epoch" == <-> ]] || {
+            _ui_msg_fail "--from invalide: $from (attendu: 2026-03-26T15:30:00)"
+            return 1
+        }
+        if [[ -n "$to" ]]; then
+            to_epoch=$(_work_es_paris_to_epoch "$to")
+            [[ "$to_epoch" == <-> ]] || {
+                _ui_msg_fail "--to invalide: $to (attendu: 2026-03-26T15:30:00)"
+                return 1
+            }
+            _work_es_display="$from -> $to (Europe/Paris)"
+        else
+            to_epoch=$(date -u +%s)
+            _work_es_display="$from -> now (Europe/Paris)"
+        fi
+        _work_es_gte=$(_work_es_epoch_to_iso $from_epoch)
+        _work_es_lte=$(_work_es_epoch_to_iso $to_epoch)
+    fi
+    return 0
+}
+
 work_fetch_logs() {
     if [[ ! -x "$_WORK_FETCH_LOGS_SCRIPT" ]]; then
         _ui_msg_fail "Script introuvable ou non executable: $_WORK_FETCH_LOGS_SCRIPT"

--- a/modules/work/elasticsearch.zsh
+++ b/modules/work/elasticsearch.zsh
@@ -490,7 +490,7 @@ work_fetch_logs() {
     # Extraction de --yes + capture des options utiles au comptage.
     # Tout le reste part tel quel au script (qui fait sa propre validation).
     local -a pass_args
-    local skip_guard=false app="" since="" from="" to="" search=""
+    local skip_guard=false app="" since="" from="" to="" search="" margin=""
     while (( $# > 0 )); do
         case "$1" in
             --yes) skip_guard=true; shift ;;
@@ -501,6 +501,7 @@ work_fetch_logs() {
                     --from)   from="${2:-}" ;;
                     --to)     to="${2:-}" ;;
                     --search) search="${2:-}" ;;
+                    --margin) margin="${2:-}" ;;
                 esac
                 pass_args+=("$1" "${2:-}")
                 if (( $# >= 2 )); then shift 2; else shift; fi
@@ -518,6 +519,20 @@ work_fetch_logs() {
             local resp
             resp=$(_work_es_count_query "$app" "$_work_es_gte" "$_work_es_lte" "$search" 2>/dev/null) \
                 && total=$(print -r -- "$resp" | jq -r '.hits.total.value // .hits.total // empty' 2>/dev/null)
+            # Avec --search, le script exporte la fenetre [min,max] +/- margin des matches,
+            # pas les seuls matches : re-compter sans clause search sur la fenetre elargie.
+            if [[ -n "$search" && "$total" == <-> ]] && (( total > 0 )); then
+                local min_iso max_iso margin_sec gte2 lte2
+                min_iso=$(print -r -- "$resp" | jq -r '.aggregations.min_ts.value_as_string // empty' 2>/dev/null)
+                max_iso=$(print -r -- "$resp" | jq -r '.aggregations.max_ts.value_as_string // empty' 2>/dev/null)
+                margin_sec=$(_work_es_parse_duration "${margin:-1m}" 2>/dev/null) || margin_sec=60
+                if [[ -n "$min_iso" && -n "$max_iso" ]]; then
+                    gte2=$(_work_es_epoch_to_iso $(( $(_work_es_iso_to_epoch "$min_iso") - margin_sec )))
+                    lte2=$(_work_es_epoch_to_iso $(( $(_work_es_iso_to_epoch "$max_iso") + margin_sec )))
+                    resp=$(_work_es_count_query "$app" "$gte2" "$lte2" "" 2>/dev/null) \
+                        && total=$(print -r -- "$resp" | jq -r '.hits.total.value // .hits.total // empty' 2>/dev/null)
+                fi
+            fi
         fi
         if [[ "$total" == <-> ]] && (( total > max_docs )); then
             _ui_msg_warn "Volume estime: $total documents (seuil: $max_docs)"

--- a/modules/work/elasticsearch.zsh
+++ b/modules/work/elasticsearch.zsh
@@ -226,7 +226,7 @@ work_es_query() {
 }
 
 # Liste des applications par volume. Usage: work_es_apps [RANGE] [--refresh]
-# RANGE au format Xm/Xh/Xd (defaut 24h). Cache TTL: ZANVIL_WORK_ES_APPS_TTL (3600s).
+# RANGE au format Xs/Xm/Xh/Xd (defaut 24h). Cache TTL: ZANVIL_WORK_ES_APPS_TTL (3600s).
 work_es_apps() {
     emulate -L zsh
     _work_es_require || return 1
@@ -239,7 +239,7 @@ work_es_apps() {
                 if _work_es_parse_duration "$arg" >/dev/null 2>&1; then
                     range="$arg"
                 else
-                    _ui_msg_fail "Plage invalide: $arg (attendu: Xm/Xh/Xd)"
+                    _ui_msg_fail "Plage invalide: $arg (attendu: Xs/Xm/Xh/Xd)"
                     return 1
                 fi
                 ;;
@@ -280,6 +280,8 @@ work_es_apps() {
 # Usage: _work_es_count_query APP GTE LTE [SEARCH]. Sortie: JSON ES brut.
 _work_es_count_query() {
     local app=$1 gte=$2 lte=$3 search="${4:-}"
+    local app_esc="${app//\\/\\\\}"
+    app_esc="${app_esc//\"/\\\"}"
     local search_clause=""
     if [[ -n "$search" ]]; then
         local esc="${search//\\/\\\\}"
@@ -290,7 +292,7 @@ _work_es_count_query() {
       \"size\": 0,
       \"track_total_hits\": true,
       \"query\": { \"bool\": { \"must\": [
-        { \"term\": { \"application\": \"$app\" }},
+        { \"term\": { \"application\": \"$app_esc\" }},
         { \"range\": { \"@timestamp\": { \"gte\": \"$gte\", \"lte\": \"$lte\" }}}$search_clause
       ]}},
       \"aggs\": {
@@ -434,6 +436,9 @@ work_es_tail() {
         search_clause=", { \"match_phrase\": { \"message\": \"$esc\" }}"
     fi
 
+    local app_esc="${app//\\/\\\\}"
+    app_esc="${app_esc//\"/\\\"}"
+
     # Demarrage a now-1m (sort value = epoch millis)
     local last_sort=$(( ($(date -u +%s) - 60) * 1000 ))
     _ui_msg_info "Tail de $app — interval ${interval}s, Ctrl-C pour quitter"
@@ -445,7 +450,7 @@ work_es_tail() {
           \"sort\": [{\"@timestamp\": \"asc\"}],
           \"search_after\": [$last_sort],
           \"query\": { \"bool\": { \"must\": [
-            { \"term\": { \"application\": \"$app\" }}$search_clause
+            { \"term\": { \"application\": \"$app_esc\" }}$search_clause
           ]}}
         }" "$interval") || {
             _ui_msg_warn "ES injoignable — nouvel essai dans ${interval}s"
@@ -509,7 +514,7 @@ work_fetch_logs() {
         && command -v jq &>/dev/null; then
         local max_docs="${ZANVIL_WORK_ES_MAX_DOCS:-100000}"
         local total=""
-        if _work_es_window "$since" "$from" "$to" 2>/dev/null; then
+        if _work_es_window "$since" "$from" "$to" >/dev/null 2>&1; then
             local resp
             resp=$(_work_es_count_query "$app" "$_work_es_gte" "$_work_es_lte" "$search" 2>/dev/null) \
                 && total=$(print -r -- "$resp" | jq -r '.hits.total.value // .hits.total // empty' 2>/dev/null)

--- a/modules/work/elasticsearch.zsh
+++ b/modules/work/elasticsearch.zsh
@@ -355,15 +355,59 @@ work_es_count() {
 }
 
 work_fetch_logs() {
+    emulate -L zsh
     if [[ ! -x "$_WORK_FETCH_LOGS_SCRIPT" ]]; then
         _ui_msg_fail "Script introuvable ou non executable: $_WORK_FETCH_LOGS_SCRIPT"
         return 1
     fi
-
     if [[ -z "${ES_USER:-}" || -z "${ES_PASSWORD:-}" ]]; then
         _ui_msg_fail "ES_USER/ES_PASSWORD non definis (voir env.d/work.zsh)"
         return 1
     fi
 
-    "$_WORK_FETCH_LOGS_SCRIPT" "$@"
+    # Extraction de --yes + capture des options utiles au comptage.
+    # Tout le reste part tel quel au script (qui fait sa propre validation).
+    local -a pass_args
+    local skip_guard=false app="" since="" from="" to="" search=""
+    while (( $# > 0 )); do
+        case "$1" in
+            --yes) skip_guard=true; shift ;;
+            --app|--since|--from|--to|--search|--margin|--target-dir|--format)
+                case "$1" in
+                    --app)    app="${2:-}" ;;
+                    --since)  since="${2:-}" ;;
+                    --from)   from="${2:-}" ;;
+                    --to)     to="${2:-}" ;;
+                    --search) search="${2:-}" ;;
+                esac
+                pass_args+=("$1" "${2:-}")
+                if (( $# >= 2 )); then shift 2; else shift; fi
+                ;;
+            *) pass_args+=("$1"); shift ;;
+        esac
+    done
+
+    # Garde-fou volumetrique (fail-open: ne bloque jamais plus que le script)
+    if [[ "$skip_guard" == false && -n "$app" ]] && [[ -n "$since" || -n "$from" ]] \
+        && command -v jq &>/dev/null; then
+        local max_docs="${ZANVIL_WORK_ES_MAX_DOCS:-100000}"
+        local total=""
+        if _work_es_window "$since" "$from" "$to" 2>/dev/null; then
+            local resp
+            resp=$(_work_es_count_query "$app" "$_work_es_gte" "$_work_es_lte" "$search" 2>/dev/null) \
+                && total=$(print -r -- "$resp" | jq -r '.hits.total.value // .hits.total // empty' 2>/dev/null)
+        fi
+        if [[ "$total" == <-> ]] && (( total > max_docs )); then
+            _ui_msg_warn "Volume estime: $total documents (seuil: $max_docs)"
+            if ! read -q "?Continuer l'export ? [y/N] "; then
+                echo ""
+                return 1
+            fi
+            echo ""
+        elif [[ ! "$total" == <-> ]]; then
+            _ui_msg_warn "Comptage prealable impossible — export lance sans garde-fou (--yes pour passer ce controle)"
+        fi
+    fi
+
+    "$_WORK_FETCH_LOGS_SCRIPT" "${pass_args[@]}"
 }

--- a/modules/work/elasticsearch.zsh
+++ b/modules/work/elasticsearch.zsh
@@ -456,10 +456,12 @@ work_es_tail() {
         count=$(print -r -- "$resp" | jq -r '.hits.hits | length' 2>/dev/null)
         if [[ "$count" == <-> ]] && (( count > 0 )); then
             width=${COLUMNS:-120}
+            [[ "$width" == <-> ]] && (( width >= 1 )) || width=120
             print -r -- "$resp" | jq -r '.hits.hits[]._source
                 | "\(.["@timestamp"] // "" | .[11:19]) [\(.level // "-")] \(.message // "" | gsub("[\r\n]+"; " "))"' \
                 2>/dev/null | cut -c1-$width
-            last_sort=$(print -r -- "$resp" | jq -r '.hits.hits[-1].sort[0]')
+            last_sort=$(print -r -- "$resp" | jq -r '.hits.hits[-1].sort[0]' 2>/dev/null)
+            [[ "$last_sort" == <-> ]] || last_sort=$(( $(date -u +%s) * 1000 ))
             if (( count >= 1000 )); then
                 _ui_msg_warn "Filtre trop large (>= 1000 docs/iteration) — saut a now"
                 last_sort=$(( $(date -u +%s) * 1000 ))

--- a/modules/work/elasticsearch.zsh
+++ b/modules/work/elasticsearch.zsh
@@ -175,6 +175,51 @@ _work_es_window() {
     return 0
 }
 
+# --- Commandes publiques ---
+
+# Requete ES generique. Usage: work_es_query [METHOD] PATH [BODY|-]
+# METHOD deduit si absent: GET sans body, POST avec body. BODY "-" = stdin.
+work_es_query() {
+    emulate -L zsh
+    _work_es_require || return 1
+
+    local method=""
+    if [[ "${1:u}" == (GET|POST|PUT|DELETE|HEAD) ]]; then
+        method="${1:u}"
+        shift
+    fi
+    local path="${1:-}" body="${2:-}"
+    if [[ -z "$path" ]]; then
+        _ui_msg_fail "usage: work_es_query [METHOD] PATH [BODY|-]"
+        return 1
+    fi
+    [[ "$body" == "-" ]] && body="$(cat)"
+    if [[ -z "$method" ]]; then
+        [[ -n "$body" ]] && method=POST || method=GET
+    fi
+
+    local out code resp
+    out=$(_work_es_curl "$method" "$path" "$body") || {
+        _ui_msg_fail "Elasticsearch injoignable: $(_work_es_url)"
+        return 1
+    }
+    code="${out%%$'\n'*}"
+    resp=""
+    [[ "$out" == *$'\n'* ]] && resp="${out#*$'\n'}"
+
+    if [[ "$code" == <-> ]] && (( code >= 400 )); then
+        _ui_msg_fail "HTTP $code"
+        [[ -n "$resp" ]] && { print -r -- "$resp" | jq . 2>/dev/null || print -r -- "$resp" }
+        return 1
+    fi
+    if [[ -t 1 && -n "$resp" ]]; then
+        print -r -- "$resp" | jq . 2>/dev/null || print -r -- "$resp"
+    elif [[ -n "$resp" ]]; then
+        print -r -- "$resp"
+    fi
+    return 0
+}
+
 work_fetch_logs() {
     if [[ ! -x "$_WORK_FETCH_LOGS_SCRIPT" ]]; then
         _ui_msg_fail "Script introuvable ou non executable: $_WORK_FETCH_LOGS_SCRIPT"

--- a/modules/work/elasticsearch.zsh
+++ b/modules/work/elasticsearch.zsh
@@ -3,6 +3,7 @@
 # ==============================================================================
 
 _WORK_FETCH_LOGS_SCRIPT="${ZANVIL_DIR:-$HOME/.zanvil}/modules/work/fetch_es_logs.sh"
+_WORK_ES_APPS_CACHE="${ZANVIL_DIR:-$HOME/.zanvil}/.work_es_apps_cache"
 
 # --- Configuration ES (surchargeable via env.d/work.zsh) ---
 
@@ -222,6 +223,57 @@ work_es_query() {
         print -r -- "$resp"
     fi
     return 0
+}
+
+# Liste des applications par volume. Usage: work_es_apps [RANGE] [--refresh]
+# RANGE au format Xm/Xh/Xd (defaut 24h). Cache TTL: ZANVIL_WORK_ES_APPS_TTL (3600s).
+work_es_apps() {
+    emulate -L zsh
+    _work_es_require || return 1
+
+    local range="24h" refresh=false arg
+    for arg in "$@"; do
+        case "$arg" in
+            --refresh) refresh=true ;;
+            *)
+                if _work_es_parse_duration "$arg" >/dev/null 2>&1; then
+                    range="$arg"
+                else
+                    _ui_msg_fail "Plage invalide: $arg (attendu: Xm/Xh/Xd)"
+                    return 1
+                fi
+                ;;
+        esac
+    done
+
+    local ttl="${ZANVIL_WORK_ES_APPS_TTL:-3600}"
+    if [[ "$refresh" == false && -f "$_WORK_ES_APPS_CACHE" ]]; then
+        local cached_time cached_range age
+        cached_time=$(sed -n '1p' "$_WORK_ES_APPS_CACHE")
+        cached_range=$(sed -n '2p' "$_WORK_ES_APPS_CACHE")
+        [[ "$cached_time" == <-> ]] && age=$(( $(date +%s) - cached_time )) || age=$ttl
+        if (( age < ttl )) && [[ "$cached_range" == "$range" ]]; then
+            tail -n +3 "$_WORK_ES_APPS_CACHE"
+            return 0
+        fi
+    fi
+
+    local resp data
+    resp=$(_work_es_json POST "$(_work_es_index)/_search" '{
+      "size": 0,
+      "query": { "range": { "@timestamp": { "gte": "now-'"$range"'" }}},
+      "aggs": { "apps": { "terms": { "field": "application", "size": 500 }}}
+    }') || {
+        _ui_msg_fail "Requete ES en echec: $(_work_es_url)"
+        return 1
+    }
+    data=$(print -r -- "$resp" | jq -r '.aggregations.apps.buckets[] | "\(.key)\t\(.doc_count)"' 2>/dev/null)
+    if [[ -z "$data" ]]; then
+        _ui_msg_fail "Reponse ES sans agregation apps (index: $(_work_es_index))"
+        return 1
+    fi
+    { date +%s; echo "$range"; print -r -- "$data" } > "$_WORK_ES_APPS_CACHE"
+    print -r -- "$data"
 }
 
 work_fetch_logs() {

--- a/modules/work/elasticsearch.zsh
+++ b/modules/work/elasticsearch.zsh
@@ -209,7 +209,11 @@ work_es_query() {
 
     if [[ "$code" == <-> ]] && (( code >= 400 )); then
         _ui_msg_fail "HTTP $code"
-        [[ -n "$resp" ]] && { print -r -- "$resp" | jq . 2>/dev/null || print -r -- "$resp" }
+        if [[ -t 1 && -n "$resp" ]]; then
+            print -r -- "$resp" | jq . 2>/dev/null || print -r -- "$resp"
+        elif [[ -n "$resp" ]]; then
+            print -r -- "$resp"
+        fi
         return 1
     fi
     if [[ -t 1 && -n "$resp" ]]; then

--- a/modules/work/elasticsearch.zsh
+++ b/modules/work/elasticsearch.zsh
@@ -354,6 +354,52 @@ work_es_count() {
     return 0
 }
 
+# Volet Elasticsearch de work_status. Toujours non bloquant:
+# hors contexte work -> "hors reseau", echec requete -> "injoignable"/"n/a".
+_work_es_status_section() {
+    echo ""
+    echo -e "${_ui_bold}Elasticsearch${_ui_nc}"
+    _ui_separator 44
+
+    if ! work_is_context; then
+        _ui_section "Statut" "${_ui_yellow}hors reseau${_ui_nc}"
+        return 0
+    fi
+
+    if [[ -n "${ES_USER:-}" && -n "${ES_PASSWORD:-}" ]]; then
+        _ui_section "Credentials" "${_ui_green}definis${_ui_nc}"
+    else
+        _ui_section "Credentials" "${_ui_red}absents (env.d/work.zsh)${_ui_nc}"
+        return 0
+    fi
+    if ! command -v jq &>/dev/null; then
+        _ui_section "Cluster" "${_ui_yellow}jq absent${_ui_nc}"
+        return 0
+    fi
+
+    local health status
+    health=$(_work_es_json GET "_cluster/health" "" 2)
+    if [[ -n "$health" ]]; then
+        status=$(print -r -- "$health" | jq -r '.status // "inconnu"')
+        case "$status" in
+            green)  _ui_section "Cluster" "${_ui_green}green${_ui_nc}" ;;
+            yellow) _ui_section "Cluster" "${_ui_yellow}yellow${_ui_nc}" ;;
+            red)    _ui_section "Cluster" "${_ui_red}red${_ui_nc}" ;;
+            *)      _ui_section "Cluster" "$status" ;;
+        esac
+    else
+        _ui_section "Cluster" "${_ui_red}injoignable${_ui_nc}"
+        return 0
+    fi
+
+    local resp oldest
+    resp=$(_work_es_json POST "$(_work_es_index)/_search" \
+        '{"size":0,"aggs":{"oldest":{"min":{"field":"@timestamp"}}}}' 5)
+    oldest=$(print -r -- "$resp" | jq -r '.aggregations.oldest.value_as_string // empty' 2>/dev/null)
+    _ui_section "Retention" "${oldest:-n/a}"
+    return 0
+}
+
 work_fetch_logs() {
     emulate -L zsh
     if [[ ! -x "$_WORK_FETCH_LOGS_SCRIPT" ]]; then

--- a/modules/work/elasticsearch.zsh
+++ b/modules/work/elasticsearch.zsh
@@ -309,13 +309,14 @@ work_es_count() {
     local app="" since="" from="" to="" search=""
     while (( $# > 0 )); do
         case "$1" in
-            --app)    app="${2:-}";    shift 2 ;;
-            --since)  since="${2:-}";  shift 2 ;;
-            --from)   from="${2:-}";   shift 2 ;;
-            --to)     to="${2:-}";     shift 2 ;;
-            --search) search="${2:-}"; shift 2 ;;
+            --app)    app="${2:-}" ;;
+            --since)  since="${2:-}" ;;
+            --from)   from="${2:-}" ;;
+            --to)     to="${2:-}" ;;
+            --search) search="${2:-}" ;;
             *) _ui_msg_fail "Option inconnue: $1"; return 1 ;;
         esac
+        if (( $# >= 2 )); then shift 2; else shift; fi
     done
     if [[ -z "$app" ]]; then
         _ui_msg_fail "usage: work_es_count --app APP [--since X | --from D [--to D]] [--search TEXT]"

--- a/modules/work/elasticsearch.zsh
+++ b/modules/work/elasticsearch.zsh
@@ -276,6 +276,83 @@ work_es_apps() {
     print -r -- "$data"
 }
 
+# Requete de comptage (size 0 + track_total_hits + aggs min/max sur @timestamp).
+# Usage: _work_es_count_query APP GTE LTE [SEARCH]. Sortie: JSON ES brut.
+_work_es_count_query() {
+    local app=$1 gte=$2 lte=$3 search="${4:-}"
+    local search_clause=""
+    if [[ -n "$search" ]]; then
+        local esc="${search//\\/\\\\}"
+        esc="${esc//\"/\\\"}"
+        search_clause=", { \"match_phrase\": { \"message\": \"$esc\" }}"
+    fi
+    _work_es_json POST "$(_work_es_index)/_search" "{
+      \"size\": 0,
+      \"track_total_hits\": true,
+      \"query\": { \"bool\": { \"must\": [
+        { \"term\": { \"application\": \"$app\" }},
+        { \"range\": { \"@timestamp\": { \"gte\": \"$gte\", \"lte\": \"$lte\" }}}$search_clause
+      ]}},
+      \"aggs\": {
+        \"min_ts\": { \"min\": { \"field\": \"@timestamp\" }},
+        \"max_ts\": { \"max\": { \"field\": \"@timestamp\" }}
+      }
+    }"
+}
+
+# Pre-vol avant export: total + fenetre reelle des matches, sans scroll ni fichier.
+# Usage: work_es_count --app APP [--since X | --from D [--to D]] [--search TEXT]
+work_es_count() {
+    emulate -L zsh
+    _work_es_require || return 1
+
+    local app="" since="" from="" to="" search=""
+    while (( $# > 0 )); do
+        case "$1" in
+            --app)    app="${2:-}";    shift 2 ;;
+            --since)  since="${2:-}";  shift 2 ;;
+            --from)   from="${2:-}";   shift 2 ;;
+            --to)     to="${2:-}";     shift 2 ;;
+            --search) search="${2:-}"; shift 2 ;;
+            *) _ui_msg_fail "Option inconnue: $1"; return 1 ;;
+        esac
+    done
+    if [[ -z "$app" ]]; then
+        _ui_msg_fail "usage: work_es_count --app APP [--since X | --from D [--to D]] [--search TEXT]"
+        return 1
+    fi
+    if [[ -n "$since" && ( -n "$from" || -n "$to" ) ]]; then
+        _ui_msg_fail "--since est incompatible avec --from/--to"
+        return 1
+    fi
+    if [[ -z "$since" && -z "$from" ]]; then
+        _ui_msg_fail "fournir --since ou --from (--to optionnel)"
+        return 1
+    fi
+    _work_es_window "$since" "$from" "$to" || return 1
+
+    local resp
+    resp=$(_work_es_count_query "$app" "$_work_es_gte" "$_work_es_lte" "$search") || {
+        _ui_msg_fail "Requete ES en echec: $(_work_es_url)"
+        return 1
+    }
+    local total min_iso max_iso
+    total=$(print -r -- "$resp" | jq -r '.hits.total.value // .hits.total // 0')
+    min_iso=$(print -r -- "$resp" | jq -r '.aggregations.min_ts.value_as_string // empty')
+    max_iso=$(print -r -- "$resp" | jq -r '.aggregations.max_ts.value_as_string // empty')
+
+    _ui_section "App" "$app"
+    [[ -n "$search" ]] && _ui_section "Recherche" "$search"
+    _ui_section "Plage" "$_work_es_display"
+    _ui_section "Total" "$total documents"
+    if [[ -n "$min_iso" && -n "$max_iso" ]]; then
+        local dur=$(( $(_work_es_iso_to_epoch "$max_iso") - $(_work_es_iso_to_epoch "$min_iso") ))
+        _ui_section "Fenetre" "$min_iso -> $max_iso"
+        _ui_section "Duree" "${dur}s"
+    fi
+    return 0
+}
+
 work_fetch_logs() {
     if [[ ! -x "$_WORK_FETCH_LOGS_SCRIPT" ]]; then
         _ui_msg_fail "Script introuvable ou non executable: $_WORK_FETCH_LOGS_SCRIPT"

--- a/modules/work/elasticsearch.zsh
+++ b/modules/work/elasticsearch.zsh
@@ -4,6 +4,75 @@
 
 _WORK_FETCH_LOGS_SCRIPT="${ZANVIL_DIR:-$HOME/.zanvil}/modules/work/fetch_es_logs.sh"
 
+# --- Configuration ES (surchargeable via env.d/work.zsh) ---
+
+_work_es_url() {
+    echo "${ES_URL:-${ZANVIL_WORK_ES_URL:-https://es-observability.prd.api.udb.azr.intranet}}"
+}
+
+_work_es_index() {
+    echo "${ZANVIL_WORK_ES_INDEX:-es-apis-*}"
+}
+
+# --- Helpers internes ---
+
+# Garde commune : outils + credentials avant tout appel reseau
+_work_es_require() {
+    if ! command -v curl &>/dev/null; then
+        _ui_msg_fail "curl requis"
+        return 1
+    fi
+    if ! command -v jq &>/dev/null; then
+        _ui_msg_fail "jq requis (brew install jq / apt install jq)"
+        return 1
+    fi
+    if [[ -z "${ES_USER:-}" || -z "${ES_PASSWORD:-}" ]]; then
+        _ui_msg_fail "ES_USER/ES_PASSWORD non definis (voir env.d/work.zsh)"
+        return 1
+    fi
+    return 0
+}
+
+# Appel ES brut. Usage: _work_es_curl METHOD PATH [BODY] [MAX_TIME]
+# Sortie: 1ere ligne = code HTTP, reste = corps de reponse.
+# Return: code de sortie curl (0 = reponse recue, meme en erreur HTTP).
+_work_es_curl() {
+    local method=$1 path=$2 body="${3:-}" max_time="${4:-30}"
+    local -a opts
+    opts=(-s --connect-timeout 5 --max-time "$max_time")
+    (( max_time < 5 )) && opts[2,3]=(--connect-timeout "$max_time")
+    [[ -n "${SSL_CERT_FILE:-}" ]] && opts+=(--cacert "$SSL_CERT_FILE")
+    opts+=(-u "$ES_USER:$ES_PASSWORD" -H 'Content-Type: application/json')
+    if [[ "$method" == HEAD ]]; then
+        opts+=(-I)
+    else
+        opts+=(-X "$method")
+    fi
+    [[ -n "$body" ]] && opts+=(-d "$body")
+
+    local out ret
+    out=$(command curl "${opts[@]}" -w $'\n%{http_code}' "$(_work_es_url)/$path" 2>/dev/null)
+    ret=$?
+    (( ret != 0 )) && return $ret
+    # Reordonne: code HTTP en premiere ligne, corps ensuite
+    print -r -- "${out##*$'\n'}"
+    local resp_body="${out%$'\n'*}"
+    [[ "$resp_body" != "$out" && -n "$resp_body" ]] && print -r -- "$resp_body"
+    return 0
+}
+
+# Appel ES "JSON ou rien". Usage: _work_es_json METHOD PATH [BODY] [MAX_TIME]
+# Sortie: corps seul. Return 1 si reseau KO ou HTTP >= 400.
+_work_es_json() {
+    local out code
+    out=$(_work_es_curl "$@") || return 1
+    code="${out%%$'\n'*}"
+    [[ "$code" == <-> ]] || return 1
+    (( code >= 400 )) && return 1
+    [[ "$out" == *$'\n'* ]] && print -r -- "${out#*$'\n'}"
+    return 0
+}
+
 work_fetch_logs() {
     if [[ ! -x "$_WORK_FETCH_LOGS_SCRIPT" ]]; then
         _ui_msg_fail "Script introuvable ou non executable: $_WORK_FETCH_LOGS_SCRIPT"

--- a/modules/work/fetch_es_logs.sh
+++ b/modules/work/fetch_es_logs.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Provenance : la source de vérité de ce script est le projet ~/work/misc/analysis-tools
+# (en cours de création, il reprendra ce script comme fondation).
+# Toute évolution doit se faire là-bas puis être resynchronisée ici.
 set -uo pipefail
 
 usage() {
@@ -8,16 +11,18 @@ usage() {
   Exporte les logs Elasticsearch pour l'application donnée.
 
   OPTIONS:
-    --app         APP          Application à interroger
-    --since       DURATION     Plage relative: Xm (minutes), Xh (heures), Xd (jours)
-                               Ex: --since 30m, --since 2h, --since 7d
-    --from        FROM_DATE    Début de plage en UTC+1 (Europe/Paris hiver)
-    --to          TO_DATE      Fin de plage en UTC+1 (défaut: now si omis)
-    --target-dir  DIR          Répertoire de sortie (défaut: \$PWD/logs/\$APP)
+    --app         APP          Application à interroger (ex: bff-frontcommerce)
+    --since       DURATION     Plage relative: Xs, Xm, Xh, Xd (ex: 30m, 2h, 7d)
+    --from        FROM_DATE    Début de plage (heure locale Europe/Paris, DST auto)
+    --to          TO_DATE      Fin de plage (heure locale Europe/Paris, défaut: now)
+    --search      TEXT         Cherche TEXT dans .message ; restreint l'export à
+                               la fenêtre [min, max] des matches (étendue par --margin)
+    --margin      DURATION     Padding autour des matches --search (défaut: 1m)
+    --target-dir  DIR          Répertoire de sortie (défaut: \$SCRIPT_DIR/logs/\$APP)
     --format      FORMAT       Format de sortie: ndjson (défaut), json, text
 
   DATE FORMAT (pour --from/--to):
-    "2026-03-26T15:30:00" => 2026/03/26 à 15:30 UTC+1 (14:30 UTC)
+    "2026-05-30T16:00:00" => 2026/05/30 à 16:00 Europe/Paris (DST géré)
 
   FORMATS:
     ndjson  Un document JSON (_source) par ligne (batch_XXXX.ndjson)
@@ -32,6 +37,8 @@ TO=
 SINCE=
 TARGET_DIR=
 FORMAT=ndjson
+SEARCH=
+MARGIN=1m
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -39,6 +46,8 @@ while [[ $# -gt 0 ]]; do
     --from)       FROM="$2";       shift 2 ;;
     --to)         TO="$2";         shift 2 ;;
     --since)      SINCE="$2";      shift 2 ;;
+    --search)     SEARCH="$2";     shift 2 ;;
+    --margin)     MARGIN="$2";     shift 2 ;;
     --target-dir) TARGET_DIR="$2"; shift 2 ;;
     --format)     FORMAT="$2";     shift 2 ;;
     -h|--help) usage; exit 0 ;;
@@ -75,6 +84,23 @@ else
   DATE_FLAVOR=bsd
 fi
 
+# Parse Xs/Xm/Xh/Xd -> secondes
+parse_duration_to_seconds() {
+  local d="$1"
+  if [[ "$d" =~ ^([0-9]+)([smhd])$ ]]; then
+    local num="${BASH_REMATCH[1]}"
+    local unit="${BASH_REMATCH[2]}"
+    case "$unit" in
+      s) echo "$num" ;;
+      m) echo $((num * 60)) ;;
+      h) echo $((num * 3600)) ;;
+      d) echo $((num * 86400)) ;;
+    esac
+  else
+    return 1
+  fi
+}
+
 epoch_to_iso() {
   local epoch="$1"
   if [[ "$DATE_FLAVOR" == gnu ]]; then
@@ -84,65 +110,71 @@ epoch_to_iso() {
   fi
 }
 
-# Parse une date UTC+1 "YYYY-mm-ddTHH:MM:SS" -> epoch UTC
-parse_utc1_to_epoch() {
+# Parse une date ISO UTC ("2025-05-30T14:00:00.000Z" ou sans ms) -> epoch
+iso_to_epoch() {
+  local ts="$1"
+  if [[ "$DATE_FLAVOR" == gnu ]]; then
+    date -u -d "$ts" +%s
+  else
+    local clean="${ts%.*}"
+    clean="${clean%Z}"
+    TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean" +%s 2>/dev/null
+  fi
+}
+
+# Parse une date Europe/Paris "YYYY-mm-ddTHH:MM:SS" -> epoch UTC (DST géré)
+parse_paris_to_epoch() {
   local dt="$1"
   if [[ "$DATE_FLAVOR" == gnu ]]; then
-    date -u -d "$dt UTC+1" +%s
+    TZ=Europe/Paris date -d "$dt" +%s
   else
-    local e
-    e=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$dt" +%s 2>/dev/null) || return 1
-    echo $((e - 3600))
+    TZ=Europe/Paris date -j -f "%Y-%m-%dT%H:%M:%S" "$dt" +%s 2>/dev/null
   fi
 }
 
 if [[ -n "$SINCE" ]]; then
-  if [[ "$SINCE" =~ ^([0-9]+)([mhd])$ ]]; then
-    num="${BASH_REMATCH[1]}"
-    unit="${BASH_REMATCH[2]}"
-    case "$unit" in
-      m) seconds=$((num * 60)) ;;
-      h) seconds=$((num * 3600)) ;;
-      d) seconds=$((num * 86400)) ;;
-    esac
-  else
-    echo "Erreur: format --since invalide. Attendu: Xm, Xh, ou Xd (ex: 30m, 2h, 7d)"
+  seconds=$(parse_duration_to_seconds "$SINCE") || {
+    echo "Erreur: format --since invalide. Attendu: Xs, Xm, Xh, Xd (ex: 30m, 2h, 7d)"
     exit 1
-  fi
+  }
   NOW_EPOCH=$(date -u +%s)
   FROM_EPOCH=$((NOW_EPOCH - seconds))
   GTE=$(epoch_to_iso "$FROM_EPOCH")
   LTE=$(epoch_to_iso "$NOW_EPOCH")
   RANGE_DISPLAY="depuis $SINCE (-> now)"
 else
-  FROM_EPOCH=$(parse_utc1_to_epoch "$FROM") || {
+  FROM_EPOCH=$(parse_paris_to_epoch "$FROM") || {
     echo "Erreur: format --from invalide. Attendu: 2026-03-26T15:30:00"; exit 1;
   }
   if [[ -n "$TO" ]]; then
-    TO_EPOCH=$(parse_utc1_to_epoch "$TO") || {
+    TO_EPOCH=$(parse_paris_to_epoch "$TO") || {
       echo "Erreur: format --to invalide. Attendu: 2026-03-26T15:30:00"; exit 1;
     }
-    RANGE_DISPLAY="$FROM -> $TO (UTC+1)"
+    RANGE_DISPLAY="$FROM -> $TO (Europe/Paris)"
   else
     TO_EPOCH=$(date -u +%s)
-    RANGE_DISPLAY="$FROM -> now (UTC+1)"
+    RANGE_DISPLAY="$FROM -> now (Europe/Paris)"
   fi
   GTE=$(epoch_to_iso "$FROM_EPOCH")
   LTE=$(epoch_to_iso "$TO_EPOCH")
 fi
 
-ES_URL="${ES_URL:-${ZANVIL_WORK_ES_URL:-}}"
-if [[ -z "$ES_URL" ]]; then
-  echo "Erreur: ES_URL non defini (voir env.d/work.zsh ou ZANVIL_WORK_ES_URL)"
-  exit 1
+if [[ -n "$SEARCH" ]]; then
+  MARGIN_SEC=$(parse_duration_to_seconds "$MARGIN") || {
+    echo "Erreur: format --margin invalide. Attendu: Xs, Xm, Xh (ex: 30s, 1m, 2m)"
+    exit 1
+  }
 fi
-INDEX="${ES_INDEX:-es-apis-*}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ES_URL="${ES_URL:-https://es-observability.prd.api.udb.azr.intranet}"
+INDEX="es-apis-*"
 BATCH_SIZE=10000
 
 if [[ -n "$TARGET_DIR" ]]; then
   BATCHES_DIR="$TARGET_DIR"
 else
-  BATCHES_DIR="$PWD/logs/$APP"
+  BATCHES_DIR="$SCRIPT_DIR/logs/$APP"
 fi
 
 case "$FORMAT" in
@@ -150,6 +182,21 @@ case "$FORMAT" in
   json)   EXT="json" ;;
   text)   EXT="log" ;;
 esac
+
+draw_progress() {
+  local current=$1 total=$2 batch=$3
+  local pct=0
+  if [[ "$total" =~ ^[0-9]+$ && "$total" -gt 0 ]]; then
+    pct=$((current * 100 / total))
+    [[ $pct -gt 100 ]] && pct=100
+  fi
+  local bar_width=40
+  local filled=$((pct * bar_width / 100))
+  local bar="" i
+  for ((i=0; i<filled; i++)); do bar+="#"; done
+  for ((i=filled; i<bar_width; i++)); do bar+="-"; done
+  printf "\r[%s] %3d%% — %s/%s docs (batch %d)\033[K" "$bar" "$pct" "$current" "$total" "$batch"
+}
 
 write_batch() {
   local resp="$1" file="$2"
@@ -169,6 +216,55 @@ echo "  UTC:  $GTE -> $LTE"
 echo "Format: $FORMAT"
 echo "Dir:    $BATCHES_DIR"
 echo ""
+
+# Phase recherche : restreint la fenêtre à [min, max] des matches +/- margin
+if [[ -n "$SEARCH" ]]; then
+  # Échappement JSON minimal (\\ et ")
+  SEARCH_ESC="${SEARCH//\\/\\\\}"
+  SEARCH_ESC="${SEARCH_ESC//\"/\\\"}"
+
+  echo "=== Recherche \"$SEARCH\" (margin ±$MARGIN) ==="
+  search_resp=$(curl -u "$ES_USER:$ES_PASSWORD" -s "$ES_URL/$INDEX/_search" \
+    -H 'Content-Type: application/json' \
+    -d "{
+      \"size\": 0,
+      \"track_total_hits\": true,
+      \"query\": {
+        \"bool\": {
+          \"must\": [
+            { \"term\": { \"application\": \"$APP\" }},
+            { \"range\": { \"@timestamp\": { \"gte\": \"$GTE\", \"lte\": \"$LTE\" }}},
+            { \"match_phrase\": { \"message\": \"$SEARCH_ESC\" }}
+          ]
+        }
+      },
+      \"aggs\": {
+        \"min_ts\": { \"min\": { \"field\": \"@timestamp\" }},
+        \"max_ts\": { \"max\": { \"field\": \"@timestamp\" }}
+      }
+    }")
+
+  match_total=$(echo "$search_resp" | jq -r '.hits.total.value // .hits.total // 0')
+  min_iso=$(echo "$search_resp" | jq -r '.aggregations.min_ts.value_as_string // ""')
+  max_iso=$(echo "$search_resp" | jq -r '.aggregations.max_ts.value_as_string // ""')
+
+  if [[ "$match_total" -eq 0 || -z "$min_iso" || -z "$max_iso" ]]; then
+    echo "  Aucun match dans la fenêtre initiale."
+    exit 1
+  fi
+
+  min_epoch=$(iso_to_epoch "$min_iso")
+  max_epoch=$(iso_to_epoch "$max_iso")
+  duration=$((max_epoch - min_epoch))
+
+  GTE=$(epoch_to_iso "$((min_epoch - MARGIN_SEC))")
+  LTE=$(epoch_to_iso "$((max_epoch + MARGIN_SEC))")
+
+  echo "  Matches: $match_total"
+  echo "  Plage:   $min_iso -> $max_iso (durée: ${duration}s)"
+  echo "  Étendue: $GTE -> $LTE"
+  echo ""
+fi
 
 mkdir -p "$BATCHES_DIR"
 rm -f "$BATCHES_DIR"/batch_*.ndjson "$BATCHES_DIR"/batch_*.json "$BATCHES_DIR"/batch_*.log
@@ -211,7 +307,7 @@ echo ""
 batch_file=$(printf "$BATCHES_DIR/batch_%04d.$EXT" $batch_num)
 write_batch "$response" "$batch_file"
 fetched=$hits
-echo "  Batch $batch_num: $hits docs (total: $fetched) -> $(basename "$batch_file")"
+draw_progress "$fetched" "$total" "$batch_num"
 
 # Scroll pour récupérer le reste
 while [ "$hits" -gt 0 ]; do
@@ -230,8 +326,9 @@ while [ "$hits" -gt 0 ]; do
   batch_file=$(printf "$BATCHES_DIR/batch_%04d.$EXT" $batch_num)
   write_batch "$response" "$batch_file"
   fetched=$((fetched + hits))
-  echo "  Batch $batch_num: $hits docs (total: $fetched) -> $(basename "$batch_file")"
+  draw_progress "$fetched" "$total" "$batch_num"
 done
+printf "\n"
 
 # Cleanup scroll
 curl -s -X DELETE "$ES_URL/_search/scroll" \

--- a/modules/work/work_context.zsh
+++ b/modules/work/work_context.zsh
@@ -203,6 +203,9 @@ work_status() {
     else
         _ui_section "Mise" "Non installe"
     fi
+
+    # Volet Elasticsearch (defini dans elasticsearch.zsh)
+    (( $+functions[_work_es_status_section] )) && _work_es_status_section
 }
 
 # --- Auto-initialisation au chargement ---

--- a/web/docs/superpowers/plans/2026-07-09-work-es-tooling.md
+++ b/web/docs/superpowers/plans/2026-07-09-work-es-tooling.md
@@ -1,0 +1,1213 @@
+# Outillage Elasticsearch du module work — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ajouter au module `work` 4 commandes ES génériques (`work_es_query`, `work_es_apps`, `work_es_count`, `work_es_tail`), un garde-fou volumétrique sur `work_fetch_logs` et un volet Elasticsearch dans `work_status`.
+
+**Architecture:** Tout en zsh dans `modules/work/elasticsearch.zsh` (helpers privés `_work_es_*` partagés + commandes publiques). Le script bash `fetch_es_logs.sh` reste intact ; le garde-fou vit dans le wrapper zsh. Spec : `web/docs/superpowers/specs/2026-07-09-work-es-tooling-design.md`.
+
+**Tech Stack:** zsh, curl, jq. Pas de shellspec (décision commit `8135460`) : chaque tâche se vérifie par `zsh -n` + assertions fonctionnelles hors réseau.
+
+## Global Constraints
+
+- Branche de travail : `feature/work-es-tooling` (existe déjà, spec commitée).
+- Dépendances : curl + jq uniquement. Jamais d'appel réseau pendant une complétion.
+- Ne PAS modifier : `modules/work/fetch_es_logs.sh`, `work_is_context`, le cache Nexus.
+- UI : uniquement les helpers `_ui_*` de `core/ui.zsh` (`_ui_msg_fail`, `_ui_msg_warn`, `_ui_msg_info`, `_ui_section`, `_ui_separator`, variables `$_ui_green/$_ui_red/$_ui_yellow/$_ui_bold/$_ui_nc`). Jamais de `\033[...` en dur.
+- Env : `ES_URL` puis `ZANVIL_WORK_ES_URL` (défaut `https://es-observability.prd.api.udb.azr.intranet`) ; `ES_USER`/`ES_PASSWORD` requis avant tout appel ; index `${ZANVIL_WORK_ES_INDEX:-es-apis-*}` ; `SSL_CERT_FILE` → `--cacert`.
+- Toute fonction publique `work_*` nouvelle → `modules/work/.lazy` + complétion.
+- Messages/commentaires : français sans accents dans le code (convention des fichiers du module).
+- Test hors réseau : utiliser `ES_URL=https://127.0.0.1:9` (échec immédiat, pas de hang).
+- Harness de test fonctionnel (réutilisé dans chaque tâche) :
+
+```bash
+# Depuis ~/.zanvil — charge ui + module dans un zsh propre puis exécute $ASSERT
+zsh -f -c '
+export ZANVIL_DIR=$HOME/.zanvil
+source $ZANVIL_DIR/core/ui.zsh
+source $ZANVIL_DIR/modules/work/work_context.zsh
+source $ZANVIL_DIR/modules/work/elasticsearch.zsh
+'"$ASSERT"
+```
+
+---
+
+### Task 1: Helpers ES de base (require, url, index, curl, json)
+
+**Files:**
+- Modify: `modules/work/elasticsearch.zsh` (ajouter les helpers après la déclaration de `_WORK_FETCH_LOGS_SCRIPT`, avant `work_fetch_logs`)
+
+**Interfaces:**
+- Consumes: `_ui_msg_fail` (core/ui.zsh), `ES_USER`/`ES_PASSWORD`/`SSL_CERT_FILE` (env)
+- Produces:
+  - `_work_es_url` → echo l'URL ES résolue (string, sans slash final)
+  - `_work_es_index` → echo l'index (string)
+  - `_work_es_require` → return 0 si curl+jq+creds OK, sinon message `_ui_msg_fail` + return 1
+  - `_work_es_curl METHOD PATH [BODY] [MAX_TIME]` → stdout = `HTTP_CODE\nBODY`, return = code curl
+  - `_work_es_json METHOD PATH [BODY] [MAX_TIME]` → stdout = corps seul ; return 1 si curl KO ou HTTP >= 400
+
+- [ ] **Step 1: Écrire les helpers dans `modules/work/elasticsearch.zsh`**
+
+Insérer après la ligne `_WORK_FETCH_LOGS_SCRIPT=...` :
+
+```zsh
+# --- Configuration ES (surchargeable via env.d/work.zsh) ---
+
+_work_es_url() {
+    echo "${ES_URL:-${ZANVIL_WORK_ES_URL:-https://es-observability.prd.api.udb.azr.intranet}}"
+}
+
+_work_es_index() {
+    echo "${ZANVIL_WORK_ES_INDEX:-es-apis-*}"
+}
+
+# --- Helpers internes ---
+
+# Garde commune : outils + credentials avant tout appel reseau
+_work_es_require() {
+    if ! command -v curl &>/dev/null; then
+        _ui_msg_fail "curl requis"
+        return 1
+    fi
+    if ! command -v jq &>/dev/null; then
+        _ui_msg_fail "jq requis (brew install jq / apt install jq)"
+        return 1
+    fi
+    if [[ -z "${ES_USER:-}" || -z "${ES_PASSWORD:-}" ]]; then
+        _ui_msg_fail "ES_USER/ES_PASSWORD non definis (voir env.d/work.zsh)"
+        return 1
+    fi
+    return 0
+}
+
+# Appel ES brut. Usage: _work_es_curl METHOD PATH [BODY] [MAX_TIME]
+# Sortie: 1ere ligne = code HTTP, reste = corps de reponse.
+# Return: code de sortie curl (0 = reponse recue, meme en erreur HTTP).
+_work_es_curl() {
+    local method=$1 path=$2 body="${3:-}" max_time="${4:-30}"
+    local -a opts
+    opts=(-s --connect-timeout 5 --max-time "$max_time")
+    (( max_time < 5 )) && opts[2,3]=(--connect-timeout "$max_time")
+    [[ -n "${SSL_CERT_FILE:-}" ]] && opts+=(--cacert "$SSL_CERT_FILE")
+    opts+=(-u "$ES_USER:$ES_PASSWORD" -H 'Content-Type: application/json')
+    if [[ "$method" == HEAD ]]; then
+        opts+=(-I)
+    else
+        opts+=(-X "$method")
+    fi
+    [[ -n "$body" ]] && opts+=(-d "$body")
+
+    local out ret
+    out=$(command curl "${opts[@]}" -w $'\n%{http_code}' "$(_work_es_url)/$path" 2>/dev/null)
+    ret=$?
+    (( ret != 0 )) && return $ret
+    # Reordonne: code HTTP en premiere ligne, corps ensuite
+    print -r -- "${out##*$'\n'}"
+    local resp_body="${out%$'\n'*}"
+    [[ "$resp_body" != "$out" && -n "$resp_body" ]] && print -r -- "$resp_body"
+    return 0
+}
+
+# Appel ES "JSON ou rien". Usage: _work_es_json METHOD PATH [BODY] [MAX_TIME]
+# Sortie: corps seul. Return 1 si reseau KO ou HTTP >= 400.
+_work_es_json() {
+    local out code
+    out=$(_work_es_curl "$@") || return 1
+    code="${out%%$'\n'*}"
+    [[ "$code" == <-> ]] || return 1
+    (( code >= 400 )) && return 1
+    [[ "$out" == *$'\n'* ]] && print -r -- "${out#*$'\n'}"
+    return 0
+}
+```
+
+- [ ] **Step 2: Vérifier la syntaxe**
+
+Run: `zsh -n modules/work/elasticsearch.zsh`
+Expected: aucune sortie, exit 0
+
+- [ ] **Step 3: Tests fonctionnels hors réseau**
+
+```bash
+zsh -f -c '
+export ZANVIL_DIR=$HOME/.zanvil
+source $ZANVIL_DIR/core/ui.zsh
+source $ZANVIL_DIR/modules/work/work_context.zsh
+source $ZANVIL_DIR/modules/work/elasticsearch.zsh
+# 1. resolution URL: defaut puis overrides
+[[ $(_work_es_url) == "https://es-observability.prd.api.udb.azr.intranet" ]] || { echo "FAIL url defaut"; exit 1 }
+ZANVIL_WORK_ES_URL=https://a _work_es_url | grep -qx "https://a" || { echo "FAIL url zanvil"; exit 1 }
+ES_URL=https://b ZANVIL_WORK_ES_URL=https://a _work_es_url | grep -qx "https://b" || { echo "FAIL priorite ES_URL"; exit 1 }
+[[ $(_work_es_index) == "es-apis-*" ]] || { echo "FAIL index"; exit 1 }
+# 2. garde creds
+unset ES_USER ES_PASSWORD
+_work_es_require 2>&1 | grep -q "ES_USER/ES_PASSWORD" || { echo "FAIL require"; exit 1 }
+# 3. echec reseau propre et rapide
+export ES_USER=x ES_PASSWORD=y ES_URL=https://127.0.0.1:9
+_work_es_json GET _cluster/health "" 2 && { echo "FAIL json aurait du echouer"; exit 1 }
+echo OK'
+```
+Expected: `OK` (en < 3 s)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add modules/work/elasticsearch.zsh
+git commit -m "feat(work): helpers ES partages (require, curl, json)"
+```
+
+---
+
+### Task 2: Helpers durées et dates (duplication annotée du script bash)
+
+**Files:**
+- Modify: `modules/work/elasticsearch.zsh` (après les helpers de la Task 1)
+
+**Interfaces:**
+- Consumes: rien de nouveau
+- Produces:
+  - `_work_es_parse_duration "30m"` → echo secondes (int), return 1 si format invalide
+  - `_work_es_epoch_to_iso EPOCH` → echo `YYYY-mm-ddTHH:MM:SS.000Z`
+  - `_work_es_iso_to_epoch ISO` → echo epoch (int)
+  - `_work_es_paris_to_epoch "YYYY-mm-ddTHH:MM:SS"` → echo epoch UTC (DST auto)
+  - `_work_es_window SINCE FROM TO` → return 1 + message si invalide ; sinon remplit les globales `_work_es_gte`, `_work_es_lte` (ISO UTC) et `_work_es_display` (libellé humain)
+
+- [ ] **Step 1: Écrire les helpers**
+
+Ajouter à la suite de `_work_es_json` :
+
+```zsh
+# --- Dates et durees ---
+# Duplication annotee de modules/work/fetch_es_logs.sh (bash, BASH_REMATCH) :
+# reecrit en zsh ($match). Garder les deux versions synchronisees.
+
+typeset -g _WORK_ES_DATE_FLAVOR=""
+_work_es_date_flavor() {
+    if [[ -z "$_WORK_ES_DATE_FLAVOR" ]]; then
+        if date --version &>/dev/null; then
+            _WORK_ES_DATE_FLAVOR=gnu
+        else
+            _WORK_ES_DATE_FLAVOR=bsd
+        fi
+    fi
+    echo "$_WORK_ES_DATE_FLAVOR"
+}
+
+# Xs/Xm/Xh/Xd -> secondes
+_work_es_parse_duration() {
+    local d=$1
+    if [[ "$d" =~ '^([0-9]+)([smhd])$' ]]; then
+        local num=$match[1] unit=$match[2]
+        case $unit in
+            s) echo $num ;;
+            m) echo $((num * 60)) ;;
+            h) echo $((num * 3600)) ;;
+            d) echo $((num * 86400)) ;;
+        esac
+    else
+        return 1
+    fi
+}
+
+_work_es_epoch_to_iso() {
+    local epoch=$1
+    if [[ $(_work_es_date_flavor) == gnu ]]; then
+        date -u -d "@$epoch" +"%Y-%m-%dT%H:%M:%S.000Z"
+    else
+        date -u -j -f "%s" "$epoch" +"%Y-%m-%dT%H:%M:%S.000Z"
+    fi
+}
+
+# ISO UTC ("2026-05-30T14:00:00.000Z" ou sans ms) -> epoch
+_work_es_iso_to_epoch() {
+    local ts=$1
+    if [[ $(_work_es_date_flavor) == gnu ]]; then
+        date -u -d "$ts" +%s
+    else
+        local clean="${ts%.*}"
+        clean="${clean%Z}"
+        TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%S" "$clean" +%s 2>/dev/null
+    fi
+}
+
+# Date Europe/Paris "YYYY-mm-ddTHH:MM:SS" -> epoch UTC (DST gere)
+_work_es_paris_to_epoch() {
+    local dt=$1
+    if [[ $(_work_es_date_flavor) == gnu ]]; then
+        TZ=Europe/Paris date -d "$dt" +%s
+    else
+        TZ=Europe/Paris date -j -f "%Y-%m-%dT%H:%M:%S" "$dt" +%s 2>/dev/null
+    fi
+}
+
+# Calcule la fenetre temporelle depuis --since / --from / --to.
+# Remplit les globales _work_es_gte, _work_es_lte (ISO UTC), _work_es_display.
+_work_es_window() {
+    local since="${1:-}" from="${2:-}" to="${3:-}"
+    typeset -g _work_es_gte="" _work_es_lte="" _work_es_display=""
+    if [[ -n "$since" ]]; then
+        local seconds now
+        seconds=$(_work_es_parse_duration "$since") || {
+            _ui_msg_fail "--since invalide: $since (attendu: Xs/Xm/Xh/Xd)"
+            return 1
+        }
+        now=$(date -u +%s)
+        _work_es_gte=$(_work_es_epoch_to_iso $((now - seconds)))
+        _work_es_lte=$(_work_es_epoch_to_iso $now)
+        _work_es_display="depuis $since (-> now)"
+    else
+        local from_epoch to_epoch
+        from_epoch=$(_work_es_paris_to_epoch "$from")
+        [[ "$from_epoch" == <-> ]] || {
+            _ui_msg_fail "--from invalide: $from (attendu: 2026-03-26T15:30:00)"
+            return 1
+        }
+        if [[ -n "$to" ]]; then
+            to_epoch=$(_work_es_paris_to_epoch "$to")
+            [[ "$to_epoch" == <-> ]] || {
+                _ui_msg_fail "--to invalide: $to (attendu: 2026-03-26T15:30:00)"
+                return 1
+            }
+            _work_es_display="$from -> $to (Europe/Paris)"
+        else
+            to_epoch=$(date -u +%s)
+            _work_es_display="$from -> now (Europe/Paris)"
+        fi
+        _work_es_gte=$(_work_es_epoch_to_iso $from_epoch)
+        _work_es_lte=$(_work_es_epoch_to_iso $to_epoch)
+    fi
+    return 0
+}
+```
+
+- [ ] **Step 2: Vérifier la syntaxe**
+
+Run: `zsh -n modules/work/elasticsearch.zsh`
+Expected: exit 0
+
+- [ ] **Step 3: Tests fonctionnels (aucun réseau)**
+
+```bash
+zsh -f -c '
+export ZANVIL_DIR=$HOME/.zanvil
+source $ZANVIL_DIR/core/ui.zsh
+source $ZANVIL_DIR/modules/work/work_context.zsh
+source $ZANVIL_DIR/modules/work/elasticsearch.zsh
+[[ $(_work_es_parse_duration 45s) == 45 ]] || { echo "FAIL 45s"; exit 1 }
+[[ $(_work_es_parse_duration 30m) == 1800 ]] || { echo "FAIL 30m"; exit 1 }
+[[ $(_work_es_parse_duration 2h) == 7200 ]] || { echo "FAIL 2h"; exit 1 }
+[[ $(_work_es_parse_duration 7d) == 604800 ]] || { echo "FAIL 7d"; exit 1 }
+_work_es_parse_duration 3x && { echo "FAIL 3x accepte"; exit 1 }
+# round-trip epoch <-> iso
+[[ $(_work_es_epoch_to_iso 1750000000) == "2025-06-15T15:06:40.000Z" ]] || { echo "FAIL epoch_to_iso"; exit 1 }
+[[ $(_work_es_iso_to_epoch "2025-06-15T15:06:40.000Z") == 1750000000 ]] || { echo "FAIL iso_to_epoch"; exit 1 }
+# DST: ete = UTC+2, hiver = UTC+1
+[[ $(_work_es_paris_to_epoch "2026-07-01T12:00:00") == $(_work_es_iso_to_epoch "2026-07-01T10:00:00Z") ]] || { echo "FAIL DST ete"; exit 1 }
+[[ $(_work_es_paris_to_epoch "2026-01-15T12:00:00") == $(_work_es_iso_to_epoch "2026-01-15T11:00:00Z") ]] || { echo "FAIL DST hiver"; exit 1 }
+# fenetre --since / --from / erreurs
+_work_es_window 1h "" "" || { echo "FAIL window since"; exit 1 }
+[[ -n "$_work_es_gte" && -n "$_work_es_lte" ]] || { echo "FAIL globales vides"; exit 1 }
+_work_es_window "" "2026-01-15T12:00:00" "2026-01-15T13:00:00" || { echo "FAIL window from/to"; exit 1 }
+[[ "$_work_es_gte" == "2026-01-15T11:00:00.000Z" ]] || { echo "FAIL gte hiver: $_work_es_gte"; exit 1 }
+_work_es_window bad "" "" 2>/dev/null && { echo "FAIL since invalide accepte"; exit 1 }
+_work_es_window "" garbage "" 2>/dev/null && { echo "FAIL from invalide accepte"; exit 1 }
+echo OK'
+```
+Expected: `OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add modules/work/elasticsearch.zsh
+git commit -m "feat(work): helpers dates Europe/Paris et durees (port zsh du script bash)"
+```
+
+---
+
+### Task 3: `work_es_query`
+
+**Files:**
+- Modify: `modules/work/elasticsearch.zsh` (section « Commandes publiques », avant `work_fetch_logs`)
+
+**Interfaces:**
+- Consumes: `_work_es_require`, `_work_es_curl`
+- Produces: `work_es_query [METHOD] PATH [BODY|-]` → corps sur stdout (jq pretty si TTY), return 1 si HTTP >= 400 ou réseau KO
+
+- [ ] **Step 1: Écrire la commande**
+
+```zsh
+# --- Commandes publiques ---
+
+# Requete ES generique. Usage: work_es_query [METHOD] PATH [BODY|-]
+# METHOD deduit si absent: GET sans body, POST avec body. BODY "-" = stdin.
+work_es_query() {
+    emulate -L zsh
+    _work_es_require || return 1
+
+    local method=""
+    if [[ "${1:u}" == (GET|POST|PUT|DELETE|HEAD) ]]; then
+        method="${1:u}"
+        shift
+    fi
+    local path="${1:-}" body="${2:-}"
+    if [[ -z "$path" ]]; then
+        _ui_msg_fail "usage: work_es_query [METHOD] PATH [BODY|-]"
+        return 1
+    fi
+    [[ "$body" == "-" ]] && body="$(cat)"
+    if [[ -z "$method" ]]; then
+        [[ -n "$body" ]] && method=POST || method=GET
+    fi
+
+    local out code resp
+    out=$(_work_es_curl "$method" "$path" "$body") || {
+        _ui_msg_fail "Elasticsearch injoignable: $(_work_es_url)"
+        return 1
+    }
+    code="${out%%$'\n'*}"
+    resp=""
+    [[ "$out" == *$'\n'* ]] && resp="${out#*$'\n'}"
+
+    if [[ "$code" == <-> ]] && (( code >= 400 )); then
+        _ui_msg_fail "HTTP $code"
+        [[ -n "$resp" ]] && { print -r -- "$resp" | jq . 2>/dev/null || print -r -- "$resp" }
+        return 1
+    fi
+    if [[ -t 1 && -n "$resp" ]]; then
+        print -r -- "$resp" | jq . 2>/dev/null || print -r -- "$resp"
+    elif [[ -n "$resp" ]]; then
+        print -r -- "$resp"
+    fi
+    return 0
+}
+```
+
+- [ ] **Step 2: Vérifier la syntaxe**
+
+Run: `zsh -n modules/work/elasticsearch.zsh`
+Expected: exit 0
+
+- [ ] **Step 3: Tests fonctionnels hors réseau**
+
+```bash
+zsh -f -c '
+export ZANVIL_DIR=$HOME/.zanvil
+source $ZANVIL_DIR/core/ui.zsh
+source $ZANVIL_DIR/modules/work/work_context.zsh
+source $ZANVIL_DIR/modules/work/elasticsearch.zsh
+# sans creds -> garde
+unset ES_USER ES_PASSWORD
+work_es_query _cluster/health 2>&1 | grep -q "ES_USER" || { echo "FAIL garde creds"; exit 1 }
+export ES_USER=x ES_PASSWORD=y ES_URL=https://127.0.0.1:9
+# sans PATH -> usage
+work_es_query 2>&1 | grep -q "usage:" || { echo "FAIL usage"; exit 1 }
+# reseau KO -> message clair + rc 1, rapide
+work_es_query _cluster/health 2>&1 | grep -q "injoignable" || { echo "FAIL injoignable"; exit 1 }
+work_es_query _cluster/health 2>/dev/null; [[ $? == 1 ]] || { echo "FAIL rc"; exit 1 }
+# body "-" lit stdin sans erreur de parsing d arguments
+echo "{}" | work_es_query POST "x/_search" - 2>&1 | grep -q "injoignable" || { echo "FAIL stdin"; exit 1 }
+echo OK'
+```
+Expected: `OK` (en < 5 s)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add modules/work/elasticsearch.zsh
+git commit -m "feat(work): work_es_query — wrapper curl ES generique"
+```
+
+---
+
+### Task 4: `work_es_apps` (cache + .gitignore)
+
+**Files:**
+- Modify: `modules/work/elasticsearch.zsh`
+- Modify: `.gitignore` (après la ligne 68 `.work_context_cache`)
+
+**Interfaces:**
+- Consumes: `_work_es_require`, `_work_es_json`, `_work_es_parse_duration`, `_work_es_index`
+- Produces:
+  - variable `_WORK_ES_APPS_CACHE` (chemin du cache, utilisé aussi par les complétions Task 9)
+  - `work_es_apps [RANGE] [--refresh]` → lignes `app<TAB>doc_count` triées par volume décroissant
+  - format cache : ligne 1 = epoch, ligne 2 = plage, lignes 3+ = données
+
+- [ ] **Step 1: Écrire la commande**
+
+Ajouter la variable près de `_WORK_FETCH_LOGS_SCRIPT` :
+
+```zsh
+_WORK_ES_APPS_CACHE="${ZANVIL_DIR:-$HOME/.zanvil}/.work_es_apps_cache"
+```
+
+Puis la commande après `work_es_query` :
+
+```zsh
+# Liste des applications par volume. Usage: work_es_apps [RANGE] [--refresh]
+# RANGE au format Xm/Xh/Xd (defaut 24h). Cache TTL: ZANVIL_WORK_ES_APPS_TTL (3600s).
+work_es_apps() {
+    emulate -L zsh
+    _work_es_require || return 1
+
+    local range="24h" refresh=false arg
+    for arg in "$@"; do
+        case "$arg" in
+            --refresh) refresh=true ;;
+            *)
+                if _work_es_parse_duration "$arg" >/dev/null 2>&1; then
+                    range="$arg"
+                else
+                    _ui_msg_fail "Plage invalide: $arg (attendu: Xm/Xh/Xd)"
+                    return 1
+                fi
+                ;;
+        esac
+    done
+
+    local ttl="${ZANVIL_WORK_ES_APPS_TTL:-3600}"
+    if [[ "$refresh" == false && -f "$_WORK_ES_APPS_CACHE" ]]; then
+        local cached_time cached_range age
+        cached_time=$(sed -n '1p' "$_WORK_ES_APPS_CACHE")
+        cached_range=$(sed -n '2p' "$_WORK_ES_APPS_CACHE")
+        [[ "$cached_time" == <-> ]] && age=$(( $(date +%s) - cached_time )) || age=$ttl
+        if (( age < ttl )) && [[ "$cached_range" == "$range" ]]; then
+            tail -n +3 "$_WORK_ES_APPS_CACHE"
+            return 0
+        fi
+    fi
+
+    local resp data
+    resp=$(_work_es_json POST "$(_work_es_index)/_search" '{
+      "size": 0,
+      "query": { "range": { "@timestamp": { "gte": "now-'"$range"'" }}},
+      "aggs": { "apps": { "terms": { "field": "application", "size": 500 }}}
+    }') || {
+        _ui_msg_fail "Requete ES en echec: $(_work_es_url)"
+        return 1
+    }
+    data=$(print -r -- "$resp" | jq -r '.aggregations.apps.buckets[] | "\(.key)\t\(.doc_count)"' 2>/dev/null)
+    if [[ -z "$data" ]]; then
+        _ui_msg_fail "Reponse ES sans agregation apps (index: $(_work_es_index))"
+        return 1
+    fi
+    { date +%s; echo "$range"; print -r -- "$data" } > "$_WORK_ES_APPS_CACHE"
+    print -r -- "$data"
+}
+```
+
+- [ ] **Step 2: Ajouter le cache au `.gitignore`**
+
+Après la ligne `.work_context_cache` :
+
+```
+.work_es_apps_cache
+```
+
+- [ ] **Step 3: Vérifier la syntaxe**
+
+Run: `zsh -n modules/work/elasticsearch.zsh`
+Expected: exit 0
+
+- [ ] **Step 4: Tests fonctionnels (cache fabriqué, aucun réseau)**
+
+```bash
+zsh -f -c '
+export ZANVIL_DIR=$(mktemp -d)
+source $HOME/.zanvil/core/ui.zsh
+source $HOME/.zanvil/modules/work/work_context.zsh
+source $HOME/.zanvil/modules/work/elasticsearch.zsh
+export ES_USER=x ES_PASSWORD=y ES_URL=https://127.0.0.1:9
+# plage invalide -> erreur
+work_es_apps nope 2>&1 | grep -q "Plage invalide" || { echo "FAIL plage"; exit 1 }
+# cache frais + bonne plage -> lu sans reseau
+printf "%s\n24h\napp-un\t900\napp-deux\t10\n" $(date +%s) > "$_WORK_ES_APPS_CACHE"
+[[ $(work_es_apps | head -1) == $'"'"'app-un\t900'"'"' ]] || { echo "FAIL lecture cache"; exit 1 }
+# plage differente -> cache ignore -> tentative reseau -> echec propre
+work_es_apps 7d 2>&1 | grep -q "echec" || { echo "FAIL invalidation plage"; exit 1 }
+# --refresh -> cache ignore -> echec reseau propre
+work_es_apps --refresh 2>&1 | grep -q "echec" || { echo "FAIL refresh"; exit 1 }
+# cache perime -> tentative reseau
+printf "1\n24h\nvieille-app\t1\n" > "$_WORK_ES_APPS_CACHE"
+work_es_apps 2>&1 | grep -q "echec" || { echo "FAIL TTL"; exit 1 }
+rm -rf "$ZANVIL_DIR"
+echo OK'
+```
+Expected: `OK`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add modules/work/elasticsearch.zsh .gitignore
+git commit -m "feat(work): work_es_apps — decouverte des applications avec cache TTL"
+```
+
+---
+
+### Task 5: `work_es_count` + `_work_es_count_query`
+
+**Files:**
+- Modify: `modules/work/elasticsearch.zsh`
+
+**Interfaces:**
+- Consumes: `_work_es_require`, `_work_es_json`, `_work_es_window` (globales `_work_es_gte/_work_es_lte/_work_es_display`), `_work_es_iso_to_epoch`, `_ui_section`
+- Produces:
+  - `_work_es_count_query APP GTE LTE [SEARCH]` → JSON ES brut (total + aggs min_ts/max_ts) sur stdout, return 1 si échec — **réutilisé par le garde-fou (Task 6)**
+  - `work_es_count --app APP [--since X | --from D [--to D]] [--search TEXT]` → affichage `_ui_section`
+
+- [ ] **Step 1: Écrire les fonctions**
+
+```zsh
+# Requete de comptage (size 0 + track_total_hits + aggs min/max sur @timestamp).
+# Usage: _work_es_count_query APP GTE LTE [SEARCH]. Sortie: JSON ES brut.
+_work_es_count_query() {
+    local app=$1 gte=$2 lte=$3 search="${4:-}"
+    local search_clause=""
+    if [[ -n "$search" ]]; then
+        local esc="${search//\\/\\\\}"
+        esc="${esc//\"/\\\"}"
+        search_clause=", { \"match_phrase\": { \"message\": \"$esc\" }}"
+    fi
+    _work_es_json POST "$(_work_es_index)/_search" "{
+      \"size\": 0,
+      \"track_total_hits\": true,
+      \"query\": { \"bool\": { \"must\": [
+        { \"term\": { \"application\": \"$app\" }},
+        { \"range\": { \"@timestamp\": { \"gte\": \"$gte\", \"lte\": \"$lte\" }}}$search_clause
+      ]}},
+      \"aggs\": {
+        \"min_ts\": { \"min\": { \"field\": \"@timestamp\" }},
+        \"max_ts\": { \"max\": { \"field\": \"@timestamp\" }}
+      }
+    }"
+}
+
+# Pre-vol avant export: total + fenetre reelle des matches, sans scroll ni fichier.
+# Usage: work_es_count --app APP [--since X | --from D [--to D]] [--search TEXT]
+work_es_count() {
+    emulate -L zsh
+    _work_es_require || return 1
+
+    local app="" since="" from="" to="" search=""
+    while (( $# > 0 )); do
+        case "$1" in
+            --app)    app="${2:-}";    shift 2 ;;
+            --since)  since="${2:-}";  shift 2 ;;
+            --from)   from="${2:-}";   shift 2 ;;
+            --to)     to="${2:-}";     shift 2 ;;
+            --search) search="${2:-}"; shift 2 ;;
+            *) _ui_msg_fail "Option inconnue: $1"; return 1 ;;
+        esac
+    done
+    if [[ -z "$app" ]]; then
+        _ui_msg_fail "usage: work_es_count --app APP [--since X | --from D [--to D]] [--search TEXT]"
+        return 1
+    fi
+    if [[ -n "$since" && ( -n "$from" || -n "$to" ) ]]; then
+        _ui_msg_fail "--since est incompatible avec --from/--to"
+        return 1
+    fi
+    if [[ -z "$since" && -z "$from" ]]; then
+        _ui_msg_fail "fournir --since ou --from (--to optionnel)"
+        return 1
+    fi
+    _work_es_window "$since" "$from" "$to" || return 1
+
+    local resp
+    resp=$(_work_es_count_query "$app" "$_work_es_gte" "$_work_es_lte" "$search") || {
+        _ui_msg_fail "Requete ES en echec: $(_work_es_url)"
+        return 1
+    }
+    local total min_iso max_iso
+    total=$(print -r -- "$resp" | jq -r '.hits.total.value // .hits.total // 0')
+    min_iso=$(print -r -- "$resp" | jq -r '.aggregations.min_ts.value_as_string // empty')
+    max_iso=$(print -r -- "$resp" | jq -r '.aggregations.max_ts.value_as_string // empty')
+
+    _ui_section "App" "$app"
+    [[ -n "$search" ]] && _ui_section "Recherche" "$search"
+    _ui_section "Plage" "$_work_es_display"
+    _ui_section "Total" "$total documents"
+    if [[ -n "$min_iso" && -n "$max_iso" ]]; then
+        local dur=$(( $(_work_es_iso_to_epoch "$max_iso") - $(_work_es_iso_to_epoch "$min_iso") ))
+        _ui_section "Fenetre" "$min_iso -> $max_iso"
+        _ui_section "Duree" "${dur}s"
+    fi
+    return 0
+}
+```
+
+- [ ] **Step 2: Vérifier la syntaxe**
+
+Run: `zsh -n modules/work/elasticsearch.zsh`
+Expected: exit 0
+
+- [ ] **Step 3: Tests fonctionnels hors réseau**
+
+```bash
+zsh -f -c '
+export ZANVIL_DIR=$HOME/.zanvil
+source $ZANVIL_DIR/core/ui.zsh
+source $ZANVIL_DIR/modules/work/work_context.zsh
+source $ZANVIL_DIR/modules/work/elasticsearch.zsh
+export ES_USER=x ES_PASSWORD=y ES_URL=https://127.0.0.1:9
+work_es_count 2>&1 | grep -q "usage:" || { echo "FAIL app obligatoire"; exit 1 }
+work_es_count --app a --since 1h --from x 2>&1 | grep -q "incompatible" || { echo "FAIL exclusivite"; exit 1 }
+work_es_count --app a 2>&1 | grep -q "fournir" || { echo "FAIL plage requise"; exit 1 }
+work_es_count --app a --since bad 2>&1 | grep -q -- "--since invalide" || { echo "FAIL since invalide"; exit 1 }
+work_es_count --app a --since 1h 2>&1 | grep -q "echec" || { echo "FAIL echec reseau"; exit 1 }
+echo OK'
+```
+Expected: `OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add modules/work/elasticsearch.zsh
+git commit -m "feat(work): work_es_count — comptage pre-vol sans scroll"
+```
+
+---
+
+### Task 6: Garde-fou volumétrique dans `work_fetch_logs`
+
+**Files:**
+- Modify: `modules/work/elasticsearch.zsh` (remplacer le corps de `work_fetch_logs`)
+
+**Interfaces:**
+- Consumes: `_work_es_window`, `_work_es_count_query`, `_ui_msg_warn`
+- Produces: `work_fetch_logs [--yes] <options du script>` — comportement identique, plus confirmation si total > `ZANVIL_WORK_ES_MAX_DOCS` (défaut 100000). Fail-open si le comptage échoue. `fetch_es_logs.sh` n'est PAS modifié.
+
+- [ ] **Step 1: Remplacer `work_fetch_logs`**
+
+Le corps actuel (vérification script exécutable + creds + délégation) devient :
+
+```zsh
+work_fetch_logs() {
+    emulate -L zsh
+    if [[ ! -x "$_WORK_FETCH_LOGS_SCRIPT" ]]; then
+        _ui_msg_fail "Script introuvable ou non executable: $_WORK_FETCH_LOGS_SCRIPT"
+        return 1
+    fi
+    if [[ -z "${ES_USER:-}" || -z "${ES_PASSWORD:-}" ]]; then
+        _ui_msg_fail "ES_USER/ES_PASSWORD non definis (voir env.d/work.zsh)"
+        return 1
+    fi
+
+    # Extraction de --yes + capture des options utiles au comptage.
+    # Tout le reste part tel quel au script (qui fait sa propre validation).
+    local -a pass_args
+    local skip_guard=false app="" since="" from="" to="" search=""
+    while (( $# > 0 )); do
+        case "$1" in
+            --yes) skip_guard=true; shift ;;
+            --app|--since|--from|--to|--search|--margin|--target-dir|--format)
+                case "$1" in
+                    --app)    app="${2:-}" ;;
+                    --since)  since="${2:-}" ;;
+                    --from)   from="${2:-}" ;;
+                    --to)     to="${2:-}" ;;
+                    --search) search="${2:-}" ;;
+                esac
+                pass_args+=("$1" "${2:-}")
+                if (( $# >= 2 )); then shift 2; else shift; fi
+                ;;
+            *) pass_args+=("$1"); shift ;;
+        esac
+    done
+
+    # Garde-fou volumetrique (fail-open: ne bloque jamais plus que le script)
+    if [[ "$skip_guard" == false && -n "$app" ]] && [[ -n "$since" || -n "$from" ]] \
+        && command -v jq &>/dev/null; then
+        local max_docs="${ZANVIL_WORK_ES_MAX_DOCS:-100000}"
+        local total=""
+        if _work_es_window "$since" "$from" "$to" 2>/dev/null; then
+            local resp
+            resp=$(_work_es_count_query "$app" "$_work_es_gte" "$_work_es_lte" "$search" 2>/dev/null) \
+                && total=$(print -r -- "$resp" | jq -r '.hits.total.value // .hits.total // empty' 2>/dev/null)
+        fi
+        if [[ "$total" == <-> ]] && (( total > max_docs )); then
+            _ui_msg_warn "Volume estime: $total documents (seuil: $max_docs)"
+            if ! read -q "?Continuer l'export ? [y/N] "; then
+                echo ""
+                return 1
+            fi
+            echo ""
+        elif [[ ! "$total" == <-> ]]; then
+            _ui_msg_warn "Comptage prealable impossible — export lance sans garde-fou (--yes pour passer ce controle)"
+        fi
+    fi
+
+    "$_WORK_FETCH_LOGS_SCRIPT" "${pass_args[@]}"
+}
+```
+
+- [ ] **Step 2: Vérifier la syntaxe**
+
+Run: `zsh -n modules/work/elasticsearch.zsh`
+Expected: exit 0
+
+- [ ] **Step 3: Tests fonctionnels hors réseau**
+
+```bash
+zsh -f -c '
+export ZANVIL_DIR=$HOME/.zanvil
+source $ZANVIL_DIR/core/ui.zsh
+source $ZANVIL_DIR/modules/work/work_context.zsh
+source $ZANVIL_DIR/modules/work/elasticsearch.zsh
+export ES_USER=x ES_PASSWORD=y ES_URL=https://127.0.0.1:9
+# --help passe au script sans garde (pas de --app) et rend son usage
+work_fetch_logs --help | grep -q -- "--search" || { echo "FAIL help"; exit 1 }
+# comptage KO -> fail-open: warning puis le script prend la main (erreur reseau du script attendue)
+out=$(work_fetch_logs --app a --since 1h 2>&1)
+echo "$out" | grep -q "Comptage prealable impossible" || { echo "FAIL fail-open"; exit 1 }
+# --yes saute le comptage: aucun warning de comptage
+out=$(work_fetch_logs --yes --app a --since 1h 2>&1)
+echo "$out" | grep -q "Comptage prealable" && { echo "FAIL --yes"; exit 1 }
+# --yes n est PAS transmis au script (sinon "Option inconnue")
+echo "$out" | grep -q "Option inconnue" && { echo "FAIL --yes transmis"; exit 1 }
+echo OK'
+```
+Expected: `OK`
+
+Note : le déclenchement réel de la confirmation (total > seuil) n'est testable qu'en contexte work — à faire manuellement avec `ZANVIL_WORK_ES_MAX_DOCS=1 work_fetch_logs --app <app> --since 5m`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add modules/work/elasticsearch.zsh
+git commit -m "feat(work): garde-fou volumetrique dans work_fetch_logs (--yes)"
+```
+
+---
+
+### Task 7: Volet Elasticsearch dans `work_status`
+
+**Files:**
+- Modify: `modules/work/elasticsearch.zsh` (fonction `_work_es_status_section`)
+- Modify: `modules/work/work_context.zsh` (fin de `work_status`, après la section Modules, ligne ~205)
+
+**Interfaces:**
+- Consumes: `work_is_context` (work_context.zsh), `_work_es_json`, `_ui_section`, `_ui_separator`, `$_ui_bold/$_ui_green/$_ui_yellow/$_ui_red/$_ui_nc`
+- Produces: `_work_es_status_section` → bloc d'affichage, toujours return 0 (jamais bloquant)
+
+- [ ] **Step 1: Écrire la section dans `elasticsearch.zsh`**
+
+```zsh
+# Volet Elasticsearch de work_status. Toujours non bloquant:
+# hors contexte work -> "hors reseau", echec requete -> "injoignable"/"n/a".
+_work_es_status_section() {
+    echo ""
+    echo -e "${_ui_bold}Elasticsearch${_ui_nc}"
+    _ui_separator 44
+
+    if ! work_is_context; then
+        _ui_section "Statut" "${_ui_yellow}hors reseau${_ui_nc}"
+        return 0
+    fi
+
+    if [[ -n "${ES_USER:-}" && -n "${ES_PASSWORD:-}" ]]; then
+        _ui_section "Credentials" "${_ui_green}definis${_ui_nc}"
+    else
+        _ui_section "Credentials" "${_ui_red}absents (env.d/work.zsh)${_ui_nc}"
+        return 0
+    fi
+    if ! command -v jq &>/dev/null; then
+        _ui_section "Cluster" "${_ui_yellow}jq absent${_ui_nc}"
+        return 0
+    fi
+
+    local health status
+    health=$(_work_es_json GET "_cluster/health" "" 2)
+    if [[ -n "$health" ]]; then
+        status=$(print -r -- "$health" | jq -r '.status // "inconnu"')
+        case "$status" in
+            green)  _ui_section "Cluster" "${_ui_green}green${_ui_nc}" ;;
+            yellow) _ui_section "Cluster" "${_ui_yellow}yellow${_ui_nc}" ;;
+            red)    _ui_section "Cluster" "${_ui_red}red${_ui_nc}" ;;
+            *)      _ui_section "Cluster" "$status" ;;
+        esac
+    else
+        _ui_section "Cluster" "${_ui_red}injoignable${_ui_nc}"
+        return 0
+    fi
+
+    local resp oldest
+    resp=$(_work_es_json POST "$(_work_es_index)/_search" \
+        '{"size":0,"aggs":{"oldest":{"min":{"field":"@timestamp"}}}}' 5)
+    oldest=$(print -r -- "$resp" | jq -r '.aggregations.oldest.value_as_string // empty' 2>/dev/null)
+    _ui_section "Retention" "${oldest:-n/a}"
+    return 0
+}
+```
+
+- [ ] **Step 2: Brancher dans `work_status` (work_context.zsh)**
+
+À la fin de `work_status`, après la ligne `_ui_section "Mise" "Non installe"` et son `fi` :
+
+```zsh
+    # Volet Elasticsearch (defini dans elasticsearch.zsh)
+    (( $+functions[_work_es_status_section] )) && _work_es_status_section
+```
+
+- [ ] **Step 3: Vérifier la syntaxe**
+
+Run: `zsh -n modules/work/elasticsearch.zsh && zsh -n modules/work/work_context.zsh`
+Expected: exit 0
+
+- [ ] **Step 4: Test fonctionnel hors réseau (dégradation silencieuse)**
+
+```bash
+zsh -f -c '
+export ZANVIL_DIR=$(mktemp -d)
+source $HOME/.zanvil/core/ui.zsh
+source $HOME/.zanvil/modules/work/work_context.zsh
+source $HOME/.zanvil/modules/work/elasticsearch.zsh
+# hors contexte (pas de nexus URL) -> "hors reseau", rc 0, pas de hang
+out=$(_work_es_status_section) || { echo "FAIL rc"; exit 1 }
+echo "$out" | grep -q "hors reseau" || { echo "FAIL hors reseau"; exit 1 }
+# work_status complet ne plante pas et contient le volet
+work_status | grep -q "Elasticsearch" || { echo "FAIL work_status"; exit 1 }
+rm -rf "$ZANVIL_DIR"
+echo OK'
+```
+Expected: `OK` (< 5 s)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add modules/work/elasticsearch.zsh modules/work/work_context.zsh
+git commit -m "feat(work): volet Elasticsearch dans work_status"
+```
+
+---
+
+### Task 8: `work_es_tail`
+
+**Files:**
+- Modify: `modules/work/elasticsearch.zsh`
+
+**Interfaces:**
+- Consumes: `_work_es_require`, `_work_es_json`, `_work_es_index`, `_ui_msg_info`, `_ui_msg_warn`
+- Produces: `work_es_tail --app APP [--search TEXT] [--interval N]` — boucle infinie (Ctrl-C pour sortir), aucun fichier temporaire
+
+- [ ] **Step 1: Écrire la commande**
+
+```zsh
+# Suivi quasi temps reel. Usage: work_es_tail --app APP [--search TEXT] [--interval N]
+# Poll toutes les N secondes (defaut 5, min 2) via search_after sur @timestamp asc.
+# Aucun fichier temporaire: Ctrl-C interrompt proprement la boucle.
+work_es_tail() {
+    emulate -L zsh
+    _work_es_require || return 1
+
+    local app="" search="" interval=5
+    while (( $# > 0 )); do
+        case "$1" in
+            --app)      app="${2:-}";      shift 2 ;;
+            --search)   search="${2:-}";   shift 2 ;;
+            --interval) interval="${2:-}"; shift 2 ;;
+            *) _ui_msg_fail "Option inconnue: $1"; return 1 ;;
+        esac
+    done
+    if [[ -z "$app" ]]; then
+        _ui_msg_fail "usage: work_es_tail --app APP [--search TEXT] [--interval N]"
+        return 1
+    fi
+    if [[ ! "$interval" == <-> ]]; then
+        _ui_msg_fail "--interval doit etre un entier (secondes)"
+        return 1
+    fi
+    (( interval < 2 )) && interval=2
+
+    local search_clause=""
+    if [[ -n "$search" ]]; then
+        local esc="${search//\\/\\\\}"
+        esc="${esc//\"/\\\"}"
+        search_clause=", { \"match_phrase\": { \"message\": \"$esc\" }}"
+    fi
+
+    # Demarrage a now-1m (sort value = epoch millis)
+    local last_sort=$(( ($(date -u +%s) - 60) * 1000 ))
+    _ui_msg_info "Tail de $app — interval ${interval}s, Ctrl-C pour quitter"
+
+    local resp count width
+    while true; do
+        resp=$(_work_es_json POST "$(_work_es_index)/_search" "{
+          \"size\": 1000,
+          \"sort\": [{\"@timestamp\": \"asc\"}],
+          \"search_after\": [$last_sort],
+          \"query\": { \"bool\": { \"must\": [
+            { \"term\": { \"application\": \"$app\" }}$search_clause
+          ]}}
+        }" "$interval") || {
+            _ui_msg_warn "ES injoignable — nouvel essai dans ${interval}s"
+            sleep "$interval"
+            continue
+        }
+
+        count=$(print -r -- "$resp" | jq -r '.hits.hits | length' 2>/dev/null)
+        if [[ "$count" == <-> ]] && (( count > 0 )); then
+            width=${COLUMNS:-120}
+            print -r -- "$resp" | jq -r '.hits.hits[]._source
+                | "\(.["@timestamp"] // "" | .[11:19]) [\(.level // "-")] \(.message // "" | gsub("[\r\n]+"; " "))"' \
+                2>/dev/null | cut -c1-$width
+            last_sort=$(print -r -- "$resp" | jq -r '.hits.hits[-1].sort[0]')
+            if (( count >= 1000 )); then
+                _ui_msg_warn "Filtre trop large (>= 1000 docs/iteration) — saut a now"
+                last_sort=$(( $(date -u +%s) * 1000 ))
+            fi
+        fi
+        sleep "$interval"
+    done
+}
+```
+
+- [ ] **Step 2: Vérifier la syntaxe**
+
+Run: `zsh -n modules/work/elasticsearch.zsh`
+Expected: exit 0
+
+- [ ] **Step 3: Tests fonctionnels hors réseau (validation d'arguments + boucle bornée)**
+
+```bash
+zsh -f -c '
+export ZANVIL_DIR=$HOME/.zanvil
+source $ZANVIL_DIR/core/ui.zsh
+source $ZANVIL_DIR/modules/work/work_context.zsh
+source $ZANVIL_DIR/modules/work/elasticsearch.zsh
+export ES_USER=x ES_PASSWORD=y ES_URL=https://127.0.0.1:9
+work_es_tail 2>&1 | grep -q "usage:" || { echo "FAIL app obligatoire"; exit 1 }
+work_es_tail --app a --interval abc 2>&1 | grep -q "entier" || { echo "FAIL interval"; exit 1 }
+echo OK'
+# La boucle elle-meme: lancer 7s puis tuer — doit afficher des retries, pas de stacktrace
+zsh -f -c '
+export ZANVIL_DIR=$HOME/.zanvil
+source $ZANVIL_DIR/core/ui.zsh
+source $ZANVIL_DIR/modules/work/work_context.zsh
+source $ZANVIL_DIR/modules/work/elasticsearch.zsh
+export ES_USER=x ES_PASSWORD=y ES_URL=https://127.0.0.1:9
+work_es_tail --app a --interval 2' > /tmp/work-es-tail-test.log 2>&1 &
+TAIL_PID=$!
+sleep 7
+kill $TAIL_PID 2>/dev/null
+head -5 /tmp/work-es-tail-test.log
+rm -f /tmp/work-es-tail-test.log
+```
+Expected: premier bloc `OK` ; le log du second bloc affiche `Tail de a` puis des lignes `ES injoignable — nouvel essai dans 2s`, sans erreur zsh brute.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add modules/work/elasticsearch.zsh
+git commit -m "feat(work): work_es_tail — suivi quasi temps reel par search_after"
+```
+
+---
+
+### Task 9: Complétions, `.lazy`, exemple env.d
+
+**Files:**
+- Modify: `modules/work/completions.zsh`
+- Modify: `modules/work/.lazy`
+- Modify: `examples/env.d/work.zsh`
+
+**Interfaces:**
+- Consumes: format du cache apps (Task 4 : lignes 3+ = `app<TAB>count`)
+- Produces: complétions `work_es_query`, `work_es_apps`, `work_es_count`, `work_es_tail` ; `--app` dynamique + `--yes` sur `work_fetch_logs`
+
+- [ ] **Step 1: Réécrire `modules/work/completions.zsh`**
+
+Contenu complet du fichier :
+
+```zsh
+# ==============================================================================
+# Work Completions
+# ==============================================================================
+
+(( $+functions[compdef] )) || return 0
+
+# Applications depuis le cache de work_es_apps — lecture fichier uniquement,
+# JAMAIS d'appel reseau pendant la completion. Cache perime accepte.
+_work_es_cached_apps() {
+    local cache="${ZANVIL_DIR:-$HOME/.zanvil}/.work_es_apps_cache"
+    if [[ -f "$cache" ]]; then
+        local -a apps
+        apps=(${(f)"$(tail -n +3 "$cache" 2>/dev/null | cut -f1)"})
+        if (( ${#apps} )); then
+            _describe -t applications 'application' apps
+            return
+        fi
+    fi
+    _message 'application (lancer work_es_apps pour alimenter la completion)'
+}
+
+_work_fetch_logs() {
+    _arguments \
+        '--app[Application a interroger]:app:_work_es_cached_apps' \
+        '--since[Plage relative: Xs/Xm/Xh/Xd (ex: 30s, 2h, 7d)]:duration:' \
+        '--from[Debut, heure locale Europe/Paris avec DST auto (YYYY-mm-ddTHH:MM:SS)]:date:' \
+        '--to[Fin, heure locale Europe/Paris avec DST auto (YYYY-mm-ddTHH:MM:SS)]:date:' \
+        '--search[Recherche TEXT dans .message, restreint la fenetre aux matches]:text:' \
+        '--margin[Padding autour des matches --search (defaut: 1m)]:duration:' \
+        '--target-dir[Repertoire de sortie]:directory:_directories' \
+        '--format[Format de sortie]:format:(ndjson json text)' \
+        '--yes[Passer le garde-fou volumetrique]' \
+        '(-h --help)'{-h,--help}'[Afficher l aide]'
+}
+compdef _work_fetch_logs work_fetch_logs
+
+_work_es_query() {
+    _arguments \
+        '1:methode ou chemin:(GET POST PUT DELETE HEAD)' \
+        '2:chemin ES (ex es-apis-*/_search):' \
+        '3:body JSON ou - pour stdin:'
+}
+compdef _work_es_query work_es_query
+
+_work_es_apps() {
+    _arguments \
+        '--refresh[Forcer le rafraichissement du cache]' \
+        '1:plage Xm/Xh/Xd (defaut 24h):(1h 6h 24h 7d)'
+}
+compdef _work_es_apps work_es_apps
+
+_work_es_count() {
+    _arguments \
+        '--app[Application a interroger]:app:_work_es_cached_apps' \
+        '--since[Plage relative: Xs/Xm/Xh/Xd]:duration:' \
+        '--from[Debut, heure locale Europe/Paris avec DST auto]:date:' \
+        '--to[Fin, heure locale Europe/Paris avec DST auto]:date:' \
+        '--search[Phrase a chercher dans .message]:text:'
+}
+compdef _work_es_count work_es_count
+
+_work_es_tail() {
+    _arguments \
+        '--app[Application a suivre]:app:_work_es_cached_apps' \
+        '--search[Phrase a chercher dans .message]:text:' \
+        '--interval[Intervalle de poll en secondes (defaut 5, min 2)]:secondes:(2 5 10 30)'
+}
+compdef _work_es_tail work_es_tail
+```
+
+- [ ] **Step 2: Mettre à jour `modules/work/.lazy`**
+
+Ajouter à la fin (contenu final du fichier) :
+
+```
+work_is_context
+work_refresh
+work_init
+work_status
+work_fetch_logs
+work_es_query
+work_es_apps
+work_es_count
+work_es_tail
+```
+
+- [ ] **Step 3: Documenter les variables dans `examples/env.d/work.zsh`**
+
+Remplacer le bloc « Elasticsearch observability » par :
+
+```zsh
+# Elasticsearch observability (work_fetch_logs, work_es_query/apps/count/tail)
+export ZANVIL_WORK_ES_URL="${ZANVIL_WORK_ES_URL:-}"
+export ZANVIL_WORK_ES_INDEX="${ZANVIL_WORK_ES_INDEX:-es-apis-*}"
+export ZANVIL_WORK_ES_APPS_TTL="${ZANVIL_WORK_ES_APPS_TTL:-3600}"   # TTL cache work_es_apps (s)
+export ZANVIL_WORK_ES_MAX_DOCS="${ZANVIL_WORK_ES_MAX_DOCS:-100000}" # seuil garde-fou work_fetch_logs
+export ES_USER="${ES_USER:-}"
+# ES_PASSWORD a definir dans ~/.secrets ou via SOPS, jamais ici en clair
+# export ES_PASSWORD=""
+```
+
+- [ ] **Step 4: Vérifier syntaxe + chargement complétions**
+
+```bash
+zsh -n modules/work/completions.zsh && zsh -n examples/env.d/work.zsh
+zsh -f -c '
+export ZANVIL_DIR=$HOME/.zanvil
+autoload -Uz compinit && compinit -C -d /tmp/zcompdump-test-$$
+source $ZANVIL_DIR/modules/work/completions.zsh || { echo "ERREUR chargement"; exit 1 }
+for f in _work_fetch_logs _work_es_query _work_es_apps _work_es_count _work_es_tail _work_es_cached_apps; do
+    (( $+functions[$f] )) || { echo "FAIL $f absent"; exit 1 }
+done
+for c in work_fetch_logs work_es_query work_es_apps work_es_count work_es_tail; do
+    [[ -n "$_comps[$c]" ]] || { echo "FAIL compdef $c"; exit 1 }
+done
+rm -f /tmp/zcompdump-test-$$
+echo OK'
+```
+Expected: `OK`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add modules/work/completions.zsh modules/work/.lazy examples/env.d/work.zsh
+git commit -m "feat(work): completions ES + lazy loading + variables documentees"
+```
+
+---
+
+### Task 10: Vérification finale intégrée
+
+**Files:** aucun nouveau — validation de l'ensemble.
+
+- [ ] **Step 1: Syntaxe de tous les fichiers modifiés**
+
+```bash
+for f in modules/work/elasticsearch.zsh modules/work/work_context.zsh \
+         modules/work/completions.zsh examples/env.d/work.zsh; do
+    zsh -n "$f" || echo "FAIL $f"
+done
+```
+Expected: aucune sortie
+
+- [ ] **Step 2: `.lazy` — les 4 nouvelles fonctions, rien d'autre**
+
+```bash
+diff <(sort modules/work/.lazy) <(printf '%s\n' work_is_context work_refresh work_init work_status work_fetch_logs work_es_query work_es_apps work_es_count work_es_tail | sort)
+```
+Expected: aucune différence
+
+- [ ] **Step 3: Chargement complet du module en zsh propre (via init.zsh comme le loader)**
+
+```bash
+zsh -f -c '
+export ZANVIL_DIR=$HOME/.zanvil
+source $ZANVIL_DIR/core/ui.zsh
+source $ZANVIL_DIR/modules/work/init.zsh
+for fn in work_es_query work_es_apps work_es_count work_es_tail work_fetch_logs; do
+    (( $+functions[$fn] )) || { echo "FAIL $fn non defini"; exit 1 }
+done
+echo OK'
+```
+Expected: `OK`
+
+- [ ] **Step 4: Hors réseau — aucune commande ne hang**
+
+```bash
+time zsh -f -c '
+export ZANVIL_DIR=$HOME/.zanvil
+source $ZANVIL_DIR/core/ui.zsh
+source $ZANVIL_DIR/modules/work/work_context.zsh
+source $ZANVIL_DIR/modules/work/elasticsearch.zsh
+export ES_USER=x ES_PASSWORD=y ES_URL=https://127.0.0.1:9
+work_es_query _cluster/health >/dev/null 2>&1
+work_es_apps --refresh >/dev/null 2>&1
+work_es_count --app a --since 1h >/dev/null 2>&1
+_work_es_status_section >/dev/null 2>&1
+exit 0'
+```
+Expected: total < 10 s, aucun message d'erreur zsh brut
+
+- [ ] **Step 5: Marquer le spec comme implémenté et commit final**
+
+Dans `web/docs/superpowers/specs/2026-07-09-work-es-tooling-design.md`, remplacer
+`**Statut** : Validé (en attente d'implémentation)` par `**Statut** : Implémenté`.
+
+```bash
+git add -f web/docs/superpowers/specs/2026-07-09-work-es-tooling-design.md
+git commit -m "docs(specs): work-es-tooling implemente"
+```
+
+**Rappel pour le résumé final :** les tests réseau réels (agrégation apps, comptage, tail, volet status en green) ne sont possibles qu'en contexte work — à valider manuellement : `work_es_apps`, `work_es_count --app <app> --since 1h`, `work_es_tail --app <app>`, `work_status`, et le garde-fou avec `ZANVIL_WORK_ES_MAX_DOCS=1`.

--- a/web/docs/superpowers/specs/2026-07-09-work-es-tooling-design.md
+++ b/web/docs/superpowers/specs/2026-07-09-work-es-tooling-design.md
@@ -1,0 +1,141 @@
+# Module work — Outillage Elasticsearch générique — Design
+
+**Date** : 2026-07-09
+**Statut** : Validé (en attente d'implémentation)
+**Release cible** : minor
+
+## Contexte
+
+Le module `work` n'expose qu'une commande ES : `work_fetch_logs` (wrapper de
+`fetch_es_logs.sh`, export par scroll). Lors des investigations sur l'ES d'observabilité,
+tout le reste (requêtes ad hoc, comptages, découverte des applications) se fait en curl
+manuel. Ce projet ajoute un outillage ES **générique** au module : 4 nouvelles
+commandes (`work_es_query`, `work_es_apps`, `work_es_count`, `work_es_tail`),
+un garde-fou sur `work_fetch_logs` et un volet Elasticsearch dans `work_status`.
+
+**Périmètre strict** : ergonomie d'accès ES uniquement. Aucune logique métier
+d'investigation (saleId, détecteurs, baselines) — ça vivra dans le futur projet
+`analysis-tools`.
+
+## Décisions structurantes
+
+1. **Tout en zsh** — le CLI Rust n'a pas de client HTTP (il shell-out vers git/fzf),
+   et le pattern de délégation du projet exige un fallback zsh complet : déporter
+   doublerait l'implémentation sans gain (les commandes sont network-bound).
+   Le vrai gain Rust (export massif, tail keep-alive) appartient à `analysis-tools`.
+2. **Un seul fichier** : tout dans `modules/work/elasticsearch.zsh` (helpers privés +
+   5 commandes publiques + wrapper). Cohésion thématique, pattern du module.
+3. **Pas de tests shellspec** — la suite (229 specs) a été délibérément supprimée
+   (commit `8135460`) : « tests will be rebuilt in the Rust CLI ». Vérifications :
+   `zsh -n`, chargement des complétions, comportement hors réseau.
+4. **`fetch_es_logs.sh` intact** — source de vérité externe (`~/work/misc/analysis-tools`
+   à terme), resynchronisé récemment. Le garde-fou vit dans le wrapper zsh.
+5. **Parsing dates dupliqué, pas factorisé** — le script est bash (`BASH_REMATCH`),
+   le module est zsh (`$match`) : duplication propre annotée d'un commentaire
+   pointant la source.
+
+## Configuration (env)
+
+| Variable | Défaut | Rôle |
+|---|---|---|
+| `ES_URL` puis `ZANVIL_WORK_ES_URL` | `https://es-observability.prd.api.udb.azr.intranet` | URL ES (ordre de résolution) |
+| `ES_USER` / `ES_PASSWORD` | — | credentials (env.d/work.zsh), requis avant tout appel |
+| `ZANVIL_WORK_ES_INDEX` | `es-apis-*` | index par défaut |
+| `ZANVIL_WORK_ES_APPS_TTL` | `3600` | TTL cache work_es_apps (s) |
+| `ZANVIL_WORK_ES_MAX_DOCS` | `100000` | seuil du garde-fou work_fetch_logs |
+
+`SSL_CERT_FILE` → `--cacert` (pattern `_work_test_nexus`).
+
+## Helpers privés (elasticsearch.zsh)
+
+- `_work_es_url` / `_work_es_index` : résolution config ci-dessus ;
+- `_work_es_require` : garde `ES_USER`/`ES_PASSWORD` + `jq` + `curl`,
+  messages `_ui_msg_fail`, return 1 ;
+- `_work_es_curl` : curl -s, auth, `Content-Type: application/json`,
+  `--cacert` si `SSL_CERT_FILE`, timeouts ;
+- `_work_es_parse_duration` : `Xs/Xm/Xh/Xd` → secondes (zsh `$match`) ;
+- `_work_es_paris_to_epoch` / `_work_es_epoch_to_iso` : dates Europe/Paris DST auto,
+  GNU/BSD date (duplication annotée de fetch_es_logs.sh).
+
+## Commandes
+
+### 1. `work_es_query [METHOD] PATH [BODY]`
+- METHOD optionnel (détecté si 1er arg ∈ GET/POST/PUT/DELETE/HEAD) ;
+  défaut GET sans body, POST si BODY fourni ;
+- PATH relatif à l'URL ES (ex : `es-apis-*/_search`, `_cluster/health`) ;
+- BODY : JSON inline ou `-` = stdin (heredocs) ;
+- sortie : `jq .` si stdout TTY, brute sinon (pipe-friendly) ;
+- HTTP ≥ 400 → corps d'erreur ES affiché, return 1.
+
+### 2. `work_es_apps [RANGE] [--refresh]`
+- terms agg sur `application` (size 500), plage en date-math ES (`now-24h` défaut,
+  RANGE au format Xm/Xh/Xd) ;
+- sortie : `app<TAB>doc_count`, tri volume décroissant ;
+- cache `$ZANVIL_DIR/.work_es_apps_cache` (gitignored) : ligne 1 timestamp,
+  ligne 2 plage, puis données ; valide si TTL ok **et** plage identique ;
+  `--refresh` force.
+
+### 3. `work_es_count --app APP [--since X | --from D [--to D]] [--search TEXT]`
+- mêmes options et exclusivités que fetch_es_logs.sh (dates Europe/Paris DST) ;
+- scindé : `_work_es_count_query` (JSON brut total/min/max, réutilisé par le
+  garde-fou) + `work_es_count` (formatage `_ui_section` : total, fenêtre min→max, durée) ;
+- `size: 0` + `track_total_hits` + aggs min/max ; jamais de scroll, aucun fichier.
+
+### 4. Garde-fou dans `work_fetch_logs` (wrapper uniquement)
+- extrait `--yes` des args avant délégation ;
+- sans `--yes` : comptage via `_work_es_count_query` ; si total >
+  `ZANVIL_WORK_ES_MAX_DOCS` → `read -q` de confirmation ;
+- **fail-open** : comptage en échec (réseau) → warning + délégation directe,
+  le garde-fou ne bloque jamais plus que le script.
+
+### 5. Volet Elasticsearch dans `work_status`
+- `_work_es_status_section` définie dans elasticsearch.zsh, appelée par **une ligne**
+  ajoutée dans work_context.zsh (détection de contexte intouchée) ;
+- hors contexte work → « hors réseau », aucune requête ;
+- sinon : creds définis/absents (jamais les valeurs), ping `_cluster/health`
+  timeout 2s (green/yellow/red coloré, « injoignable » sinon), rétention =
+  agg min `@timestamp` (« n/a » si échec, non bloquant).
+
+### 6. `work_es_tail --app APP [--search TEXT] [--interval N]`
+- poll toutes les N s (défaut 5, min 2), démarrage `now-1m` ;
+- tri `@timestamp` asc + `search_after` sur le sort value du dernier hit ;
+- affichage : `HH:MM:SS [level] message` tronqué à `$COLUMNS` ;
+- > 1000 docs par itération → `_ui_msg_warn` « filtre trop large » + saut à now ;
+- aucun fichier temporaire → Ctrl-C propre par nature.
+
+## Complétions (completions.zsh)
+
+- une fonction `_work_es_*` + `compdef` par commande publique ;
+- `--app` complété depuis le cache apps (lecture fichier seule, **jamais d'appel
+  réseau pendant la complétion**, cache périmé accepté), fallback complétion libre ;
+- `--yes` ajouté à `_work_fetch_logs`.
+
+## Fichiers touchés
+
+| Fichier | Changement |
+|---|---|
+| `modules/work/elasticsearch.zsh` | helpers + 4 nouvelles commandes + garde-fou + section status |
+| `modules/work/completions.zsh` | 4 nouvelles complétions + `--yes` + `--app` dynamique |
+| `modules/work/work_context.zsh` | 1 ligne : appel `_work_es_status_section` dans `work_status` |
+| `modules/work/.lazy` | + `work_es_query`, `work_es_apps`, `work_es_count`, `work_es_tail` |
+| `.gitignore` | + `.work_es_apps_cache` |
+| `examples/env.d/work.zsh` | documenter les nouvelles variables `ZANVIL_WORK_ES_*` |
+
+## Vérifications avant de conclure
+
+- `zsh -n` sur chaque fichier modifié ;
+- `.lazy` : les 4 nouvelles fonctions publiques, rien d'autre ;
+- complétions chargées sans erreur en shell propre ; `work_fetch_logs --app <TAB>`
+  complète depuis le cache si présent ;
+- hors réseau : chaque commande échoue proprement (message clair, pas de hang
+  au-delà des timeouts) ;
+- test réel contre l'ES : **manuel, en contexte work uniquement** (à signaler
+  dans le résumé final).
+
+## Hors périmètre
+
+- `fetch_es_logs.sh` (source de vérité externe) ;
+- logique métier d'investigation (saleId, sentinelles, timelines, détecteurs) ;
+- dépendances au-delà de curl + jq ;
+- détection de contexte (`work_is_context`, cache Nexus) ;
+- CLI Rust (tail/export haute perf → futur `analysis-tools`).

--- a/web/docs/superpowers/specs/2026-07-09-work-es-tooling-design.md
+++ b/web/docs/superpowers/specs/2026-07-09-work-es-tooling-design.md
@@ -1,7 +1,7 @@
 # Module work — Outillage Elasticsearch générique — Design
 
 **Date** : 2026-07-09
-**Statut** : Validé (en attente d'implémentation)
+**Statut** : Implémenté
 **Release cible** : minor
 
 ## Contexte

--- a/web/docs/superpowers/specs/2026-07-27-gclone-workdir-design.md
+++ b/web/docs/superpowers/specs/2026-07-27-gclone-workdir-design.md
@@ -1,0 +1,153 @@
+# gclone — clone d'un groupe GitLab depuis WORK_DIR
+
+**Date** : 2026-07-27
+**Statut** : design validé
+**Module** : `modules/gitlab/`
+
+## Problème
+
+`scripts/clone-projects.sh` clone les projets d'un groupe GitLab dans le répertoire
+courant. L'utilisateur doit donc penser à se placer dans `$WORK_DIR` avant de le
+lancer, sous peine de disséminer des dépôts un peu partout.
+
+Les alias générés `gc-<composant>-<env>` contournent le problème avec
+`cd $WORK_DIR && clone-projects.sh $id $GITLAB_TOKEN`, mais cette forme a trois
+défauts :
+
+1. Le token GitLab est inscrit en clair dans la définition de l'alias, visible via
+   `alias` ou `alias gc-frontco-ptf`.
+2. Le `cd` s'arrête à `$WORK_DIR` : après un clone, l'utilisateur doit encore
+   descendre à la main dans l'arborescence du groupe.
+3. La logique est dupliquée dans chaque alias généré, sans validation des
+   préconditions (token absent, `WORK_DIR` non défini, script introuvable).
+
+## Solution
+
+Une fonction zsh `gclone` qui encapsule le déplacement, l'appel au script et le
+positionnement final du shell. Les alias `gc-*` deviennent de simples délégations.
+
+## Interface
+
+```
+gclone <clé|group-id> [options de clone-projects.sh]
+```
+
+**Premier argument** :
+
+- une valeur purement numérique est traitée comme un group ID GitLab brut ;
+- toute autre valeur est traitée comme une clé de `GITLAB_PROJECTS`
+  (format `env-composant`, ex. `ptf-frontco`).
+
+Une clé inconnue produit une erreur `_ui_msg_fail` suivie de la liste des clés
+configurées, et `return 1`.
+
+**Arguments suivants** : transmis tels quels à `clone-projects.sh`
+(`ssh`, `https`, `full`, `shallow`, `--parallel N`, `--dry-run`).
+
+**Exemples** :
+
+```zsh
+gclone ptf-frontco ssh --parallel 8
+gclone 35621 --dry-run
+gclone --help
+```
+
+## Déroulé
+
+1. **Aide** — `--help` / `-h` en premier argument affiche l'usage de `gclone`, la
+   liste des clés `GITLAB_PROJECTS`, et renvoie vers `clone-projects.sh --help`
+   pour le détail des options. `return 0`.
+
+2. **Résolution de l'ID** — numérique → ID direct ; sinon lookup dans
+   `GITLAB_PROJECTS`. Échec → erreur + liste des clés, `return 1`.
+
+3. **Préconditions** — vérifiées dans cet ordre, chacune sortant en erreur
+   explicite via `_ui_msg_fail` :
+   - `GITLAB_TOKEN` non vide (sinon : pointer vers `~/.gitlab_secrets`) ;
+   - `GITLAB_BASE_DOMAIN` non vide (sinon : pointer vers `env.d/gitlab.zsh`) ;
+   - `WORK_DIR` défini et répertoire existant ;
+   - script trouvable : `$SCRIPTS_DIR/clone-projects.sh` si présent, sinon
+     `command -v clone-projects.sh`.
+
+4. **Résolution du dossier cible** — appel `GET /groups/<id>` sur
+   `https://$GITLAB_BASE_DOMAIN/api/v4` pour lire `.full_path`
+   (ex. `blg-caas/ptf`). L'appel utilise `--max-time 5`, et `-k` si
+   `GITLAB_IGNORE_SSL` vaut `true`. En cas d'échec ou de `jq` absent, on
+   n'interrompt pas : `full_path` reste vide et l'étape 6 se contente de laisser
+   le shell dans `$WORK_DIR`.
+
+5. **Exécution** — mémorisation du cwd de départ, `cd "$WORK_DIR"`, puis
+   `clone-projects.sh <id> "$GITLAB_TOKEN" "$@"`. Le code de sortie est conservé.
+
+6. **Positionnement final** :
+   - script en succès et `$WORK_DIR/<full_path>` existe → `cd` dans ce répertoire ;
+   - script en succès sans `full_path` exploitable → le shell reste dans `$WORK_DIR` ;
+   - script en échec → retour au cwd de départ, et `gclone` propage le code
+     de sortie du script.
+
+   « Échec » désigne ici un code de sortie non nul de `clone-projects.sh`,
+   c'est-à-dire une erreur bloquante (arguments manquants, `jq` absent,
+   `GITLAB_BASE_DOMAIN` non défini, erreur API critique). Les échecs de clone ou
+   de pull sur des dépôts individuels sont comptabilisés dans le résumé du script
+   sans changer son code de sortie : `gclone` positionne alors normalement le
+   shell dans le groupe.
+
+   Le `cd` final s'applique aussi en `--dry-run` si le répertoire existe déjà : le
+   mode dry-run ne crée rien, donc ce cas ne se présente que sur un groupe déjà
+   cloné, où le déplacement reste le comportement attendu.
+
+La fonction ne peut pas s'exécuter dans un sous-shell, puisque le `cd` doit
+persister dans le shell appelant. D'où la mémorisation explicite du cwd et le
+retour manuel en cas d'échec.
+
+## Modifications
+
+### `modules/gitlab/gitlab_logic.zsh`
+
+- Nouvelle fonction `gclone`, placée après `load_gitlab_aliases` / avant
+  `list-gitlab-cmds`.
+- Ligne 43 : `alias "$alias_name"="gclone $key"` au lieu de
+  `"cd $WORK_DIR && clone-projects.sh $id $GITLAB_TOKEN"`. Le token disparaît de
+  la définition des alias.
+
+Les alias conservent leur nom (`gc-<composant>-<env>`) et acceptent toujours des
+options en suffixe : `gc-frontco-ptf ssh --parallel 8`.
+
+### `modules/gitlab/completions.zsh`
+
+Nouvelle fonction `_gclone` enregistrée via `compdef _gclone gclone` :
+
+- premier argument : clés de `GITLAB_PROJECTS`, décrites par leur group ID ;
+- arguments suivants : `ssh`, `https`, `full`, `shallow`, `--parallel`,
+  `--dry-run`, `--help`.
+
+Les `compdef` existants des alias `gc-*` restent inchangés.
+
+### Documentation
+
+- `web/wiki/Commandes.md` et `web/site/src/content/docs/commandes.md` : ajouter
+  une ligne `gclone` dans le tableau des commandes GitLab.
+
+## Hors périmètre
+
+- Clonage de tous les groupes `GITLAB_PROJECTS` en une commande (`--all`) :
+  écarté, un groupe à la fois suffit.
+- Modification de `scripts/clone-projects.sh` : le script reste utilisable seul
+  depuis n'importe quel répertoire, son comportement ne change pas.
+- Délégation au CLI Rust : la logique est trop fine pour justifier une commande
+  `zanvil`.
+
+## Vérification
+
+Aucun harnais de test zsh dans le projet (pas de shellspec). Vérification
+manuelle après `source ~/.zshrc` :
+
+1. `gclone --help` → usage + liste des clés.
+2. `gclone cle-inexistante` → erreur + liste des clés, code 1, cwd inchangé.
+3. `gclone <clé> --dry-run` depuis un répertoire quelconque → le script tourne
+   bien depuis `$WORK_DIR`, aucune écriture, shell positionné dans le groupe.
+4. `gclone <clé>` → dépôts sous `$WORK_DIR/<full_path>`, shell positionné dedans.
+5. `alias gc-frontco-ptf` → plus aucun token affiché.
+6. `gclone <TAB>` → complétion des clés `GITLAB_PROJECTS`.
+7. Token invalide → le script échoue, `gclone` propage le code et rend le cwd
+   de départ.

--- a/web/site/src/content/docs/commandes.md
+++ b/web/site/src/content/docs/commandes.md
@@ -49,6 +49,7 @@ Toutes les commandes `zanvil-*` utilisent un style visuel moderne et compact via
 | `zanvil-gitlab-browse` | Ouvre le projet GitLab dans le navigateur |
 | `gpr` | Alias pour créer une merge request GitLab |
 | `clone-projects [--dry-run] [--parallel]` | Clone en masse des projets GitLab |
+| `gclone <clé\|group-id>` | Clone un groupe GitLab depuis `$WORK_DIR` et s'y positionne |
 | `git-bulk [--dry-run]` | Opérations Git en masse sur plusieurs repos |
 
 ## Navigation

--- a/web/wiki/Commandes.md
+++ b/web/wiki/Commandes.md
@@ -46,6 +46,7 @@ Toutes les commandes `zanvil-*` utilisent un style visuel moderne et compact via
 | `zanvil-gitlab-browse` | Ouvre le projet GitLab dans le navigateur |
 | `gpr` | Alias pour creer une merge request GitLab |
 | `clone-projects [--dry-run] [--parallel]` | Clone en masse des projets GitLab |
+| `gclone <cle\|group-id>` | Clone un groupe GitLab depuis `$WORK_DIR` et s'y positionne |
 | `git-bulk [--dry-run]` | Operations Git en masse sur plusieurs repos |
 
 ## Navigation


### PR DESCRIPTION
## Résumé

Deux lots indépendants (regroupés à la demande, cf. dernier commit) :

### 1. Outillage Elasticsearch générique du module `work`

Ergonomie d'accès uniquement, pas de logique métier d'investigation :

- **`work_es_query [METHOD] PATH [BODY|-]`** — wrapper curl générique (auth, CA, jq pretty si TTY, corps d'erreur sur HTTP ≥ 400)
- **`work_es_apps [RANGE] [--refresh]`** — découverte des applications par volume (terms agg, cache TTL 1h invalidé par plage, branché sur la complétion `--app`)
- **`work_es_count`** — comptage pré-vol (size 0 + track_total_hits + fenêtre min→max des matches), mêmes options/dates Europe/Paris que le script
- **Garde-fou `work_fetch_logs`** — confirmation si volume estimé > `ZANVIL_WORK_ES_MAX_DOCS` (100k), `--yes` pour bypasser, fail-open, re-comptage fenêtre élargie avec `--search`
- **Volet Elasticsearch dans `work_status`** — creds/cluster health/rétention, dégradé silencieusement hors réseau
- **`work_es_tail`** — suivi quasi temps réel par search_after (validation du sort value, garde 1000 docs/itération)

Inclut aussi la resynchronisation de `fetch_es_logs.sh` avec la version de référence (`--search`/`--margin`, dates Europe/Paris DST).

Spec : `web/docs/superpowers/specs/2026-07-09-work-es-tooling-design.md` · Plan : `web/docs/superpowers/plans/2026-07-09-work-es-tooling.md`

### 2. `gclone` — clone d'un groupe GitLab depuis `WORK_DIR`

- **`gclone <clé|group-id> [options]`** — résout la clé `GITLAB_PROJECTS` (ou un ID numérique brut), lance `clone-projects.sh` depuis `$WORK_DIR`, puis positionne le shell dans le répertoire du groupe cloné (`full_path` résolu via l'API GitLab, best-effort avec repli sur `$WORK_DIR`)
- Retour au cwd de départ avec propagation du code de sortie si le script échoue
- Les alias `gc-*` délèguent désormais à `gclone` : **le token GitLab n'apparaît plus dans leur définition** (`alias gc-frontco-ptf` l'exposait en clair)
- Complétion `_gclone` (clés `GITLAB_PROJECTS`, puis options du script)

Spec : `web/docs/superpowers/specs/2026-07-27-gclone-workdir-design.md`

## Qualité

- **ES** : review par tâche (10 tâches) + review finale whole-branch : 1 Critical (boucle infinie parsing zsh) et 3 Important corrigés en cours de route, verdict final « prêt à merger »
- **gclone** : harnais de test isolé (curl/jq/script stubbés) — 25 assertions, 0 échec : exécution depuis `$WORK_DIR`, `cd` final dans le groupe, restauration du cwd + propagation du code sur échec, repli sans `full_path`, erreurs clé inconnue / token absent / `WORK_DIR` invalide, absence de token dans les alias
- Vérifications communes : `zsh -n` sur tous les fichiers, chargement module + complétions en shell propre, comportement hors réseau borné (pas de hang)
- Décision projet : pas de tests shellspec (suite supprimée au commit 8135460, tests à reconstruire côté CLI Rust)

## Tests manuels restants (contexte work uniquement, ES interne inaccessible hors réseau)

- [ ] `work_es_apps` puis `work_fetch_logs --app <TAB>` (complétion depuis le cache)
- [ ] `work_es_count --app <app> --since 1h` et variante `--search`
- [ ] `work_es_tail --app <app>` (flux + Ctrl-C)
- [ ] `work_status` (volet ES : cluster + rétention)
- [ ] Garde-fou : `ZANVIL_WORK_ES_MAX_DOCS=1 work_fetch_logs --app <app> --since 5m` (confirmation) puis `--yes` (bypass)
- [ ] `gclone <clé> --dry-run` : vérifier que le `full_path` renvoyé par l'API correspond bien à l'arborescence créée (seul point non couvert par les stubs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
