### PR TITLE
feat(k9s): rendu logback et explorateur de logs interactif

### DIFF
--- a/config/k9s/fixtures/logs-sample.jsonl
+++ b/config/k9s/fixtures/logs-sample.jsonl
@@ -1,0 +1,10 @@
+{"@timestamp":"2026-07-28T08:00:00.123Z","level":"INFO","thread_name":"main","logger_name":"com.boulanger.foo.FooService","message":"Demarrage termine"}
+{"@timestamp":"2026-07-28T08:00:01.456Z","level":"ERROR","thread_name":"http-nio-8080-exec-2","logger_name":"com.boulanger.foo.BarClient","message":"Timeout amont","stack_trace":"java.lang.IllegalStateException: Timeout amont\n\tat com.boulanger.foo.BarClient.send(BarClient.java:17)\n\tat com.boulanger.foo.FooService.call(FooService.java:42)\n\t... 24 more"}
+{"@timestamp":"2026-07-28T08:00:02.001Z","level":"WARN","thread_name":"scheduling-1","logger_name":"com.boulanger.foo.Cleanup","message":"3 orphelins ignores","http.status":503,"retry":2}
+{"@timestamp":"2026-07-28T08:00:03.100Z","level":"DEBUG","thread_name":"main","logger_name":"com.boulanger.foo.bar.baz.qux.EnormousServiceImplementation","message":"Logger de plus de 36 caracteres"}
+{"@timestamp":"2026-07-28T08:00:04.200Z","level":"TRACE","thread_name":"http-nio-8080-exec-with-a-very-long-thread-name","logger_name":"com.boulanger.foo.Pool","message":"Thread de plus de 20 caracteres"}
+{"@timestamp":"2026-07-28T08:00:05.300Z","message":"Sans niveau ni thread ni logger"}
+{"@timestamp":"2026-07-28T08:00:06.400Z","severity":"WARN","msg":"Champs severity et msg","trace_id":"4bf92f3577b34da6a3ce929d0e0e4736","span_id":"00f067aa0ba902b7"}
+{"@timestamp":"2026-07-28T08:00:07.500Z","level":"INFO","thread_name":"main","logger_name":"com.boulanger.foo.Report","message":"Ligne 1\nLigne 2\nLigne 3"}
+Log applicatif en texte brut, emis par un conteneur sidecar
+{"@timestamp":"2026-07-28T08:00:08.600Z","level":"INFO","message":"accolade manquante"

--- a/config/k9s/plugins.yaml
+++ b/config/k9s/plugins.yaml
@@ -6,7 +6,7 @@ plugins:
   # Logs JSON depuis un pod (toutes les containers)
   log-json-pod:
     shortCut: Shift-L
-    description: Logs JSON formatés (humanlog)
+    description: Logs formatés (logback)
     scopes:
       - po
     command: bash
@@ -31,7 +31,7 @@ plugins:
   # Note: dans le scope containers, $NAME = container, $POD = pod
   log-json-container:
     shortCut: Shift-L
-    description: Logs JSON formatés (humanlog)
+    description: Logs formatés (logback)
     scopes:
       - containers
     command: bash
@@ -40,6 +40,55 @@ plugins:
     args:
       - -c
       - '"$@" | $ZANVIL_DIR/scripts/k9s-log-fmt.sh | less -R +G'
+      - dummy-arg
+      - kubectl
+      - logs
+      - -c
+      - $NAME
+      - $POD
+      - -n
+      - $NAMESPACE
+      - --context
+      - $CONTEXT
+      - --tail
+      - "500"
+
+  # Explorateur de logs interactif (fzf) — filtrer, rechercher, copier
+  log-view-pod:
+    shortCut: Ctrl-L
+    description: Logs interactifs (fzf)
+    scopes:
+      - po
+    command: bash
+    background: false
+    confirm: false
+    args:
+      - -c
+      - '"$@" | $ZANVIL_DIR/scripts/k9s-log-fmt.sh --pairs | $ZANVIL_DIR/scripts/k9s-log-view.sh'
+      - dummy-arg
+      - kubectl
+      - logs
+      - $NAME
+      - -n
+      - $NAMESPACE
+      - --context
+      - $CONTEXT
+      - --tail
+      - "500"
+      - --all-containers=true
+
+  # Note: dans le scope containers, $NAME = container, $POD = pod
+  log-view-container:
+    shortCut: Ctrl-L
+    description: Logs interactifs (fzf)
+    scopes:
+      - containers
+    command: bash
+    background: false
+    confirm: false
+    args:
+      - -c
+      - '"$@" | $ZANVIL_DIR/scripts/k9s-log-fmt.sh --pairs | $ZANVIL_DIR/scripts/k9s-log-view.sh'
       - dummy-arg
       - kubectl
       - logs

--- a/modules/kube/kube_config.zsh
+++ b/modules/kube/kube_config.zsh
@@ -1238,9 +1238,9 @@ Kube Config Manager - Commandes disponibles:
   kube_switch      Switch de contexte Kubernetes (interactif)
   kube_ns          Switch de namespace (interactif)
   k [ctx] [ns]     Ouvre k9s (supporte les alias, "all" pour tous ns)
-  k9s: Shift-L    Logs formatés (logback) dans less
-  k9s: Ctrl-L     Logs interactifs (fzf) — filtrer, copier
-  klog [pod] [ctn] Logs interactifs (fzf) — --follow, --previous, --tail N, -n ns
+  k9s: Shift-L     Logs formatés (logback) dans less
+  k9s: Ctrl-L      Logs interactifs (fzf) — filtrer, copier
+  klog [pod] [ctn] Logs d'un pod (selection fzf) — JSON brut, --follow, --previous, --tail N, -n ns
   kube_k9s_setup   Deploie hotkeys + skin k9s depuis le repo
   kube_status      Affiche les configs actuellement chargees
   kube_list        Liste toutes les configs disponibles

--- a/modules/kube/kube_config.zsh
+++ b/modules/kube/kube_config.zsh
@@ -1203,10 +1203,12 @@ kube_k9s_setup() {
         _ui_msg_warn "config/k9s/hotkeys.yaml absent dans $ZANVIL_DIR"
     fi
 
-    # Deployer plugins
+    # Deployer plugins — $ZANVIL_DIR est resolu a la copie : k9s tente de
+    # substituer lui-meme les $VAR et n'a pas ZANVIL_DIR dans son environnement
+    # (warning "No k9s environment matching key" + chemin vide si la var change).
     local plugins_src="$ZANVIL_DIR/config/k9s/plugins.yaml"
     if [[ -f "$plugins_src" ]]; then
-        cp "$plugins_src" "$k9s_dir/plugins.yaml"
+        sed "s|\$ZANVIL_DIR|$ZANVIL_DIR|g" "$plugins_src" > "$k9s_dir/plugins.yaml"
         _ui_msg_ok "plugins.yaml deploye"
     else
         _ui_msg_warn "config/k9s/plugins.yaml absent dans $ZANVIL_DIR"

--- a/modules/kube/kube_config.zsh
+++ b/modules/kube/kube_config.zsh
@@ -1238,6 +1238,8 @@ Kube Config Manager - Commandes disponibles:
   kube_switch      Switch de contexte Kubernetes (interactif)
   kube_ns          Switch de namespace (interactif)
   k [ctx] [ns]     Ouvre k9s (supporte les alias, "all" pour tous ns)
+  k9s: Shift-L    Logs formatés (logback) dans less
+  k9s: Ctrl-L     Logs interactifs (fzf) — filtrer, copier
   klog [pod] [ctn] Logs interactifs (fzf) — --follow, --previous, --tail N, -n ns
   kube_k9s_setup   Deploie hotkeys + skin k9s depuis le repo
   kube_status      Affiche les configs actuellement chargees

--- a/scripts/k9s-log-fmt.sh
+++ b/scripts/k9s-log-fmt.sh
@@ -45,6 +45,17 @@ def level_color:
   elif . == "DEBUG" or . == "TRACE" then "36"
   else "1;32" end;
 
+# Regle logback %logger{36} : au-dela de $max caracteres, chaque segment de
+# package est reduit a son initiale, la classe finale etant preservee.
+# "com.boulanger.foo.FooService" -> "c.b.f.FooService"
+def abbrev_logger($max):
+  if length <= $max then .
+  else (split(".")) as $p
+    | (if ($p | length) > 1
+       then (($p[0:-1] | map(.[0:1])) + [$p[-1]]) | join(".")
+       else . end)
+  end;
+
 # --- rendu -------------------------------------------------------------------
 . as $line |
 try (
@@ -53,8 +64,22 @@ try (
   (.level // .severity // .lvl // "INFO" | ascii_upcase) as $lvl |
   (.["@timestamp"] // .timestamp // .time // "" | tostring | hhmmss) as $hh |
   (.message // .msg // "" | tostring) as $msg |
+  (.thread_name // "" | tostring) as $thr |
+  (.logger_name // "" | tostring) as $log |
 
-  c("2"; $hh) + " " + c($lvl | level_color; $lvl | pad(5)) + " " + $msg
+  (if $thr == "" then "" else "[" + ($thr | trunc(20)) + "] " end) as $thr_plain |
+  (if $log == "" then "" else ($log | abbrev_logger(36)) + " " end) as $log_plain |
+  (if $thr == "" and $log == "" then "" else "- " end) as $sep |
+
+  # Prefixe sans ANSI : sert a calculer l indentation de la 2e ligne (Task 4).
+  ($hh + " " + ($lvl | pad(5)) + " " + $thr_plain + $log_plain + $sep) as $pre_plain |
+
+  (c("2"; $hh) + " " + c($lvl | level_color; $lvl | pad(5)) + " "
+   + (if $thr == "" then "" else c("2"; "[" + ($thr | trunc(20)) + "]") + " " end)
+   + (if $log == "" then "" else c("36"; ($log | abbrev_logger(36))) + " " end)
+   + $sep + $msg) as $head |
+
+  $head
 
 ) catch $line
 '

--- a/scripts/k9s-log-fmt.sh
+++ b/scripts/k9s-log-fmt.sh
@@ -89,7 +89,7 @@ try (
   $head
   + (if $st == "" then ""
      else "\n" + c("2";
-       ($st | gsub("\t"; "    ") | split("\n") | map("  " + .) | join("\n")))
+       ($st | gsub("\t"; "    ") | sub("\n+$"; "") | split("\n") | map("  " + .) | join("\n")))
      end)
 
 ) catch $line

--- a/scripts/k9s-log-fmt.sh
+++ b/scripts/k9s-log-fmt.sh
@@ -1,38 +1,62 @@
 #!/usr/bin/env bash
-# k9s-log-fmt.sh — Formatte les logs JSON ligne par ligne avec couleurs ANSI
-# Utilise jq pour parser, codes ANSI embarqués dans les strings (TTY-indépendant)
-# Usage : kubectl logs ... | k9s-log-fmt.sh | less -R +G
+# k9s-log-fmt.sh — rend des logs JSON au format d'une console logback.
+# Filtre pur stdin -> stdout : pas d'etat, pas de fichier temporaire.
+# Les codes ANSI sont embarques par jq (\u001b) : le rendu ne depend pas d'un TTY,
+# ce qui est necessaire puisque k9s execute le plugin derriere deux pipes.
+#
+# Usage : kubectl logs ... | k9s-log-fmt.sh [--pairs]
+#   (defaut)  rendu multi-ligne : stack trace indentee, champs extra sur 2e ligne
+#   --pairs   une ligne par entree : texte, TAB, JSON source (pour k9s-log-view.sh)
+set -uo pipefail
+
+pairs=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pairs) pairs=true; shift ;;
+        -h|--help)
+            sed -n '2,9p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0 ;;
+        *)
+            printf 'k9s-log-fmt.sh: option inconnue : %s\n' "$1" >&2
+            exit 2 ;;
+    esac
+done
 
 JQ_FILTER='
+# --- helpers -----------------------------------------------------------------
+def c($code; $s): "\u001b[" + $code + "m" + $s + "\u001b[0m";
+def pad($n): if length >= $n then . else . + (" " * ($n - length)) end;
+def trunc($n): if length > $n then .[0:$n-1] + "…" else . end;
+
+# "2026-07-28T08:00:00.123456Z" -> "08:00:00.123". Chaine vide -> 12 espaces,
+# pour que la colonne du niveau reste alignee.
+def hhmmss:
+  if . == "" then "            "
+  else (if test("T") then split("T")[1] else . end) as $t
+    | ($t | sub("(Z|[+-][0-9:]+)$"; "")) as $u
+    | (if ($u | test("\\."))
+       then (($u | split("."))[0] + "." + (($u | split("."))[1][0:3]))
+       else $u + ".000" end)
+  end;
+
+def level_color:
+  if . == "ERROR" or . == "FATAL" or . == "CRITICAL" then "1;31"
+  elif . == "WARN" or . == "WARNING" then "1;33"
+  elif . == "DEBUG" or . == "TRACE" then "36"
+  else "1;32" end;
+
+# --- rendu -------------------------------------------------------------------
 . as $line |
 try (
   $line | fromjson |
 
   (.level // .severity // .lvl // "INFO" | ascii_upcase) as $lvl |
-  (if $lvl == "ERROR" or $lvl == "FATAL" or $lvl == "CRITICAL"
-   then "[1;31m"
-   elif $lvl == "WARN" or $lvl == "WARNING"
-   then "[1;33m"
-   elif $lvl == "DEBUG" or $lvl == "TRACE"
-   then "[36m"
-   else "[1;32m"
-   end) as $lc |
+  (.["@timestamp"] // .timestamp // .time // "" | tostring | hhmmss) as $hh |
+  (.message // .msg // "" | tostring) as $msg |
 
-  (.["@timestamp"] // .timestamp // .time // "") as $ts |
-  (.message // .msg // "") as $msg |
-
-  (del(
-    .["@timestamp"], .timestamp, .time,
-    .level, .severity, .lvl,
-    .message, .msg,
-    .trace_id, .span_id, .trace_flags,
-    .logger_name, .thread_name
-  ) | to_entries | map("\(.key)=\(.value|tostring)") | join("  ")) as $extra |
-
-  "[2m\($ts)[0m \($lc)|\($lvl)|[0m \($msg)" +
-  (if $extra != "" then "\n         [2m\($extra)[0m" else "" end)
+  c("2"; $hh) + " " + c($lvl | level_color; $lvl | pad(5)) + " " + $msg
 
 ) catch $line
 '
 
-jq -Rr "$JQ_FILTER"
+jq -Rr --argjson pairs "$pairs" "$JQ_FILTER"

--- a/scripts/k9s-log-fmt.sh
+++ b/scripts/k9s-log-fmt.sh
@@ -99,8 +99,13 @@ try (
      | map("\(.key)=\(if (.value | type) == "string" then .value else (.value | tojson) end)")
      | join("  ")) as $extra |
 
-  ($thr | trunc(20)) as $thr_t |
-  ($log | abbrev_logger(36)) as $log_a |
+  # oneline est applique inconditionnellement : un nom de thread ou de logger est
+  # un identifiant, jamais du texte multi-ligne (contrairement au message, ou un
+  # retour a la ligne est signifiant et donc conserve en mode statique). Une
+  # tabulation ou un newline y casserait le contrat --pairs, et l alignement de
+  # la ligne d extras en mode statique.
+  ($thr | oneline | trunc(20)) as $thr_t |
+  ($log | oneline | abbrev_logger(36)) as $log_a |
 
   (if $thr == "" then "" else "[" + $thr_t + "] " end) as $thr_plain |
   (if $log == "" then "" else $log_a + " " end) as $log_plain |

--- a/scripts/k9s-log-fmt.sh
+++ b/scripts/k9s-log-fmt.sh
@@ -74,6 +74,17 @@ try (
   (.logger_name // "" | tostring) as $log |
   (.stack_trace // .exception // .stacktrace // .throwable // "" | tostring) as $st |
 
+  (del(
+    .["@timestamp"], .timestamp, .time,
+    .level, .severity, .lvl,
+    .message, .msg,
+    .thread_name, .logger_name,
+    .stack_trace, .exception, .stacktrace, .throwable,
+    .trace_id, .span_id, .trace_flags
+   ) | to_entries
+     | map("\(.key)=\(if (.value | type) == "string" then .value else (.value | tojson) end)")
+     | join("  ")) as $extra |
+
   (if $thr == "" then "" else "[" + ($thr | trunc(20)) + "] " end) as $thr_plain |
   (if $log == "" then "" else ($log | abbrev_logger(36)) + " " end) as $log_plain |
   (if $thr == "" and $log == "" then "" else "- " end) as $sep |
@@ -87,6 +98,9 @@ try (
    + $sep + $msg) as $head |
 
   $head
+  + (if $extra == "" then ""
+     else "\n" + (" " * ($pre_plain | length)) + c("2"; $extra)
+     end)
   + (if $st == "" then ""
      else "\n" + c("2";
        ($st | gsub("\t"; "    ") | sub("\n+$"; "") | split("\n") | map("  " + .) | join("\n")))

--- a/scripts/k9s-log-fmt.sh
+++ b/scripts/k9s-log-fmt.sh
@@ -53,7 +53,8 @@ def abbrev_logger($max):
   else (split(".")) as $p
     | (if ($p | length) > 1
        then (($p[0:-1] | map(.[0:1])) + [$p[-1]]) | join(".")
-       else . end)
+       else . end) as $s
+    | if ($s | length) <= $max then $s else "…" + $s[-($max-1):] end
   end;
 
 # --- rendu -------------------------------------------------------------------

--- a/scripts/k9s-log-fmt.sh
+++ b/scripts/k9s-log-fmt.sh
@@ -63,7 +63,7 @@ def short_exception:
   split("\n")[0] | split(":")[0] | split(".") | last;
 
 # Rend une chaine sure pour une ligne unique.
-def oneline: gsub("\n"; "↵") | gsub("\t"; " ");
+def oneline: gsub("\n"; "↵") | gsub("\t"; " ") | gsub("\r"; "");
 
 # --- rendu -------------------------------------------------------------------
 . as $line |
@@ -102,7 +102,7 @@ try (
 
   (if $pairs then
      $head
-     + (if $st == "" then "" else " " + c("2"; "⤷ " + ($st | short_exception)) end)
+     + (if $st == "" then "" else " " + c("2"; "⤷ " + ($st | short_exception | oneline)) end)
      + (if $extra == "" then "" else "  " + c("2"; ($extra | oneline | trunc(120))) end)
      + "\t" + $line
    else
@@ -114,7 +114,7 @@ try (
           ($st | gsub("\t"; "    ") | sub("\n+$"; "") | split("\n") | map("  " + .) | join("\n"))) end)
    end)
 
-) catch (if $pairs then $line + "\t" + $line else $line end)
+) catch (if $pairs then ($line | oneline) + "\t" + $line else $line end)
 '
 
 jq -Rr --argjson pairs "$pairs" "$JQ_FILTER"

--- a/scripts/k9s-log-fmt.sh
+++ b/scripts/k9s-log-fmt.sh
@@ -22,6 +22,11 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+if ! command -v jq &> /dev/null; then
+    printf "k9s-log-fmt.sh: 'jq' requis mais non installe.\n" >&2
+    exit 1
+fi
+
 JQ_FILTER='
 # --- helpers -----------------------------------------------------------------
 def c($code; $s): "\u001b[" + $code + "m" + $s + "\u001b[0m";
@@ -38,6 +43,12 @@ def hhmmss:
        then (($u | split("."))[0] + "." + (($u | split("."))[1][0:3]))
        else $u + ".000" end)
   end;
+
+def lvl_name:
+  if (type) == "number" then
+    (if . <= 10 then "TRACE" elif . <= 20 then "DEBUG" elif . <= 30 then "INFO"
+     elif . <= 40 then "WARN" elif . <= 50 then "ERROR" else "FATAL" end)
+  else (tostring | ascii_upcase) end;
 
 def level_color:
   if . == "ERROR" or . == "FATAL" or . == "CRITICAL" then "1;31"
@@ -70,7 +81,7 @@ def oneline: gsub("\n"; "↵") | gsub("\t"; " ") | gsub("\r"; "");
 try (
   $line | fromjson |
 
-  (.level // .severity // .lvl // "INFO" | ascii_upcase) as $lvl |
+  (.level // .severity // .lvl // "INFO" | lvl_name) as $lvl |
   (.["@timestamp"] // .timestamp // .time // "" | tostring | hhmmss) as $hh |
   (.message // .msg // "" | tostring | if $pairs then oneline else . end) as $msg |
   (.thread_name // "" | tostring) as $thr |
@@ -88,16 +99,19 @@ try (
      | map("\(.key)=\(if (.value | type) == "string" then .value else (.value | tojson) end)")
      | join("  ")) as $extra |
 
-  (if $thr == "" then "" else "[" + ($thr | trunc(20)) + "] " end) as $thr_plain |
-  (if $log == "" then "" else ($log | abbrev_logger(36)) + " " end) as $log_plain |
+  ($thr | trunc(20)) as $thr_t |
+  ($log | abbrev_logger(36)) as $log_a |
+
+  (if $thr == "" then "" else "[" + $thr_t + "] " end) as $thr_plain |
+  (if $log == "" then "" else $log_a + " " end) as $log_plain |
   (if $thr == "" and $log == "" then "" else "- " end) as $sep |
 
   # Prefixe sans ANSI : sert a calculer l indentation de la 2e ligne (Task 4).
   ($hh + " " + ($lvl | pad(5)) + " " + $thr_plain + $log_plain + $sep) as $pre_plain |
 
   (c("2"; $hh) + " " + c($lvl | level_color; $lvl | pad(5)) + " "
-   + (if $thr == "" then "" else c("2"; "[" + ($thr | trunc(20)) + "]") + " " end)
-   + (if $log == "" then "" else c("36"; ($log | abbrev_logger(36))) + " " end)
+   + (if $thr == "" then "" else c("2"; "[" + $thr_t + "]") + " " end)
+   + (if $log == "" then "" else c("36"; $log_a) + " " end)
    + $sep + $msg) as $head |
 
   (if $pairs then
@@ -108,7 +122,7 @@ try (
    else
      $head
      + (if $extra == "" then ""
-        else "\n" + (" " * ($pre_plain | length)) + c("2"; $extra) end)
+        else "\n" + (" " * ($pre_plain | length)) + c("2"; $extra | oneline) end)
      + (if $st == "" then ""
         else "\n" + c("2";
           ($st | gsub("\t"; "    ") | sub("\n+$"; "") | split("\n") | map("  " + .) | join("\n"))) end)

--- a/scripts/k9s-log-fmt.sh
+++ b/scripts/k9s-log-fmt.sh
@@ -62,6 +62,9 @@ def abbrev_logger($max):
 def short_exception:
   split("\n")[0] | split(":")[0] | split(".") | last;
 
+# Rend une chaine sure pour une ligne unique.
+def oneline: gsub("\n"; "↵") | gsub("\t"; " ");
+
 # --- rendu -------------------------------------------------------------------
 . as $line |
 try (
@@ -69,7 +72,7 @@ try (
 
   (.level // .severity // .lvl // "INFO" | ascii_upcase) as $lvl |
   (.["@timestamp"] // .timestamp // .time // "" | tostring | hhmmss) as $hh |
-  (.message // .msg // "" | tostring) as $msg |
+  (.message // .msg // "" | tostring | if $pairs then oneline else . end) as $msg |
   (.thread_name // "" | tostring) as $thr |
   (.logger_name // "" | tostring) as $log |
   (.stack_trace // .exception // .stacktrace // .throwable // "" | tostring) as $st |
@@ -97,16 +100,21 @@ try (
    + (if $log == "" then "" else c("36"; ($log | abbrev_logger(36))) + " " end)
    + $sep + $msg) as $head |
 
-  $head
-  + (if $extra == "" then ""
-     else "\n" + (" " * ($pre_plain | length)) + c("2"; $extra)
-     end)
-  + (if $st == "" then ""
-     else "\n" + c("2";
-       ($st | gsub("\t"; "    ") | sub("\n+$"; "") | split("\n") | map("  " + .) | join("\n")))
-     end)
+  (if $pairs then
+     $head
+     + (if $st == "" then "" else " " + c("2"; "⤷ " + ($st | short_exception)) end)
+     + (if $extra == "" then "" else "  " + c("2"; ($extra | oneline | trunc(120))) end)
+     + "\t" + $line
+   else
+     $head
+     + (if $extra == "" then ""
+        else "\n" + (" " * ($pre_plain | length)) + c("2"; $extra) end)
+     + (if $st == "" then ""
+        else "\n" + c("2";
+          ($st | gsub("\t"; "    ") | sub("\n+$"; "") | split("\n") | map("  " + .) | join("\n"))) end)
+   end)
 
-) catch $line
+) catch (if $pairs then $line + "\t" + $line else $line end)
 '
 
 jq -Rr --argjson pairs "$pairs" "$JQ_FILTER"

--- a/scripts/k9s-log-fmt.sh
+++ b/scripts/k9s-log-fmt.sh
@@ -57,6 +57,11 @@ def abbrev_logger($max):
     | if ($s | length) <= $max then $s else "…" + $s[-($max-1):] end
   end;
 
+# Nom court de l exception, extrait de la premiere ligne de la stack.
+# "java.lang.IllegalStateException: Boom\n\tat ..." -> "IllegalStateException"
+def short_exception:
+  split("\n")[0] | split(":")[0] | split(".") | last;
+
 # --- rendu -------------------------------------------------------------------
 . as $line |
 try (
@@ -67,6 +72,7 @@ try (
   (.message // .msg // "" | tostring) as $msg |
   (.thread_name // "" | tostring) as $thr |
   (.logger_name // "" | tostring) as $log |
+  (.stack_trace // .exception // .stacktrace // .throwable // "" | tostring) as $st |
 
   (if $thr == "" then "" else "[" + ($thr | trunc(20)) + "] " end) as $thr_plain |
   (if $log == "" then "" else ($log | abbrev_logger(36)) + " " end) as $log_plain |
@@ -81,6 +87,10 @@ try (
    + $sep + $msg) as $head |
 
   $head
+  + (if $st == "" then ""
+     else "\n" + c("2";
+       ($st | gsub("\t"; "    ") | split("\n") | map("  " + .) | join("\n")))
+     end)
 
 ) catch $line
 '

--- a/scripts/k9s-log-view.sh
+++ b/scripts/k9s-log-view.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# k9s-log-view.sh — explorateur interactif de logs, pilote par fzf.
+# Consomme le format --pairs de k9s-log-fmt.sh : <texte rendu>TAB<json source>.
+# Ne connait rien du format des logs : il ne manipule que deux champs.
+#
+# Usage : kubectl logs ... | k9s-log-fmt.sh --pairs | k9s-log-view.sh
+set -uo pipefail
+
+FMT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/k9s-log-fmt.sh"
+
+# --- presse-papier -----------------------------------------------------------
+# Resolu une fois : les bindings fzf ne sont construits qu ensuite.
+clip=""
+if command -v pbcopy >/dev/null 2>&1; then
+    clip="pbcopy"
+elif command -v wl-copy >/dev/null 2>&1; then
+    clip="wl-copy"
+elif command -v xclip >/dev/null 2>&1; then
+    clip="xclip -selection clipboard"
+fi
+
+# --- repli sans fzf ----------------------------------------------------------
+# Seul le premier champ est affiche : le JSON source n a d interet qu en
+# interactif. sed retire tout ce qui suit la premiere tabulation.
+if ! command -v fzf >/dev/null 2>&1; then
+    sed 's/\t.*$//' | less -R
+    exit $?
+fi
+
+# --- construction des options ------------------------------------------------
+strip_ansi='sed "s/\x1b\[[0-9;]*m//g"'
+
+header="⏎ evenement complet   ?  preview"
+opts=(
+    --ansi
+    --multi
+    --no-sort
+    --delimiter=$'\t'
+    --with-nth=1
+    --prompt="log > "
+    --header="$header"
+    --preview="printf '%s' {2..} | jq -C . 2>/dev/null || printf '%s' {2..}"
+    --preview-window="right:50%:wrap"
+    --bind="?:toggle-preview"
+    --bind="enter:execute(printf '%s' {2..} | \"$FMT\" | less -R)"
+)
+
+if [[ -n "$clip" ]]; then
+    header="ctrl-y copier   ctrl-o JSON   ⏎ evenement complet   ?  preview"
+    opts+=(
+        --header="$header"
+        # Copie le texte rendu, sans ANSI ni indicateur de stack.
+        --bind="ctrl-y:execute-silent(printf '%s\n' {+1} | $strip_ansi | $clip)"
+        --bind="ctrl-o:execute-silent(printf '%s\n' {+2..} | $clip)"
+    )
+else
+    opts+=(--header="$header   (presse-papier indisponible)")
+fi
+
+fzf "${opts[@]}" >/dev/null

--- a/scripts/k9s-log-view.sh
+++ b/scripts/k9s-log-view.sh
@@ -43,7 +43,7 @@ fi
 # --- construction des options ------------------------------------------------
 strip_ansi='sed "s/\x1b\[[0-9;]*m//g"'
 
-header="⏎ evenement complet   ?  preview"
+header="⏎ evenement complet   ? apercu JSON"
 opts=(
     --ansi
     --multi
@@ -53,13 +53,16 @@ opts=(
     --prompt="log > "
     --header="$header"
     --preview="printf '%s' {2..} | jq -C . 2>/dev/null || printf '%s' {2..}"
-    --preview-window="right:50%:wrap"
+    # hidden : le panneau demarre replie, la liste occupe toute la largeur.
+    # Les lignes rendues sont longues (heure, niveau, thread, logger, message) et
+    # le JSON source ne sert qu a l inspection ponctuelle. "?" le deplie.
+    --preview-window="right:50%:wrap:hidden"
     --bind="?:toggle-preview"
     --bind="enter:execute(printf '%s' {2..} | \"$FMT\" | less -R)"
 )
 
 if [[ -n "$clip" ]]; then
-    header="ctrl-y copier   ctrl-o JSON   ⏎ evenement complet   ?  preview"
+    header="ctrl-y copier   ctrl-o JSON   ⏎ evenement complet   ? apercu JSON"
     opts+=(
         --header="$header"
         # Copie le texte rendu, codes ANSI retires (le sed ne touche pas

--- a/scripts/k9s-log-view.sh
+++ b/scripts/k9s-log-view.sh
@@ -19,12 +19,25 @@ elif command -v xclip >/dev/null 2>&1; then
     clip="xclip -selection clipboard"
 fi
 
+# --- normalisation du code de sortie -----------------------------------------
+# Quitter l explorateur est une sortie normale, pas un echec : fzf rend 130
+# (128 + SIGINT) sur Esc / Ctrl-C et 1 quand aucune ligne ne correspond au
+# filtre. k9s affiche une popup d erreur des que le plugin sort non nul
+# ("command failed ... exit status 130"), donc ces deux codes deviennent 0.
+# Le code 2 (vraie erreur fzf) et tout autre code sont conserves.
+_exit_normal() {
+    case "$1" in
+        130|1) exit 0 ;;
+        *)     exit "$1" ;;
+    esac
+}
+
 # --- repli sans fzf ----------------------------------------------------------
 # Seul le premier champ est affiche : le JSON source n a d interet qu en
 # interactif. sed retire tout ce qui suit la premiere tabulation.
 if ! command -v fzf >/dev/null 2>&1; then
     sed 's/\t.*$//' | less -R
-    exit $?
+    _exit_normal $?
 fi
 
 # --- construction des options ------------------------------------------------
@@ -59,3 +72,4 @@ else
 fi
 
 fzf "${opts[@]}" >/dev/null
+_exit_normal $?

--- a/scripts/k9s-log-view.sh
+++ b/scripts/k9s-log-view.sh
@@ -49,7 +49,8 @@ if [[ -n "$clip" ]]; then
     header="ctrl-y copier   ctrl-o JSON   ⏎ evenement complet   ?  preview"
     opts+=(
         --header="$header"
-        # Copie le texte rendu, sans ANSI ni indicateur de stack.
+        # Copie le texte rendu, codes ANSI retires (le sed ne touche pas
+        # au texte lui-meme : un indicateur de stack "⤷ ..." est conserve).
         --bind="ctrl-y:execute-silent(printf '%s\n' {+1} | $strip_ansi | $clip)"
         --bind="ctrl-o:execute-silent(printf '%s\n' {+2..} | $clip)"
     )

--- a/scripts/tests/k9s-log-fmt.test.sh
+++ b/scripts/tests/k9s-log-fmt.test.sh
@@ -68,6 +68,33 @@ printf '%s\n' '{"@timestamp":"2026-07-28T08:00:03+02:00","level":"INFO","message
     | "$FMT" | assert_contains "horodatage sans millisecondes" "08:00:03.000 INFO  Offset"
 
 echo
+echo "== thread et logger =="
+
+printf '%s\n' '{"@timestamp":"2026-07-28T08:00:00.123Z","level":"INFO","thread_name":"main","logger_name":"com.boulanger.foo.FooService","message":"Demarrage termine"}' \
+    | "$FMT" | assert_contains "thread entre crochets, logger, separateur" \
+    "08:00:00.123 INFO  [main] com.boulanger.foo.FooService - Demarrage termine"
+
+printf '%s\n' '{"level":"DEBUG","logger_name":"com.boulanger.foo.bar.baz.qux.EnormousServiceImplementation","message":"x"}' \
+    | "$FMT" | assert_contains "logger de plus de 36 caracteres abrege" \
+    "c.b.f.b.b.q.EnormousServiceImplementation - x"
+
+printf '%s\n' '{"level":"TRACE","thread_name":"http-nio-8080-exec-with-a-very-long-name","logger_name":"com.Pool","message":"x"}' \
+    | "$FMT" | assert_contains "thread de plus de 20 caracteres tronque" \
+    "[http-nio-8080-exec-…] com.Pool - x"
+
+printf '%s\n' '{"level":"INFO","logger_name":"com.boulanger.foo.FooService","message":"Sans thread"}' \
+    | "$FMT" | assert_contains "thread absent : pas de crochets vides" \
+    "INFO  com.boulanger.foo.FooService - Sans thread"
+
+printf '%s\n' '{"level":"INFO","thread_name":"main","message":"Sans logger"}' \
+    | "$FMT" | assert_contains "logger absent : thread conserve" \
+    "INFO  [main] - Sans logger"
+
+printf '%s\n' '{"level":"INFO","message":"Ni thread ni logger"}' \
+    | "$FMT" | assert_contains "thread et logger absents : pas de tiret orphelin" \
+    "INFO  Ni thread ni logger"
+
+echo
 pass=$(cat "$TEST_TMPDIR/pass")
 fail=$(cat "$TEST_TMPDIR/fail")
 printf '%d ok, %d echec(s)\n' "$pass" "$fail"

--- a/scripts/tests/k9s-log-fmt.test.sh
+++ b/scripts/tests/k9s-log-fmt.test.sh
@@ -188,6 +188,16 @@ printf '%s\n' "$n_out" | assert_equals "$n_in ligne(s) en entree, autant en sort
 printf '%s\n' '{"level":"INFO","message":"x"}' | "$FMT" --oops 2>/dev/null
 printf '%s\n' "$?" | assert_equals "option inconnue : code de sortie 2" "2"
 
+printf '%s\n' '{"level":"ERROR","message":"x","stack_trace":"weird trace\tsans colon ni point\nmore"}' \
+    | "$FMT" --pairs | awk -F'\t' '{print NF}' \
+    | assert_equals "stack avec tabulation : champ rendu sans tab" "2"
+
+printf '%s\n' '{"level":"INFO","message":"Ligne1\rLigne2"}' | "$FMT" --pairs | cut -f1 | grep -c $'\r' \
+    | assert_equals "carriage return neutralise" "0"
+
+printf '%s\n' $'col1\tcol2 texte brut' | "$FMT" --pairs | cut -f2- \
+    | assert_equals "texte brut avec tabulation : source intacte" $'col1\tcol2 texte brut'
+
 echo
 pass=$(cat "$TEST_TMPDIR/pass")
 fail=$(cat "$TEST_TMPDIR/fail")

--- a/scripts/tests/k9s-log-fmt.test.sh
+++ b/scripts/tests/k9s-log-fmt.test.sh
@@ -127,6 +127,10 @@ printf '%s\n' '{"level":"INFO","message":"Rien a signaler"}' \
     | "$FMT" | assert_equals "sans stack : une seule ligne" \
     "             INFO  Rien a signaler"
 
+printf '%s\n' '{"level":"ERROR","logger_name":"com.Foo","message":"Boom","stack_trace":"java.lang.IllegalStateException: Boom\n\tat com.Foo.bar(Foo.java:17)\n"}' \
+    | "$FMT" | strip_ansi | wc -l | tr -d ' ' \
+    | assert_equals "stack avec newline final : pas de ligne parasite" "3"
+
 echo
 pass=$(cat "$TEST_TMPDIR/pass")
 fail=$(cat "$TEST_TMPDIR/fail")

--- a/scripts/tests/k9s-log-fmt.test.sh
+++ b/scripts/tests/k9s-log-fmt.test.sh
@@ -248,6 +248,55 @@ printf '%s\n' '{"level":"INFO","message":"Bonjour"}' \
     | assert_equals "repli sans fzf : JSON source masque" "             INFO  Bonjour"
 
 echo
+echo "== viewer (code de sortie) =="
+
+# k9s affiche une popup d erreur des que le plugin sort non nul. Quitter fzf par
+# Esc rend 130, et un filtre sans correspondance rend 1 : deux sorties normales.
+# Un faux fzf permet de verifier la normalisation sans TTY.
+_fake_fzf() {
+    printf '#!/bin/sh\nexit %s\n' "$1" > "$TEST_TMPDIR/bin/fzf"
+    chmod +x "$TEST_TMPDIR/bin/fzf"
+}
+
+_fake_fzf 130
+printf '%s\n' '{"level":"INFO","message":"x"}' | "$FMT" --pairs \
+    | env PATH="$TEST_TMPDIR/bin" "$VIEW" >/dev/null 2>&1
+printf '%s\n' "$?" | assert_equals "fzf annule (130) : sortie normalisee a 0" "0"
+
+_fake_fzf 1
+printf '%s\n' '{"level":"INFO","message":"x"}' | "$FMT" --pairs \
+    | env PATH="$TEST_TMPDIR/bin" "$VIEW" >/dev/null 2>&1
+printf '%s\n' "$?" | assert_equals "aucune correspondance (1) : sortie normalisee a 0" "0"
+
+_fake_fzf 2
+printf '%s\n' '{"level":"INFO","message":"x"}' | "$FMT" --pairs \
+    | env PATH="$TEST_TMPDIR/bin" "$VIEW" >/dev/null 2>&1
+printf '%s\n' "$?" | assert_equals "erreur fzf (2) : code preserve" "2"
+
+rm -f "$TEST_TMPDIR/bin/fzf"
+
+echo
+echo "== thread et logger : identifiants sur une seule ligne =="
+
+# Un nom de thread ou de logger contenant une tabulation ou un newline casserait
+# le contrat --pairs (indexation fzf par ligne) et l alignement en statique.
+printf '%s\n' '{"level":"INFO","thread_name":"pool\n1","message":"x"}' \
+    | "$FMT" --pairs | wc -l | tr -d ' ' \
+    | assert_equals "thread avec newline : une seule ligne en --pairs" "1"
+
+printf '%s\n' '{"level":"INFO","thread_name":"pool\t1","message":"x"}' \
+    | "$FMT" --pairs | awk -F'\t' '{print NF}' \
+    | assert_equals "thread avec tabulation : deux champs" "2"
+
+printf '%s\n' '{"level":"INFO","logger_name":"com.A\tB","message":"x"}' \
+    | "$FMT" --pairs | awk -F'\t' '{print NF}' \
+    | assert_equals "logger avec tabulation : deux champs" "2"
+
+printf '%s\n' '{"level":"INFO","thread_name":"pool\n1","message":"x"}' \
+    | "$FMT" | wc -l | tr -d ' ' \
+    | assert_equals "thread avec newline : une seule ligne en statique" "1"
+
+echo
 pass=$(cat "$TEST_TMPDIR/pass")
 fail=$(cat "$TEST_TMPDIR/fail")
 printf '%d ok, %d echec(s)\n' "$pass" "$fail"

--- a/scripts/tests/k9s-log-fmt.test.sh
+++ b/scripts/tests/k9s-log-fmt.test.sh
@@ -153,6 +153,42 @@ printf '%s\n' '{"level":"ERROR","message":"Boom","stack_trace":"java.lang.Error:
     | assert_equals "extras et stack : 3 lignes" "3"
 
 echo
+echo "== mode --pairs =="
+
+PAIRS_JSON='{"@timestamp":"2026-07-28T08:00:01.456Z","level":"ERROR","thread_name":"main","logger_name":"com.Foo","message":"Boom","stack_trace":"java.lang.IllegalStateException: Boom\n\tat com.Foo.bar(Foo.java:17)","retry":2}'
+
+printf '%s\n' "$PAIRS_JSON" | "$FMT" --pairs | strip_ansi | wc -l | tr -d ' ' \
+    | assert_equals "un evenement avec stack et extras tient sur une ligne" "1"
+
+printf '%s\n' "$PAIRS_JSON" | "$FMT" --pairs | strip_ansi | cut -f1 \
+    | assert_contains "stack reduite au nom court de l exception" "⤷ IllegalStateException"
+
+printf '%s\n' "$PAIRS_JSON" | "$FMT" --pairs | strip_ansi | cut -f1 \
+    | assert_contains "extras concatenes en fin de ligne" "retry=2"
+
+printf '%s\n' "$PAIRS_JSON" | "$FMT" --pairs | cut -f2- \
+    | assert_equals "2e champ = JSON source intact" "$PAIRS_JSON"
+
+printf '%s\n' '{"level":"INFO","message":"Ligne 1\nLigne 2"}' | "$FMT" --pairs | strip_ansi | cut -f1 \
+    | assert_contains "retours a la ligne du message remplaces par un symbole" "Ligne 1↵Ligne 2"
+
+printf '%s\n' 'texte brut' | "$FMT" --pairs | assert_equals "texte brut duplique dans les deux champs" \
+    "$(printf 'texte brut\ttexte brut')"
+
+echo
+echo "== contrat --pairs sur les fixtures =="
+
+n_in=$(wc -l < "$FIXTURES" | tr -d ' ')
+n_out=$("$FMT" --pairs < "$FIXTURES" | wc -l | tr -d ' ')
+printf '%s\n' "$n_out" | assert_equals "$n_in ligne(s) en entree, autant en sortie" "$n_in"
+
+"$FMT" --pairs < "$FIXTURES" | awk -F'\t' '{print NF}' | sort -u | tr '\n' ' ' | sed 's/ $//' \
+    | assert_equals "chaque ligne porte exactement 2 champs" "2"
+
+printf '%s\n' '{"level":"INFO","message":"x"}' | "$FMT" --oops 2>/dev/null
+printf '%s\n' "$?" | assert_equals "option inconnue : code de sortie 2" "2"
+
+echo
 pass=$(cat "$TEST_TMPDIR/pass")
 fail=$(cat "$TEST_TMPDIR/fail")
 printf '%d ok, %d echec(s)\n' "$pass" "$fail"

--- a/scripts/tests/k9s-log-fmt.test.sh
+++ b/scripts/tests/k9s-log-fmt.test.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Verifie le rendu de k9s-log-fmt.sh. Autonome, sans dependance.
+# Usage : scripts/tests/k9s-log-fmt.test.sh
+set -uo pipefail
+
+ROOT="${ZANVIL_DIR:-$HOME/.zanvil}"
+FMT="$ROOT/scripts/k9s-log-fmt.sh"
+FIXTURES="$ROOT/config/k9s/fixtures/logs-sample.jsonl"
+pass=0 fail=0
+
+# Retire les codes ANSI : les assertions portent sur le texte, pas les couleurs.
+strip_ansi() { sed $'s/\033\\[[0-9;]*m//g'; }
+
+# assert_contains <libelle> <attendu>, entree sur stdin
+assert_contains() {
+    local label="$1" needle="$2" out
+    out=$(strip_ansi)
+    if [[ "$out" == *"$needle"* ]]; then
+        printf '  ok   %s\n' "$label"
+        pass=$((pass + 1))
+    else
+        printf '  FAIL %s\n       attendu : %s\n       obtenu  : %s\n' \
+            "$label" "$needle" "$out"
+        fail=$((fail + 1))
+    fi
+}
+
+# assert_equals <libelle> <attendu>, entree sur stdin
+assert_equals() {
+    local label="$1" needle="$2" out
+    out=$(strip_ansi)
+    if [[ "$out" == "$needle" ]]; then
+        printf '  ok   %s\n' "$label"
+        pass=$((pass + 1))
+    else
+        printf '  FAIL %s\n       attendu : %s\n       obtenu  : %s\n' \
+            "$label" "$needle" "$out"
+        fail=$((fail + 1))
+    fi
+}
+
+echo "== rendu de base =="
+
+printf '%s\n' '{"@timestamp":"2026-07-28T08:00:00.123Z","level":"INFO","message":"Demarrage termine"}' \
+    | "$FMT" | assert_contains "horodatage court + niveau complete" "08:00:00.123 INFO  Demarrage termine"
+
+printf '%s\n' '{"@timestamp":"2026-07-28T08:00:01.456Z","level":"error","message":"Boom"}' \
+    | "$FMT" | assert_contains "niveau en majuscules" "08:00:01.456 ERROR Boom"
+
+printf '%s\n' '{"@timestamp":"2026-07-28T08:00:02.000Z","severity":"WARN","msg":"Alerte"}' \
+    | "$FMT" | assert_contains "champs severity et msg reconnus" "08:00:02.000 WARN  Alerte"
+
+printf '%s\n' '{"message":"Sans horodatage"}' \
+    | "$FMT" | assert_contains "niveau par defaut INFO, colonne heure vide" "             INFO  Sans horodatage"
+
+printf '%s\n' 'ligne de texte brut' \
+    | "$FMT" | assert_equals "texte brut reemis a l identique" "ligne de texte brut"
+
+printf '%s\n' '{"level":"INFO","message":"accolade manquante"' \
+    | "$FMT" | assert_equals "JSON malforme traite comme du texte brut" '{"level":"INFO","message":"accolade manquante"'
+
+printf '%s\n' '{"@timestamp":"2026-07-28T08:00:03+02:00","level":"INFO","message":"Offset"}' \
+    | "$FMT" | assert_contains "horodatage sans millisecondes" "08:00:03.000 INFO  Offset"
+
+echo
+printf '%d ok, %d echec(s)\n' "$pass" "$fail"
+[[ $fail -eq 0 ]]

--- a/scripts/tests/k9s-log-fmt.test.sh
+++ b/scripts/tests/k9s-log-fmt.test.sh
@@ -99,6 +99,35 @@ printf '%s\n' '{"level":"DEBUG","logger_name":"UneClasseSansAucunPointDontLeNomD
     "…DontLeNomDepasseTrenteSixCaracteres - x"
 
 echo
+echo "== stack trace =="
+
+STACK_JSON='{"level":"ERROR","logger_name":"com.Foo","message":"Boom","stack_trace":"java.lang.IllegalStateException: Boom\n\tat com.Foo.bar(Foo.java:17)\n\t... 24 more"}'
+
+printf '%s\n' "$STACK_JSON" \
+    | "$FMT" | assert_contains "premiere ligne de la stack indentee de 2 espaces" \
+    "  java.lang.IllegalStateException: Boom"
+
+printf '%s\n' "$STACK_JSON" \
+    | "$FMT" | assert_contains "cadres indentes, tabulations converties" \
+    "      at com.Foo.bar(Foo.java:17)"
+
+printf '%s\n' "$STACK_JSON" \
+    | "$FMT" | assert_contains "dernier cadre" "      ... 24 more"
+
+printf '%s\n' "$STACK_JSON" | "$FMT" | strip_ansi | wc -l | tr -d ' ' \
+    | assert_equals "un evenement avec stack occupe 4 lignes" "4"
+
+printf '%s\n' '{"level":"ERROR","message":"Boom","exception":"java.lang.NullPointerException: null"}' \
+    | "$FMT" | assert_contains "champ exception reconnu" "  java.lang.NullPointerException: null"
+
+printf '%s\n' '{"level":"ERROR","message":"Boom","throwable":"java.io.IOException: broken pipe"}' \
+    | "$FMT" | assert_contains "champ throwable reconnu" "  java.io.IOException: broken pipe"
+
+printf '%s\n' '{"level":"INFO","message":"Rien a signaler"}' \
+    | "$FMT" | assert_equals "sans stack : une seule ligne" \
+    "             INFO  Rien a signaler"
+
+echo
 pass=$(cat "$TEST_TMPDIR/pass")
 fail=$(cat "$TEST_TMPDIR/fail")
 printf '%d ok, %d echec(s)\n' "$pass" "$fail"

--- a/scripts/tests/k9s-log-fmt.test.sh
+++ b/scripts/tests/k9s-log-fmt.test.sh
@@ -7,7 +7,9 @@ ROOT="${ZANVIL_DIR:-$HOME/.zanvil}"
 FMT="$ROOT/scripts/k9s-log-fmt.sh"
 FIXTURES="$ROOT/config/k9s/fixtures/logs-sample.jsonl"
 
-# Temp directory pour les compteurs (escape subshell issue)
+# Repertoire temporaire pour les compteurs : les assertions tournent en fin de
+# pipeline (donc dans une sous-shell) ou une simple variable ne survivrait pas
+# a l issue du pipe ; on passe donc par des fichiers.
 TEST_TMPDIR=$(mktemp -d) || { echo "mktemp failed" >&2; exit 2; }
 trap 'rm -rf "$TEST_TMPDIR"' EXIT
 echo 0 > "$TEST_TMPDIR/pass"
@@ -66,6 +68,22 @@ printf '%s\n' '{"level":"INFO","message":"accolade manquante"' \
 
 printf '%s\n' '{"@timestamp":"2026-07-28T08:00:03+02:00","level":"INFO","message":"Offset"}' \
     | "$FMT" | assert_contains "horodatage sans millisecondes" "08:00:03.000 INFO  Offset"
+
+echo
+echo "== niveau numerique (pino/bunyan) =="
+
+printf '%s\n' '{"level":30,"message":"hello"}' \
+    | "$FMT" | assert_contains "niveau numerique 30 rendu INFO" "             INFO  hello"
+
+printf '%s\n' '{"level":50,"message":"hello"}' \
+    | "$FMT" | assert_contains "niveau numerique 50 rendu ERROR" "             ERROR hello"
+
+printf '%s\n' '{"level":60,"message":"hello"}' \
+    | "$FMT" | assert_contains "niveau numerique 60 rendu FATAL" "             FATAL hello"
+
+printf '%s\n' '{"level":30,"message":"hello"}' \
+    | "$FMT" | assert_equals "niveau numerique : rendu complet, pas de passthrough JSON brut" \
+    "             INFO  hello"
 
 echo
 echo "== thread et logger =="
@@ -145,6 +163,10 @@ printf '%s\n' '{"level":"INFO","message":"x","trace_id":"4bf92f35","span_id":"00
     | "$FMT" | assert_equals "trace_id, span_id et trace_flags masques" \
     "             INFO  x"
 
+printf '%s\n' '{"level":"INFO","message":"x","mdc_field":"aaa\nbbb"}' \
+    | "$FMT" | strip_ansi | wc -l | tr -d ' ' \
+    | assert_equals "MDC avec newline : reste sur 2 lignes (extras aplatis)" "2"
+
 printf '%s\n' '{"level":"INFO","message":"x","nested":{"a":1}}' \
     | "$FMT" | assert_contains "valeur structuree serialisee" 'nested={"a":1}'
 
@@ -203,16 +225,26 @@ echo "== viewer (repli sans fzf) =="
 
 VIEW="$ROOT/scripts/k9s-log-view.sh"
 
-# PATH vide de fzf : le viewer doit se rabattre sur un affichage simple et
-# n afficher que le premier champ. LESS=-FX evite d ouvrir un pager interactif.
+# PATH minimal sans fzf : on ne peut pas se fier a /usr/bin:/bin pour exclure
+# fzf (apt l installe la-bas sur Debian/Ubuntu). On construit un bin dedie
+# avec uniquement ce dont le viewer et son repli ont besoin (bash pour le
+# shebang, dirname pour se localiser, sed et less pour l affichage simple).
+mkdir -p "$TEST_TMPDIR/bin"
+ln -s "$(command -v bash)" "$TEST_TMPDIR/bin/bash"
+ln -s "$(command -v dirname)" "$TEST_TMPDIR/bin/dirname"
+ln -s "$(command -v sed)" "$TEST_TMPDIR/bin/sed"
+ln -s "$(command -v less)" "$TEST_TMPDIR/bin/less"
+
+# Le viewer doit se rabattre sur un affichage simple et n afficher que le
+# premier champ. LESS=-FX evite d ouvrir un pager interactif.
 printf '%s\n' '{"level":"INFO","message":"Bonjour"}' \
     | "$FMT" --pairs \
-    | env PATH="/usr/bin:/bin" LESS="-FX" "$VIEW" \
+    | env PATH="$TEST_TMPDIR/bin" LESS="-FX" "$VIEW" \
     | assert_contains "repli sans fzf : premier champ affiche" "INFO  Bonjour"
 
 printf '%s\n' '{"level":"INFO","message":"Bonjour"}' \
     | "$FMT" --pairs \
-    | env PATH="/usr/bin:/bin" LESS="-FX" "$VIEW" \
+    | env PATH="$TEST_TMPDIR/bin" LESS="-FX" "$VIEW" \
     | assert_equals "repli sans fzf : JSON source masque" "             INFO  Bonjour"
 
 echo

--- a/scripts/tests/k9s-log-fmt.test.sh
+++ b/scripts/tests/k9s-log-fmt.test.sh
@@ -6,7 +6,12 @@ set -uo pipefail
 ROOT="${ZANVIL_DIR:-$HOME/.zanvil}"
 FMT="$ROOT/scripts/k9s-log-fmt.sh"
 FIXTURES="$ROOT/config/k9s/fixtures/logs-sample.jsonl"
-pass=0 fail=0
+
+# Temp directory pour les compteurs (escape subshell issue)
+TEST_TMPDIR=$(mktemp -d) || { echo "mktemp failed" >&2; exit 2; }
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+echo 0 > "$TEST_TMPDIR/pass"
+echo 0 > "$TEST_TMPDIR/fail"
 
 # Retire les codes ANSI : les assertions portent sur le texte, pas les couleurs.
 strip_ansi() { sed $'s/\033\\[[0-9;]*m//g'; }
@@ -17,11 +22,11 @@ assert_contains() {
     out=$(strip_ansi)
     if [[ "$out" == *"$needle"* ]]; then
         printf '  ok   %s\n' "$label"
-        pass=$((pass + 1))
+        echo $(($(cat "$TEST_TMPDIR/pass") + 1)) > "$TEST_TMPDIR/pass"
     else
         printf '  FAIL %s\n       attendu : %s\n       obtenu  : %s\n' \
             "$label" "$needle" "$out"
-        fail=$((fail + 1))
+        echo $(($(cat "$TEST_TMPDIR/fail") + 1)) > "$TEST_TMPDIR/fail"
     fi
 }
 
@@ -31,11 +36,11 @@ assert_equals() {
     out=$(strip_ansi)
     if [[ "$out" == "$needle" ]]; then
         printf '  ok   %s\n' "$label"
-        pass=$((pass + 1))
+        echo $(($(cat "$TEST_TMPDIR/pass") + 1)) > "$TEST_TMPDIR/pass"
     else
         printf '  FAIL %s\n       attendu : %s\n       obtenu  : %s\n' \
             "$label" "$needle" "$out"
-        fail=$((fail + 1))
+        echo $(($(cat "$TEST_TMPDIR/fail") + 1)) > "$TEST_TMPDIR/fail"
     fi
 }
 
@@ -63,5 +68,7 @@ printf '%s\n' '{"@timestamp":"2026-07-28T08:00:03+02:00","level":"INFO","message
     | "$FMT" | assert_contains "horodatage sans millisecondes" "08:00:03.000 INFO  Offset"
 
 echo
+pass=$(cat "$TEST_TMPDIR/pass")
+fail=$(cat "$TEST_TMPDIR/fail")
 printf '%d ok, %d echec(s)\n' "$pass" "$fail"
 [[ $fail -eq 0 ]]

--- a/scripts/tests/k9s-log-fmt.test.sh
+++ b/scripts/tests/k9s-log-fmt.test.sh
@@ -132,6 +132,27 @@ printf '%s\n' '{"level":"ERROR","logger_name":"com.Foo","message":"Boom","stack_
     | assert_equals "stack avec newline final : pas de ligne parasite" "3"
 
 echo
+echo "== champs extra (MDC) =="
+
+printf '%s\n' '{"level":"WARN","thread_name":"main","logger_name":"com.Cleanup","message":"3 orphelins","http.status":503,"retry":2}' \
+    | "$FMT" | assert_contains "champs extra en cle=valeur" "http.status=503  retry=2"
+
+printf '%s\n' '{"level":"WARN","thread_name":"main","logger_name":"com.Cleanup","message":"3 orphelins","retry":2}' \
+    | "$FMT" | assert_contains "2e ligne alignee sous le message" \
+    "                                        retry=2"
+
+printf '%s\n' '{"level":"INFO","message":"x","trace_id":"4bf92f35","span_id":"00f067aa","trace_flags":"01"}' \
+    | "$FMT" | assert_equals "trace_id, span_id et trace_flags masques" \
+    "             INFO  x"
+
+printf '%s\n' '{"level":"INFO","message":"x","nested":{"a":1}}' \
+    | "$FMT" | assert_contains "valeur structuree serialisee" 'nested={"a":1}'
+
+printf '%s\n' '{"level":"ERROR","message":"Boom","stack_trace":"java.lang.Error: Boom","retry":2}' \
+    | "$FMT" | strip_ansi | wc -l | tr -d ' ' \
+    | assert_equals "extras et stack : 3 lignes" "3"
+
+echo
 pass=$(cat "$TEST_TMPDIR/pass")
 fail=$(cat "$TEST_TMPDIR/fail")
 printf '%d ok, %d echec(s)\n' "$pass" "$fail"

--- a/scripts/tests/k9s-log-fmt.test.sh
+++ b/scripts/tests/k9s-log-fmt.test.sh
@@ -76,7 +76,7 @@ printf '%s\n' '{"@timestamp":"2026-07-28T08:00:00.123Z","level":"INFO","thread_n
 
 printf '%s\n' '{"level":"DEBUG","logger_name":"com.boulanger.foo.bar.baz.qux.EnormousServiceImplementation","message":"x"}' \
     | "$FMT" | assert_contains "logger de plus de 36 caracteres abrege" \
-    "c.b.f.b.b.q.EnormousServiceImplementation - x"
+    "…b.b.q.EnormousServiceImplementation - x"
 
 printf '%s\n' '{"level":"TRACE","thread_name":"http-nio-8080-exec-with-a-very-long-name","logger_name":"com.Pool","message":"x"}' \
     | "$FMT" | assert_contains "thread de plus de 20 caracteres tronque" \
@@ -93,6 +93,10 @@ printf '%s\n' '{"level":"INFO","thread_name":"main","message":"Sans logger"}' \
 printf '%s\n' '{"level":"INFO","message":"Ni thread ni logger"}' \
     | "$FMT" | assert_contains "thread et logger absents : pas de tiret orphelin" \
     "INFO  Ni thread ni logger"
+
+printf '%s\n' '{"level":"DEBUG","logger_name":"UneClasseSansAucunPointDontLeNomDepasseTrenteSixCaracteres","message":"x"}' \
+    | "$FMT" | assert_contains "logger sans point de plus de 36 caracteres tronque" \
+    "…DontLeNomDepasseTrenteSixCaracteres - x"
 
 echo
 pass=$(cat "$TEST_TMPDIR/pass")

--- a/scripts/tests/k9s-log-fmt.test.sh
+++ b/scripts/tests/k9s-log-fmt.test.sh
@@ -199,6 +199,23 @@ printf '%s\n' $'col1\tcol2 texte brut' | "$FMT" --pairs | cut -f2- \
     | assert_equals "texte brut avec tabulation : source intacte" $'col1\tcol2 texte brut'
 
 echo
+echo "== viewer (repli sans fzf) =="
+
+VIEW="$ROOT/scripts/k9s-log-view.sh"
+
+# PATH vide de fzf : le viewer doit se rabattre sur un affichage simple et
+# n afficher que le premier champ. LESS=-FX evite d ouvrir un pager interactif.
+printf '%s\n' '{"level":"INFO","message":"Bonjour"}' \
+    | "$FMT" --pairs \
+    | env PATH="/usr/bin:/bin" LESS="-FX" "$VIEW" \
+    | assert_contains "repli sans fzf : premier champ affiche" "INFO  Bonjour"
+
+printf '%s\n' '{"level":"INFO","message":"Bonjour"}' \
+    | "$FMT" --pairs \
+    | env PATH="/usr/bin:/bin" LESS="-FX" "$VIEW" \
+    | assert_equals "repli sans fzf : JSON source masque" "             INFO  Bonjour"
+
+echo
 pass=$(cat "$TEST_TMPDIR/pass")
 fail=$(cat "$TEST_TMPDIR/fail")
 printf '%d ok, %d echec(s)\n' "$pass" "$fail"

--- a/web/docs/ROADMAP.md
+++ b/web/docs/ROADMAP.md
@@ -24,7 +24,7 @@
 | 6 | Piste A — productivité shell (×7) | v4.x | feat | 💡 idées | non |
 | 7 | Piste B — onboarding / DX (×3) | v4.x | feat | 💡 idées | non |
 | 8 | Piste D — méta / écosystème (×2) | v4.x | feat | 💡 idées | non |
-| 9 | Tests e2e en moteur de règles (pilotés par YAML) | v4.x | test | 💡 idée — à brainstormer | non |
+| 9 | Adoption de l'outil e2e (projet distinct) | v4.x | test | 🧠 cadré — dépend de l'incrément 2 de l'outil | non |
 
 ### Détail des pistes features (1 ligne = 1 release)
 - **A — productivité** : command-not-found intelligent · widgets fzf (gco / process / env) · marque-pages de répertoires · `web_search` · `copypath`/`copyfile`/`copybuffer` · `alias-finder` · `bgnotify` (notif commandes longues)
@@ -60,7 +60,7 @@ expect:
 
 Les briques intéressantes à transposer : les **fakes pilotés par règles de `match`** (avec catch-all explicite pour détecter les appels non prévus), les **invariants nommés et réutilisables** entre cas, le **poids par cas**, et la séparation `case.rs` / `harness.rs` / `runner.rs` / `report.rs`.
 
-Transposition à concevoir pour zanvil : les fakes porteraient sur les binaires externes (`kubectl`, `git`, `glab`, `k9s`) injectés en tête de `PATH` ; les attentes sur le code de sortie, stdout/stderr, et les effets de bord fichiers. Harnais en Rust dans `cli/` (le binaire `zanvil` existe déjà) ou en zsh — à arbitrer. Fournirait au passage un vrai socle aux fixtures introduites par la spec du viewer de logs k9s.
+Ce que l'adoption demandera à zanvil, une fois l'outil disponible : les fakes portent sur les binaires externes (`git` 221 appels, `kubectl` 87, `fzf` 70, `jq` 65, `docker` 52, `sops` 44, `k9s` 36) injectés en tête de `PATH`, et les attentes sur le code de sortie, stdout/stderr, les fichiers écrits et le journal des appels sortants. L'isolation par `HOME` temporaire suffit — vérifié : seuls 4 chemins absolus ne dérivent pas de `$HOME` dans `modules/` et `core/`, et le dépôt ne contient qu'un seul `rm -rf`, dans un alias npm. Le harnais ne sera pas écrit ici : cet arbitrage est tranché dans le document de lancement de l'outil. Premier cas visé, parce qu'il attrape une régression réellement survenue : `kube_k9s_setup` ne doit laisser aucune variable non résolue dans le fichier déployé.
 
 ## ✅ v4.0.0 — Rename technique (LIVRÉ)
 

--- a/web/docs/ROADMAP.md
+++ b/web/docs/ROADMAP.md
@@ -37,6 +37,8 @@ Le projet n'a aucun harnais de test (shellspec écarté) : chaque fonction est v
 
 Modèle à reprendre : **`~/work/misc/armadai`, `tests/e2e/`** — un cas = un fichier YAML, un harnais qui les exécute et produit un rapport.
 
+> **Cadrage fait le 2026-07-28 :** l'outil ne sera pas construit dans zanvil. Il devient un **projet distinct**, réutilisable comme dépendance, dont armadai est le prototype et zanvil le second consommateur. Décisions d'architecture, découpage en incréments et critères de succès : `~/work/misc/e2e-harness/PROJECT-BRIEF.md` (dossier au nom provisoire). L'entrée #9 se réduit donc à « zanvil adopte cet outil », ce qui dépend de son incrément 2.
+
 ```yaml
 name: direct
 weight: 5

--- a/web/docs/ROADMAP.md
+++ b/web/docs/ROADMAP.md
@@ -24,11 +24,41 @@
 | 6 | Piste A — productivité shell (×7) | v4.x | feat | 💡 idées | non |
 | 7 | Piste B — onboarding / DX (×3) | v4.x | feat | 💡 idées | non |
 | 8 | Piste D — méta / écosystème (×2) | v4.x | feat | 💡 idées | non |
+| 9 | Tests e2e en moteur de règles (pilotés par YAML) | v4.x | test | 💡 idée — à brainstormer | non |
 
 ### Détail des pistes features (1 ligne = 1 release)
 - **A — productivité** : command-not-found intelligent · widgets fzf (gco / process / env) · marque-pages de répertoires · `web_search` · `copypath`/`copyfile`/`copybuffer` · `alias-finder` · `bgnotify` (notif commandes longues)
 - **B — onboarding/DX** : wizard `zanvil init` · dashboard / MOTD · `zanvil profile` (breakdown startup)
 - **D — méta** : registre de modules + `module install` · profils/presets (work / perso / minimal)
+
+## Tests e2e en moteur de règles (#9)
+
+Le projet n'a aucun harnais de test (shellspec écarté) : chaque fonction est vérifiée à la main, et les scripts qui dépendent d'un cluster ou d'un remote ne sont pas testables du tout.
+
+Modèle à reprendre : **`~/work/misc/armadai`, `tests/e2e/`** — un cas = un fichier YAML, un harnais qui les exécute et produit un rapport.
+
+```yaml
+name: direct
+weight: 5
+setup:
+  pattern: direct
+  flags: ["--json"]
+fake:
+  rules:
+    - match: { agent: t-writer }
+      respond: "done"
+    - match: {}                     # catch-all : ne doit jamais être atteint
+      respond: "unexpected"
+expect:
+  exit_code: 0
+  events: [...]
+  event_counts: { agent_start: 1 }
+  invariants: [agent_start_end_symmetric, no_orphan_events]
+```
+
+Les briques intéressantes à transposer : les **fakes pilotés par règles de `match`** (avec catch-all explicite pour détecter les appels non prévus), les **invariants nommés et réutilisables** entre cas, le **poids par cas**, et la séparation `case.rs` / `harness.rs` / `runner.rs` / `report.rs`.
+
+Transposition à concevoir pour zanvil : les fakes porteraient sur les binaires externes (`kubectl`, `git`, `glab`, `k9s`) injectés en tête de `PATH` ; les attentes sur le code de sortie, stdout/stderr, et les effets de bord fichiers. Harnais en Rust dans `cli/` (le binaire `zanvil` existe déjà) ou en zsh — à arbitrer. Fournirait au passage un vrai socle aux fixtures introduites par la spec du viewer de logs k9s.
 
 ## ✅ v4.0.0 — Rename technique (LIVRÉ)
 

--- a/web/docs/superpowers/plans/2026-07-28-k9s-log-viewer.md
+++ b/web/docs/superpowers/plans/2026-07-28-k9s-log-viewer.md
@@ -1,0 +1,982 @@
+# k9s — rendu logback et explorateur de logs interactif : plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Donner aux plugins de logs k9s un rendu calqué sur une console logback (thread, logger, stack trace lisible) et un second mode interactif permettant de filtrer, rechercher et copier les événements.
+
+**Architecture:** Deux scripts aux responsabilités disjointes. `scripts/k9s-log-fmt.sh` reste un filtre pur `stdin → stdout` piloté par un unique filtre `jq` ; son flag `--pairs` garantit une ligne de sortie par ligne d'entrée, suivie d'un TAB et du JSON source. `scripts/k9s-log-view.sh` consomme ce format et pilote `fzf`, sans rien connaître du format des logs. Deux plugins k9s exposent les deux modes : `Shift-L` (statique, `less`) et `Ctrl-L` (interactif, `fzf`).
+
+**Tech Stack:** bash, jq (filtre unique, codes ANSI embarqués), fzf, less, pbcopy/wl-copy/xclip, zsh (module kube), YAML (plugins k9s).
+
+## Global Constraints
+
+- **Spec de référence :** `web/docs/superpowers/specs/2026-07-28-k9s-log-viewer-design.md`. Toute divergence doit être remontée, pas décidée en silence.
+- **Aucun caractère ESC littéral dans les sources.** Les couleurs sont produites par `jq` via l'échappement `\u001b` (validé sur jq 1.7). Le fichier actuel contient des ESC bruts invisibles : ils disparaissent en Task 1.
+- **Le rendu ne dépend jamais de la détection d'un TTY.** k9s exécute le plugin derrière deux pipes ; toute logique `[[ -t 1 ]]` casserait les couleurs.
+- **`k9s-log-fmt.sh` reste un filtre pur** : pas de fichier temporaire, pas de lecture de `/dev/tty`, pas d'appel réseau. C'est ce qui le rend testable et réutilisable par `klog`.
+- **Contrat `--pairs` :** le nombre de lignes en sortie est **strictement égal** au nombre de lignes en entrée. Tout le mode interactif en dépend (`fzf` indexe par ligne).
+- **Largeurs :** niveau complété à 5 caractères ; thread tronqué à 20 avec `…` ; logger abrégé à 36 selon la règle `%logger{36}`. **Ni le thread ni le logger ne sont complétés** à largeur fixe.
+- **Une ligne d'entrée non-JSON est réémise à l'identique**, sans préfixe ni couleur (comportement actuel, à préserver).
+- **Champs masqués :** `trace_id`, `span_id`, `trace_flags` ne sont jamais affichés dans la ligne rendue.
+- **Style projet :** commentaire d'en-tête en français dans chaque script, `set -uo pipefail`, pas de `_ui_*` dans les scripts de `scripts/` (ils tournent hors zsh, donc hors système UI).
+- **Écart assumé par rapport à la spec :** ce plan ajoute `scripts/tests/k9s-log-fmt.test.sh`, un vérificateur autonome d'une soixantaine de lignes sans dépendance. La spec ne prévoyait qu'une vérification manuelle par fixtures ; le cycle rouge/vert de ce plan a besoin d'un moyen répétable de constater l'échec. Ce n'est pas un framework de test, et cela ne préempte pas le backlog #9 (harnais e2e piloté par YAML).
+
+---
+
+## File Structure
+
+| Fichier | Responsabilité |
+|---------|----------------|
+| `scripts/k9s-log-fmt.sh` *(modifié)* | Filtre pur. Parse les arguments, porte le filtre `jq` unique. Seul endroit qui connaît le format des logs. |
+| `scripts/k9s-log-view.sh` *(créé)* | Viewer interactif. Résout le presse-papier, construit les options `fzf`, exécute. Ignore tout du format des logs. |
+| `scripts/tests/k9s-log-fmt.test.sh` *(créé)* | Vérificateur autonome : cas inline, assertions sur la sortie débarrassée des ANSI, code de sortie non nul en cas d'échec. |
+| `config/k9s/fixtures/logs-sample.jsonl` *(créé)* | Fixtures rejouables sans cluster : inspection visuelle et contrôle du contrat `--pairs`. |
+| `config/k9s/plugins.yaml` *(modifié)* | Ajoute `log-view-pod` et `log-view-container` sur `Ctrl-L`. Corrige la mention obsolète de `humanlog`. |
+| `modules/kube/kube_config.zsh` *(modifié)* | Une ligne d'aide dans `kube_help`. |
+
+`k9s-log-fmt.sh` grossit d'environ 40 à 110 lignes : il reste sous le seuil où un découpage se justifierait, et son filtre `jq` forme un tout indissociable.
+
+---
+
+## Task 1 : Socle de test et rendu de base
+
+Remplace le filtre `jq` actuel par une structure à fonctions nommées, avec horodatage court et niveau complété. Le thread et le logger arrivent en Task 2.
+
+**Files:**
+- Create: `scripts/tests/k9s-log-fmt.test.sh`
+- Create: `config/k9s/fixtures/logs-sample.jsonl`
+- Modify: `scripts/k9s-log-fmt.sh` (réécriture du filtre, lignes 1-39)
+
+**Interfaces:**
+- Produces: `scripts/k9s-log-fmt.sh` lit stdin, écrit stdout, code de sortie 0. `scripts/tests/k9s-log-fmt.test.sh` sort 0 si tous les cas passent, 1 sinon. Fonctions `jq` disponibles pour les tâches suivantes : `c($code; $s)`, `pad($n)`, `trunc($n)`, `hhmmss`.
+
+- [ ] **Step 1 : Écrire le vérificateur qui échoue**
+
+Créer `scripts/tests/k9s-log-fmt.test.sh` :
+
+```bash
+#!/usr/bin/env bash
+# Verifie le rendu de k9s-log-fmt.sh. Autonome, sans dependance.
+# Usage : scripts/tests/k9s-log-fmt.test.sh
+set -uo pipefail
+
+ROOT="${ZANVIL_DIR:-$HOME/.zanvil}"
+FMT="$ROOT/scripts/k9s-log-fmt.sh"
+FIXTURES="$ROOT/config/k9s/fixtures/logs-sample.jsonl"
+pass=0 fail=0
+
+# Retire les codes ANSI : les assertions portent sur le texte, pas les couleurs.
+strip_ansi() { sed $'s/\033\\[[0-9;]*m//g'; }
+
+# assert_contains <libelle> <attendu>, entree sur stdin
+assert_contains() {
+    local label="$1" needle="$2" out
+    out=$(strip_ansi)
+    if [[ "$out" == *"$needle"* ]]; then
+        printf '  ok   %s\n' "$label"
+        pass=$((pass + 1))
+    else
+        printf '  FAIL %s\n       attendu : %s\n       obtenu  : %s\n' \
+            "$label" "$needle" "$out"
+        fail=$((fail + 1))
+    fi
+}
+
+# assert_equals <libelle> <attendu>, entree sur stdin
+assert_equals() {
+    local label="$1" needle="$2" out
+    out=$(strip_ansi)
+    if [[ "$out" == "$needle" ]]; then
+        printf '  ok   %s\n' "$label"
+        pass=$((pass + 1))
+    else
+        printf '  FAIL %s\n       attendu : %s\n       obtenu  : %s\n' \
+            "$label" "$needle" "$out"
+        fail=$((fail + 1))
+    fi
+}
+
+echo "== rendu de base =="
+
+printf '%s\n' '{"@timestamp":"2026-07-28T08:00:00.123Z","level":"INFO","message":"Demarrage termine"}' \
+    | "$FMT" | assert_contains "horodatage court + niveau complete" "08:00:00.123 INFO  Demarrage termine"
+
+printf '%s\n' '{"@timestamp":"2026-07-28T08:00:01.456Z","level":"error","message":"Boom"}' \
+    | "$FMT" | assert_contains "niveau en majuscules" "08:00:01.456 ERROR Boom"
+
+printf '%s\n' '{"@timestamp":"2026-07-28T08:00:02.000Z","severity":"WARN","msg":"Alerte"}' \
+    | "$FMT" | assert_contains "champs severity et msg reconnus" "08:00:02.000 WARN  Alerte"
+
+printf '%s\n' '{"message":"Sans horodatage"}' \
+    | "$FMT" | assert_contains "niveau par defaut INFO, colonne heure vide" "             INFO  Sans horodatage"
+
+printf '%s\n' 'ligne de texte brut' \
+    | "$FMT" | assert_equals "texte brut reemis a l identique" "ligne de texte brut"
+
+printf '%s\n' '{"level":"INFO","message":"accolade manquante"' \
+    | "$FMT" | assert_equals "JSON malforme traite comme du texte brut" '{"level":"INFO","message":"accolade manquante"'
+
+printf '%s\n' '{"@timestamp":"2026-07-28T08:00:03+02:00","level":"INFO","message":"Offset"}' \
+    | "$FMT" | assert_contains "horodatage sans millisecondes" "08:00:03.000 INFO  Offset"
+
+echo
+printf '%d ok, %d echec(s)\n' "$pass" "$fail"
+[[ $fail -eq 0 ]]
+```
+
+Rendre exécutable : `chmod +x scripts/tests/k9s-log-fmt.test.sh`
+
+- [ ] **Step 2 : Lancer le vérificateur pour constater l'échec**
+
+Run: `scripts/tests/k9s-log-fmt.test.sh`
+
+Expected: FAIL sur les 6 premiers cas. Le format actuel produit `2026-07-28T08:00:00.123Z |INFO| Demarrage termine` — horodatage complet, niveau encadré de barres. Le cas « texte brut réémis à l'identique » passe déjà (comportement existant à ne pas casser).
+
+- [ ] **Step 3 : Réécrire le filtre**
+
+Remplacer intégralement le contenu de `scripts/k9s-log-fmt.sh` :
+
+```bash
+#!/usr/bin/env bash
+# k9s-log-fmt.sh — rend des logs JSON au format d'une console logback.
+# Filtre pur stdin -> stdout : pas d'etat, pas de fichier temporaire.
+# Les codes ANSI sont embarques par jq (\u001b) : le rendu ne depend pas d'un TTY,
+# ce qui est necessaire puisque k9s execute le plugin derriere deux pipes.
+#
+# Usage : kubectl logs ... | k9s-log-fmt.sh [--pairs]
+#   (defaut)  rendu multi-ligne : stack trace indentee, champs extra sur 2e ligne
+#   --pairs   une ligne par entree : texte, TAB, JSON source (pour k9s-log-view.sh)
+set -uo pipefail
+
+pairs=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pairs) pairs=true; shift ;;
+        -h|--help)
+            sed -n '2,9p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0 ;;
+        *)
+            printf 'k9s-log-fmt.sh: option inconnue : %s\n' "$1" >&2
+            exit 2 ;;
+    esac
+done
+
+JQ_FILTER='
+# --- helpers -----------------------------------------------------------------
+def c($code; $s): "\u001b[" + $code + "m" + $s + "\u001b[0m";
+def pad($n): if length >= $n then . else . + (" " * ($n - length)) end;
+def trunc($n): if length > $n then .[0:$n-1] + "…" else . end;
+
+# "2026-07-28T08:00:00.123456Z" -> "08:00:00.123". Chaine vide -> 12 espaces,
+# pour que la colonne du niveau reste alignee.
+def hhmmss:
+  if . == "" then "            "
+  else (if test("T") then split("T")[1] else . end) as $t
+    | ($t | sub("(Z|[+-][0-9:]+)$"; "")) as $u
+    | (if ($u | test("\\."))
+       then (($u | split("."))[0] + "." + (($u | split("."))[1][0:3]))
+       else $u + ".000" end)
+  end;
+
+def level_color:
+  if . == "ERROR" or . == "FATAL" or . == "CRITICAL" then "1;31"
+  elif . == "WARN" or . == "WARNING" then "1;33"
+  elif . == "DEBUG" or . == "TRACE" then "36"
+  else "1;32" end;
+
+# --- rendu -------------------------------------------------------------------
+. as $line |
+try (
+  $line | fromjson |
+
+  (.level // .severity // .lvl // "INFO" | ascii_upcase) as $lvl |
+  (.["@timestamp"] // .timestamp // .time // "" | tostring | hhmmss) as $hh |
+  (.message // .msg // "" | tostring) as $msg |
+
+  c("2"; $hh) + " " + c($lvl | level_color; $lvl | pad(5)) + " " + $msg
+
+) catch $line
+'
+
+jq -Rr --argjson pairs "$pairs" "$JQ_FILTER"
+```
+
+Note : `--argjson pairs` est déjà passé mais pas encore consommé par le filtre — Task 5 s'en sert. `jq` accepte un argument non utilisé sans broncher.
+
+- [ ] **Step 4 : Lancer le vérificateur pour constater le succès**
+
+Run: `scripts/tests/k9s-log-fmt.test.sh`
+Expected: `7 ok, 0 echec(s)`, code de sortie 0.
+
+- [ ] **Step 5 : Créer les fixtures**
+
+Créer `config/k9s/fixtures/logs-sample.jsonl`. **Une entrée par ligne, pas de ligne vide, le fichier se termine par un saut de ligne** (le contrôle de comptage de Task 5 en dépend) :
+
+```
+{"@timestamp":"2026-07-28T08:00:00.123Z","level":"INFO","thread_name":"main","logger_name":"com.boulanger.foo.FooService","message":"Demarrage termine"}
+{"@timestamp":"2026-07-28T08:00:01.456Z","level":"ERROR","thread_name":"http-nio-8080-exec-2","logger_name":"com.boulanger.foo.BarClient","message":"Timeout amont","stack_trace":"java.lang.IllegalStateException: Timeout amont\n\tat com.boulanger.foo.BarClient.send(BarClient.java:17)\n\tat com.boulanger.foo.FooService.call(FooService.java:42)\n\t... 24 more"}
+{"@timestamp":"2026-07-28T08:00:02.001Z","level":"WARN","thread_name":"scheduling-1","logger_name":"com.boulanger.foo.Cleanup","message":"3 orphelins ignores","http.status":503,"retry":2}
+{"@timestamp":"2026-07-28T08:00:03.100Z","level":"DEBUG","thread_name":"main","logger_name":"com.boulanger.foo.bar.baz.qux.EnormousServiceImplementation","message":"Logger de plus de 36 caracteres"}
+{"@timestamp":"2026-07-28T08:00:04.200Z","level":"TRACE","thread_name":"http-nio-8080-exec-with-a-very-long-thread-name","logger_name":"com.boulanger.foo.Pool","message":"Thread de plus de 20 caracteres"}
+{"@timestamp":"2026-07-28T08:00:05.300Z","message":"Sans niveau ni thread ni logger"}
+{"@timestamp":"2026-07-28T08:00:06.400Z","severity":"WARN","msg":"Champs severity et msg","trace_id":"4bf92f3577b34da6a3ce929d0e0e4736","span_id":"00f067aa0ba902b7"}
+{"@timestamp":"2026-07-28T08:00:07.500Z","level":"INFO","thread_name":"main","logger_name":"com.boulanger.foo.Report","message":"Ligne 1\nLigne 2\nLigne 3"}
+Log applicatif en texte brut, emis par un conteneur sidecar
+{"@timestamp":"2026-07-28T08:00:08.600Z","level":"INFO","message":"accolade manquante"
+```
+
+- [ ] **Step 6 : Vérifier les fixtures à l'œil**
+
+Run: `scripts/k9s-log-fmt.sh < config/k9s/fixtures/logs-sample.jsonl`
+
+Expected: 10 lignes, horodatages courts, niveaux colorés et alignés sur 5 caractères. Le thread, le logger, la stack trace et les champs extra ne sont **pas encore rendus** — c'est normal, Tasks 2 à 4 les ajoutent. La ligne de texte brut et la ligne malformée ressortent à l'identique.
+
+- [ ] **Step 7 : Commit**
+
+```bash
+git add scripts/k9s-log-fmt.sh scripts/tests/k9s-log-fmt.test.sh config/k9s/fixtures/logs-sample.jsonl
+git commit -m "test(k9s): verificateur de rendu + fixtures de logs
+
+feat(k9s): rendu logback — horodatage court et niveau complete
+
+Les codes ANSI passent d'ESC litteraux (invisibles a la lecture) a
+l'echappement \\u001b de jq."
+```
+
+---
+
+## Task 2 : Thread et logger
+
+**Files:**
+- Modify: `scripts/k9s-log-fmt.sh` (filtre `jq` : ajout de `abbrev_logger`, construction du préfixe)
+- Modify: `scripts/tests/k9s-log-fmt.test.sh` (nouvelle section de cas)
+
+**Interfaces:**
+- Consumes: `c`, `pad`, `trunc`, `hhmmss`, `level_color` (Task 1).
+- Produces: fonction `jq` `abbrev_logger($max)`. Variables du filtre disponibles pour les tâches suivantes : `$pre_plain` (préfixe sans ANSI, sert à calculer l'indentation en Task 4) et `$head` (première ligne colorée, complète).
+
+- [ ] **Step 1 : Écrire les cas qui échouent**
+
+Ajouter à la fin de `scripts/tests/k9s-log-fmt.test.sh`, **avant** le bloc `echo` / `printf '%d ok` final :
+
+```bash
+echo
+echo "== thread et logger =="
+
+printf '%s\n' '{"@timestamp":"2026-07-28T08:00:00.123Z","level":"INFO","thread_name":"main","logger_name":"com.boulanger.foo.FooService","message":"Demarrage termine"}' \
+    | "$FMT" | assert_contains "thread entre crochets, logger, separateur" \
+    "08:00:00.123 INFO  [main] com.boulanger.foo.FooService - Demarrage termine"
+
+printf '%s\n' '{"level":"DEBUG","logger_name":"com.boulanger.foo.bar.baz.qux.EnormousServiceImplementation","message":"x"}' \
+    | "$FMT" | assert_contains "logger de plus de 36 caracteres abrege" \
+    "c.b.f.b.b.q.EnormousServiceImplementation - x"
+
+printf '%s\n' '{"level":"TRACE","thread_name":"http-nio-8080-exec-with-a-very-long-name","logger_name":"com.Pool","message":"x"}' \
+    | "$FMT" | assert_contains "thread de plus de 20 caracteres tronque" \
+    "[http-nio-8080-exec-…] com.Pool - x"
+
+printf '%s\n' '{"level":"INFO","logger_name":"com.boulanger.foo.FooService","message":"Sans thread"}' \
+    | "$FMT" | assert_contains "thread absent : pas de crochets vides" \
+    "INFO  com.boulanger.foo.FooService - Sans thread"
+
+printf '%s\n' '{"level":"INFO","thread_name":"main","message":"Sans logger"}' \
+    | "$FMT" | assert_contains "logger absent : thread conserve" \
+    "INFO  [main] - Sans logger"
+
+printf '%s\n' '{"level":"INFO","message":"Ni thread ni logger"}' \
+    | "$FMT" | assert_contains "thread et logger absents : pas de tiret orphelin" \
+    "INFO  Ni thread ni logger"
+```
+
+- [ ] **Step 2 : Lancer le vérificateur pour constater l'échec**
+
+Run: `scripts/tests/k9s-log-fmt.test.sh`
+Expected: les 7 cas de Task 1 passent, les 5 premiers nouveaux cas échouent (thread et logger absents du rendu). Le dernier — « pas de tiret orphelin » — passe déjà, puisque rien n'est encore rendu : c'est un cas de non-régression pour la suite.
+
+- [ ] **Step 3 : Ajouter l'abréviation et le préfixe**
+
+Dans `JQ_FILTER`, ajouter la fonction après `def trunc` :
+
+```jq
+# Regle logback %logger{36} : au-dela de $max caracteres, chaque segment de
+# package est reduit a son initiale, la classe finale etant preservee.
+# "com.boulanger.foo.FooService" -> "c.b.f.FooService"
+def abbrev_logger($max):
+  if length <= $max then .
+  else (split(".")) as $p
+    | (if ($p | length) > 1
+       then (($p[0:-1] | map(.[0:1])) + [$p[-1]]) | join(".")
+       else . end) as $s
+    | if ($s | length) <= $max then $s else "…" + $s[-($max-1):] end
+  end;
+```
+
+Puis remplacer le bloc `# --- rendu` par :
+
+```jq
+. as $line |
+try (
+  $line | fromjson |
+
+  (.level // .severity // .lvl // "INFO" | ascii_upcase) as $lvl |
+  (.["@timestamp"] // .timestamp // .time // "" | tostring | hhmmss) as $hh |
+  (.message // .msg // "" | tostring) as $msg |
+  (.thread_name // "" | tostring) as $thr |
+  (.logger_name // "" | tostring) as $log |
+
+  (if $thr == "" then "" else "[" + ($thr | trunc(20)) + "] " end) as $thr_plain |
+  (if $log == "" then "" else ($log | abbrev_logger(36)) + " " end) as $log_plain |
+  (if $thr == "" and $log == "" then "" else "- " end) as $sep |
+
+  # Prefixe sans ANSI : sert a calculer l indentation de la 2e ligne (Task 4).
+  ($hh + " " + ($lvl | pad(5)) + " " + $thr_plain + $log_plain + $sep) as $pre_plain |
+
+  (c("2"; $hh) + " " + c($lvl | level_color; $lvl | pad(5)) + " "
+   + (if $thr == "" then "" else c("2"; "[" + ($thr | trunc(20)) + "]") + " " end)
+   + (if $log == "" then "" else c("36"; ($log | abbrev_logger(36))) + " " end)
+   + $sep + $msg) as $head |
+
+  $head
+
+) catch $line
+```
+
+- [ ] **Step 4 : Lancer le vérificateur pour constater le succès**
+
+Run: `scripts/tests/k9s-log-fmt.test.sh`
+Expected: `13 ok, 0 echec(s)`.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add scripts/k9s-log-fmt.sh scripts/tests/k9s-log-fmt.test.sh
+git commit -m "feat(k9s): rendu logback — thread et logger abrege (%logger{36})"
+```
+
+---
+
+## Task 3 : Stack trace
+
+**Files:**
+- Modify: `scripts/k9s-log-fmt.sh` (filtre `jq` : champ stack, rendu multi-ligne)
+- Modify: `scripts/tests/k9s-log-fmt.test.sh` (nouvelle section de cas)
+
+**Interfaces:**
+- Consumes: `$head`, `$pre_plain` (Task 2).
+- Produces: variable `$st` (stack trace brute, `""` si absente) et fonction `jq` `short_exception`, consommées par Task 5.
+
+- [ ] **Step 1 : Écrire les cas qui échouent**
+
+Ajouter à `scripts/tests/k9s-log-fmt.test.sh`, avant le bloc final :
+
+```bash
+echo
+echo "== stack trace =="
+
+STACK_JSON='{"level":"ERROR","logger_name":"com.Foo","message":"Boom","stack_trace":"java.lang.IllegalStateException: Boom\n\tat com.Foo.bar(Foo.java:17)\n\t... 24 more"}'
+
+printf '%s\n' "$STACK_JSON" \
+    | "$FMT" | assert_contains "premiere ligne de la stack indentee de 2 espaces" \
+    "  java.lang.IllegalStateException: Boom"
+
+printf '%s\n' "$STACK_JSON" \
+    | "$FMT" | assert_contains "cadres indentes, tabulations converties" \
+    "      at com.Foo.bar(Foo.java:17)"
+
+printf '%s\n' "$STACK_JSON" \
+    | "$FMT" | assert_contains "dernier cadre" "      ... 24 more"
+
+printf '%s\n' "$STACK_JSON" | "$FMT" | strip_ansi | wc -l | tr -d ' ' \
+    | assert_equals "un evenement avec stack occupe 4 lignes" "4"
+
+printf '%s\n' '{"level":"ERROR","message":"Boom","exception":"java.lang.NullPointerException: null"}' \
+    | "$FMT" | assert_contains "champ exception reconnu" "  java.lang.NullPointerException: null"
+
+printf '%s\n' '{"level":"ERROR","message":"Boom","throwable":"java.io.IOException: broken pipe"}' \
+    | "$FMT" | assert_contains "champ throwable reconnu" "  java.io.IOException: broken pipe"
+
+printf '%s\n' '{"level":"INFO","message":"Rien a signaler"}' \
+    | "$FMT" | assert_equals "sans stack : une seule ligne" \
+    "             INFO  Rien a signaler"
+```
+
+Note : `assert_equals` reçoit ici la sortie de `wc -l`, pas celle du formatteur — `strip_ansi` s'y applique sans effet, ce qui est inoffensif.
+
+- [ ] **Step 2 : Lancer le vérificateur pour constater l'échec**
+
+Run: `scripts/tests/k9s-log-fmt.test.sh`
+Expected: les 6 premiers nouveaux cas échouent (la stack n'est pas rendue, le comptage donne `1` au lieu de `4`). Le dernier passe déjà.
+
+- [ ] **Step 3 : Rendre la stack trace**
+
+Dans `JQ_FILTER`, ajouter après `def abbrev_logger` :
+
+```jq
+# Nom court de l exception, extrait de la premiere ligne de la stack.
+# "java.lang.IllegalStateException: Boom\n\tat ..." -> "IllegalStateException"
+def short_exception:
+  split("\n")[0] | split(":")[0] | split(".") | last;
+```
+
+Puis, dans le bloc `try`, ajouter la capture du champ après `$log` :
+
+```jq
+  (.stack_trace // .exception // .stacktrace // .throwable // "" | tostring) as $st |
+```
+
+Et remplacer la dernière expression `$head` par :
+
+```jq
+  $head
+  + (if $st == "" then ""
+     else "\n" + c("2";
+       ($st | gsub("\t"; "    ") | split("\n") | map("  " + .) | join("\n")))
+     end)
+```
+
+- [ ] **Step 4 : Lancer le vérificateur pour constater le succès**
+
+Run: `scripts/tests/k9s-log-fmt.test.sh`
+Expected: `20 ok, 0 echec(s)`.
+
+- [ ] **Step 5 : Vérifier le rendu sur les fixtures**
+
+Run: `scripts/k9s-log-fmt.sh < config/k9s/fixtures/logs-sample.jsonl`
+Expected: l'entrée `ERROR` de la ligne 2 est suivie de 4 lignes indentées en gris.
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add scripts/k9s-log-fmt.sh scripts/tests/k9s-log-fmt.test.sh
+git commit -m "feat(k9s): rendu logback — stack trace restituee et indentee"
+```
+
+---
+
+## Task 4 : Champs extra (MDC)
+
+**Files:**
+- Modify: `scripts/k9s-log-fmt.sh` (filtre `jq` : extraction et rendu des champs restants)
+- Modify: `scripts/tests/k9s-log-fmt.test.sh` (nouvelle section de cas)
+
+**Interfaces:**
+- Consumes: `$head`, `$pre_plain`, `$st` (Tasks 2-3).
+- Produces: variable `$extra` (`"cle=valeur  cle=valeur"`, `""` si aucun), consommée par Task 5.
+
+- [ ] **Step 1 : Écrire les cas qui échouent**
+
+Ajouter à `scripts/tests/k9s-log-fmt.test.sh`, avant le bloc final :
+
+```bash
+echo
+echo "== champs extra (MDC) =="
+
+printf '%s\n' '{"level":"WARN","thread_name":"main","logger_name":"com.Cleanup","message":"3 orphelins","http.status":503,"retry":2}' \
+    | "$FMT" | assert_contains "champs extra en cle=valeur" "http.status=503  retry=2"
+
+printf '%s\n' '{"level":"WARN","thread_name":"main","logger_name":"com.Cleanup","message":"3 orphelins","retry":2}' \
+    | "$FMT" | assert_contains "2e ligne alignee sous le message" \
+    "                                        retry=2"
+
+printf '%s\n' '{"level":"INFO","message":"x","trace_id":"4bf92f35","span_id":"00f067aa","trace_flags":"01"}' \
+    | "$FMT" | assert_equals "trace_id, span_id et trace_flags masques" \
+    "             INFO  x"
+
+printf '%s\n' '{"level":"INFO","message":"x","nested":{"a":1}}' \
+    | "$FMT" | assert_contains "valeur structuree serialisee" 'nested={"a":1}'
+
+printf '%s\n' '{"level":"ERROR","message":"Boom","stack_trace":"java.lang.Error: Boom","retry":2}' \
+    | "$FMT" | strip_ansi | wc -l | tr -d ' ' \
+    | assert_equals "extras et stack : 3 lignes" "3"
+```
+
+Le deuxième cas fixe l'alignement attendu : préfixe `             WARN  [main] com.Cleanup - ` = 12 + 1 + 5 + 1 + 7 + 12 + 2 = 40 caractères, donc 40 espaces d'indentation.
+
+- [ ] **Step 2 : Lancer le vérificateur pour constater l'échec**
+
+Run: `scripts/tests/k9s-log-fmt.test.sh`
+Expected: cas 1, 2, 4 et 5 échouent. Le cas 3 (champs de traçage masqués) passe déjà, puisque aucun extra n'est rendu — il devient un garde-fou pour cette tâche.
+
+- [ ] **Step 3 : Rendre les champs extra**
+
+Dans le bloc `try`, ajouter après la capture de `$st` :
+
+```jq
+  (del(
+    .["@timestamp"], .timestamp, .time,
+    .level, .severity, .lvl,
+    .message, .msg,
+    .thread_name, .logger_name,
+    .stack_trace, .exception, .stacktrace, .throwable,
+    .trace_id, .span_id, .trace_flags
+   ) | to_entries
+     | map("\(.key)=\(if (.value | type) == "string" then .value else (.value | tojson) end)")
+     | join("  ")) as $extra |
+```
+
+Puis remplacer l'expression finale par :
+
+```jq
+  $head
+  + (if $extra == "" then ""
+     else "\n" + (" " * ($pre_plain | length)) + c("2"; $extra)
+     end)
+  + (if $st == "" then ""
+     else "\n" + c("2";
+       ($st | gsub("\t"; "    ") | split("\n") | map("  " + .) | join("\n")))
+     end)
+```
+
+L'ordre compte : les extras se placent juste sous le message, la stack trace ferme l'événement.
+
+- [ ] **Step 4 : Lancer le vérificateur pour constater le succès**
+
+Run: `scripts/tests/k9s-log-fmt.test.sh`
+Expected: `25 ok, 0 echec(s)`.
+
+- [ ] **Step 5 : Vérifier le rendu complet sur les fixtures**
+
+Run: `scripts/k9s-log-fmt.sh < config/k9s/fixtures/logs-sample.jsonl`
+
+Expected: le rendu correspond à l'exemple de la section « Format de rendu » de la spec. Contrôler en particulier que la ligne `WARN` porte `http.status=503  retry=2` aligné sous son message, et que la ligne avec `trace_id` / `span_id` n'affiche aucun extra.
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add scripts/k9s-log-fmt.sh scripts/tests/k9s-log-fmt.test.sh
+git commit -m "feat(k9s): rendu logback — champs MDC sur une 2e ligne alignee"
+```
+
+---
+
+## Task 5 : Mode `--pairs`
+
+**Files:**
+- Modify: `scripts/k9s-log-fmt.sh` (filtre `jq` : branche `$pairs`)
+- Modify: `scripts/tests/k9s-log-fmt.test.sh` (nouvelle section de cas)
+
+**Interfaces:**
+- Consumes: `$head`, `$extra`, `$st`, `short_exception`, `$line`, et l'argument `--argjson pairs` déjà passé en Task 1.
+- Produces: le format consommé par `k9s-log-view.sh` en Task 6 — `<texte rendu><TAB><json source>`, une ligne par entrée.
+
+- [ ] **Step 1 : Écrire les cas qui échouent**
+
+Ajouter à `scripts/tests/k9s-log-fmt.test.sh`, avant le bloc final :
+
+```bash
+echo
+echo "== mode --pairs =="
+
+PAIRS_JSON='{"@timestamp":"2026-07-28T08:00:01.456Z","level":"ERROR","thread_name":"main","logger_name":"com.Foo","message":"Boom","stack_trace":"java.lang.IllegalStateException: Boom\n\tat com.Foo.bar(Foo.java:17)","retry":2}'
+
+printf '%s\n' "$PAIRS_JSON" | "$FMT" --pairs | strip_ansi | wc -l | tr -d ' ' \
+    | assert_equals "un evenement avec stack et extras tient sur une ligne" "1"
+
+printf '%s\n' "$PAIRS_JSON" | "$FMT" --pairs | strip_ansi | cut -f1 \
+    | assert_contains "stack reduite au nom court de l exception" "⤷ IllegalStateException"
+
+printf '%s\n' "$PAIRS_JSON" | "$FMT" --pairs | strip_ansi | cut -f1 \
+    | assert_contains "extras concatenes en fin de ligne" "retry=2"
+
+printf '%s\n' "$PAIRS_JSON" | "$FMT" --pairs | cut -f2- \
+    | assert_equals "2e champ = JSON source intact" "$PAIRS_JSON"
+
+printf '%s\n' '{"level":"INFO","message":"Ligne 1\nLigne 2"}' | "$FMT" --pairs | strip_ansi | cut -f1 \
+    | assert_contains "retours a la ligne du message remplaces par un symbole" "Ligne 1↵Ligne 2"
+
+printf '%s\n' 'texte brut' | "$FMT" --pairs | assert_equals "texte brut duplique dans les deux champs" \
+    "$(printf 'texte brut\ttexte brut')"
+
+echo
+echo "== contrat --pairs sur les fixtures =="
+
+n_in=$(wc -l < "$FIXTURES" | tr -d ' ')
+n_out=$("$FMT" --pairs < "$FIXTURES" | wc -l | tr -d ' ')
+printf '%s\n' "$n_out" | assert_equals "$n_in ligne(s) en entree, autant en sortie" "$n_in"
+
+"$FMT" --pairs < "$FIXTURES" | awk -F'\t' '{print NF}' | sort -u | tr '\n' ' ' | sed 's/ $//' \
+    | assert_equals "chaque ligne porte exactement 2 champs" "2"
+
+printf '%s\n' '{"level":"INFO","message":"x"}' | "$FMT" --oops 2>/dev/null
+printf '%s\n' "$?" | assert_equals "option inconnue : code de sortie 2" "2"
+```
+
+- [ ] **Step 2 : Lancer le vérificateur pour constater l'échec**
+
+Run: `scripts/tests/k9s-log-fmt.test.sh`
+Expected: les cas `--pairs` échouent — `--pairs` est accepté mais ignoré, donc la sortie reste multi-ligne et sans second champ. Le dernier cas (code de sortie 2) passe déjà.
+
+- [ ] **Step 3 : Implémenter la branche `--pairs`**
+
+Dans `JQ_FILTER`, ajouter après `def short_exception` :
+
+```jq
+# Rend une chaine sure pour une ligne unique.
+def oneline: gsub("\n"; "↵") | gsub("\t"; " ");
+```
+
+Le message est déjà capturé par `(.message // .msg // "" | tostring) as $msg` ; en mode `--pairs`, il doit passer par `oneline`. Remplacer sa capture par :
+
+```jq
+  (.message // .msg // "" | tostring | if $pairs then oneline else . end) as $msg |
+```
+
+Puis remplacer l'expression finale (celle construite en Task 4) par :
+
+```jq
+  (if $pairs then
+     $head
+     + (if $st == "" then "" else " " + c("2"; "⤷ " + ($st | short_exception)) end)
+     + (if $extra == "" then "" else "  " + c("2"; ($extra | oneline | trunc(120))) end)
+     + "\t" + $line
+   else
+     $head
+     + (if $extra == "" then ""
+        else "\n" + (" " * ($pre_plain | length)) + c("2"; $extra) end)
+     + (if $st == "" then ""
+        else "\n" + c("2";
+          ($st | gsub("\t"; "    ") | split("\n") | map("  " + .) | join("\n"))) end)
+   end)
+```
+
+Et remplacer le `catch $line` final par :
+
+```jq
+) catch (if $pairs then $line + "\t" + $line else $line end)
+```
+
+- [ ] **Step 4 : Lancer le vérificateur pour constater le succès**
+
+Run: `scripts/tests/k9s-log-fmt.test.sh`
+Expected: `34 ok, 0 echec(s)`.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add scripts/k9s-log-fmt.sh scripts/tests/k9s-log-fmt.test.sh
+git commit -m "feat(k9s): mode --pairs — une ligne par evenement + JSON source"
+```
+
+---
+
+## Task 6 : Viewer interactif
+
+**Files:**
+- Create: `scripts/k9s-log-view.sh`
+- Modify: `scripts/tests/k9s-log-fmt.test.sh` (section de cas sur le repli sans `fzf`)
+
+**Interfaces:**
+- Consumes: le format `--pairs` de Task 5.
+- Produces: `scripts/k9s-log-view.sh`, lit stdin, sans argument. Consommé par les plugins de Task 7.
+
+- [ ] **Step 1 : Écrire les cas qui échouent**
+
+Ajouter à `scripts/tests/k9s-log-fmt.test.sh`, avant le bloc final :
+
+```bash
+echo
+echo "== viewer (repli sans fzf) =="
+
+VIEW="$ROOT/scripts/k9s-log-view.sh"
+
+# PATH vide de fzf : le viewer doit se rabattre sur un affichage simple et
+# n afficher que le premier champ. LESS=-FX evite d ouvrir un pager interactif.
+printf '%s\n' '{"level":"INFO","message":"Bonjour"}' \
+    | "$FMT" --pairs \
+    | env PATH="/usr/bin:/bin" LESS="-FX" "$VIEW" \
+    | assert_contains "repli sans fzf : premier champ affiche" "INFO  Bonjour"
+
+printf '%s\n' '{"level":"INFO","message":"Bonjour"}' \
+    | "$FMT" --pairs \
+    | env PATH="/usr/bin:/bin" LESS="-FX" "$VIEW" \
+    | assert_equals "repli sans fzf : JSON source masque" "             INFO  Bonjour"
+```
+
+- [ ] **Step 2 : Lancer le vérificateur pour constater l'échec**
+
+Run: `scripts/tests/k9s-log-fmt.test.sh`
+Expected: les 2 nouveaux cas échouent — `scripts/k9s-log-view.sh` n'existe pas, la sortie est vide.
+
+- [ ] **Step 3 : Écrire le viewer**
+
+Créer `scripts/k9s-log-view.sh` :
+
+```bash
+#!/usr/bin/env bash
+# k9s-log-view.sh — explorateur interactif de logs, pilote par fzf.
+# Consomme le format --pairs de k9s-log-fmt.sh : <texte rendu>TAB<json source>.
+# Ne connait rien du format des logs : il ne manipule que deux champs.
+#
+# Usage : kubectl logs ... | k9s-log-fmt.sh --pairs | k9s-log-view.sh
+set -uo pipefail
+
+FMT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/k9s-log-fmt.sh"
+
+# --- presse-papier -----------------------------------------------------------
+# Resolu une fois : les bindings fzf ne sont construits qu ensuite.
+clip=""
+if command -v pbcopy >/dev/null 2>&1; then
+    clip="pbcopy"
+elif command -v wl-copy >/dev/null 2>&1; then
+    clip="wl-copy"
+elif command -v xclip >/dev/null 2>&1; then
+    clip="xclip -selection clipboard"
+fi
+
+# --- repli sans fzf ----------------------------------------------------------
+# Seul le premier champ est affiche : le JSON source n a d interet qu en
+# interactif. sed retire tout ce qui suit la premiere tabulation.
+if ! command -v fzf >/dev/null 2>&1; then
+    sed 's/\t.*$//' | less -R
+    exit $?
+fi
+
+# --- construction des options ------------------------------------------------
+strip_ansi='sed "s/\x1b\[[0-9;]*m//g"'
+
+header="⏎ evenement complet   ?  preview"
+opts=(
+    --ansi
+    --multi
+    --no-sort
+    --delimiter=$'\t'
+    --with-nth=1
+    --prompt="log > "
+    --header="$header"
+    --preview="printf '%s' {2..} | jq -C . 2>/dev/null || printf '%s' {2..}"
+    --preview-window="right:50%:wrap"
+    --bind="?:toggle-preview"
+    --bind="enter:execute(printf '%s' {2..} | \"$FMT\" | less -R)"
+)
+
+if [[ -n "$clip" ]]; then
+    header="ctrl-y copier   ctrl-o JSON   ⏎ evenement complet   ?  preview"
+    opts+=(
+        --header="$header"
+        # Copie le texte rendu, sans ANSI ni indicateur de stack.
+        --bind="ctrl-y:execute-silent(printf '%s\n' {+1} | $strip_ansi | $clip)"
+        --bind="ctrl-o:execute-silent(printf '%s\n' {+2..} | $clip)"
+    )
+else
+    opts+=(--header="$header   (presse-papier indisponible)")
+fi
+
+fzf "${opts[@]}" >/dev/null
+```
+
+Rendre exécutable : `chmod +x scripts/k9s-log-view.sh`
+
+Notes d'implémentation :
+- `--with-nth=1` masque le second champ à l'affichage ; `{2..}` reste disponible aux bindings et récupère tout ce qui suit la première tabulation, ce qui couvre le cas d'une ligne de texte brut contenant elle-même une tabulation.
+- `{+1}` et `{+2..}` prennent en compte la sélection multiple (`Tab`) ; sans sélection, `fzf` retombe sur la ligne courante.
+- `--header` est passé deux fois quand le presse-papier existe : la dernière occurrence gagne, ce qui évite de dupliquer la liste d'options.
+- `>/dev/null` en sortie : le viewer est un terminal d'affichage, il n'émet pas de résultat sur stdout.
+
+- [ ] **Step 4 : Lancer le vérificateur pour constater le succès**
+
+Run: `scripts/tests/k9s-log-fmt.test.sh`
+Expected: `36 ok, 0 echec(s)`.
+
+- [ ] **Step 5 : Vérifier l'interactif à la main**
+
+Run: `scripts/k9s-log-fmt.sh --pairs < config/k9s/fixtures/logs-sample.jsonl | scripts/k9s-log-view.sh`
+
+Contrôler, un point après l'autre :
+1. Les 10 événements s'affichent sur 10 lignes, la stack réduite à `⤷ IllegalStateException`.
+2. Taper `ERROR` : une seule ligne reste, le compteur `fzf` affiche `1/10`.
+3. Le panneau de droite montre le JSON coloré par `jq` ; sur la ligne de texte brut, il montre le texte.
+4. `?` masque puis rétablit le panneau.
+5. `⏎` sur la ligne `ERROR` ouvre `less` avec la stack complète sur 4 lignes ; `q` revient à la liste.
+6. `ctrl-y` puis `pbpaste` : le texte rendu, sans codes ANSI.
+7. `Tab` sur deux lignes puis `ctrl-y` puis `pbpaste` : les deux lignes.
+8. `ctrl-o` puis `pbpaste` : le JSON source de la ligne.
+9. `Esc` quitte, code de sortie 0 (`echo $?`).
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add scripts/k9s-log-view.sh scripts/tests/k9s-log-fmt.test.sh
+git commit -m "feat(k9s): k9s-log-view.sh — explorateur de logs fzf (filtre, copie)"
+```
+
+---
+
+## Task 7 : Plugins k9s et intégration
+
+**Files:**
+- Modify: `config/k9s/plugins.yaml` (2 entrées créées, 2 descriptions corrigées)
+- Modify: `modules/kube/kube_config.zsh` (`kube_help`, ligne k9s)
+
+**Interfaces:**
+- Consumes: `scripts/k9s-log-fmt.sh --pairs` et `scripts/k9s-log-view.sh` (Tasks 5-6).
+
+- [ ] **Step 1 : Corriger les descriptions obsolètes**
+
+Dans `config/k9s/plugins.yaml`, les deux entrées `log-json-pod` et `log-json-container` portent `description: Logs JSON formatés (humanlog)`. Le formatage est assuré par `jq`, pas par `humanlog`. Remplacer les deux occurrences par :
+
+```yaml
+    description: Logs formatés (logback)
+```
+
+- [ ] **Step 2 : Ajouter les deux plugins interactifs**
+
+Toujours dans `config/k9s/plugins.yaml`, insérer après l'entrée `log-json-container` (avant le commentaire `# YAML live formaté via delta`) :
+
+```yaml
+  # Explorateur de logs interactif (fzf) — filtrer, rechercher, copier
+  log-view-pod:
+    shortCut: Ctrl-L
+    description: Logs interactifs (fzf)
+    scopes:
+      - po
+    command: bash
+    background: false
+    confirm: false
+    args:
+      - -c
+      - '"$@" | $ZANVIL_DIR/scripts/k9s-log-fmt.sh --pairs | $ZANVIL_DIR/scripts/k9s-log-view.sh'
+      - dummy-arg
+      - kubectl
+      - logs
+      - $NAME
+      - -n
+      - $NAMESPACE
+      - --context
+      - $CONTEXT
+      - --tail
+      - "500"
+      - --all-containers=true
+
+  # Note: dans le scope containers, $NAME = container, $POD = pod
+  log-view-container:
+    shortCut: Ctrl-L
+    description: Logs interactifs (fzf)
+    scopes:
+      - containers
+    command: bash
+    background: false
+    confirm: false
+    args:
+      - -c
+      - '"$@" | $ZANVIL_DIR/scripts/k9s-log-fmt.sh --pairs | $ZANVIL_DIR/scripts/k9s-log-view.sh'
+      - dummy-arg
+      - kubectl
+      - logs
+      - -c
+      - $NAME
+      - $POD
+      - -n
+      - $NAMESPACE
+      - --context
+      - $CONTEXT
+      - --tail
+      - "500"
+```
+
+`$ZANVIL_DIR` est laissé tel quel dans le fichier source : `kube_k9s_setup` le résout à la copie.
+
+- [ ] **Step 3 : Vérifier que le YAML est valide**
+
+Run: `ZANVIL_DIR=/tmp yq '.plugins | keys' config/k9s/plugins.yaml 2>/dev/null || python3 -c "import yaml,sys; print(list(yaml.safe_load(open('config/k9s/plugins.yaml'))['plugins']))"`
+
+Expected: la liste des 7 plugins, dont `log-view-pod` et `log-view-container`.
+
+- [ ] **Step 4 : Compléter l'aide**
+
+Dans `modules/kube/kube_config.zsh`, fonction `kube_help`, sous la ligne `k [ctx] [ns]`, ajouter :
+
+```
+  k9s: Shift-L    Logs formatés (logback) dans less
+  k9s: Ctrl-L     Logs interactifs (fzf) — filtrer, copier
+```
+
+- [ ] **Step 5 : Déployer et contrôler l'absence de warning**
+
+```bash
+source ~/.zshrc
+kube_k9s_setup
+grep -c 'log-view' ~/Library/Application\ Support/k9s/plugins.yaml   # attendu : 2
+grep -c '\$ZANVIL_DIR' ~/Library/Application\ Support/k9s/plugins.yaml  # attendu : 0
+```
+
+Le second contrôle vérifie que la résolution à la copie a bien opéré : plus aucune variable non résolue dans le fichier déployé.
+
+- [ ] **Step 6 : Valider dans k9s, et arbitrer `Ctrl-L`**
+
+Noter la taille du log avant, pour ne relire que le nouveau :
+
+```bash
+wc -l < ~/Library/Application\ Support/k9s/k9s.log
+```
+
+Lancer `k9s`, aller sur un pod, puis :
+1. `Shift-L` — rendu logback dans `less`, stack traces indentées. `q` pour sortir.
+2. `Ctrl-L` — explorateur `fzf`. Filtrer, `ctrl-y`, `⏎`, `Esc`.
+3. Entrer dans le pod (`⏎`), se placer sur un conteneur, refaire `Shift-L` et `Ctrl-L` — les deux plugins de scope `containers`.
+
+Puis relire la fin du log :
+
+```bash
+tail -n +<ligne notée> ~/Library/Application\ Support/k9s/k9s.log | grep -iE 'plugin|environment matching|shortcut|hotkey'
+```
+
+Expected: aucune occurrence de `No k9s environment matching key`, aucun conflit de raccourci.
+
+**Si `Ctrl-L` ne déclenche rien** (interception probable par `tcell` comme rafraîchissement d'écran) : remplacer `shortCut: Ctrl-L` par `shortCut: Shift-F` dans les deux entrées, redéployer via `kube_k9s_setup`, refaire cette étape, et corriger `kube_help` ainsi que la section « Interface » de la spec en conséquence.
+
+- [ ] **Step 7 : Vérification finale de bout en bout**
+
+```bash
+scripts/tests/k9s-log-fmt.test.sh
+bash -c '"$@" | '"$ZANVIL_DIR"'/scripts/k9s-log-fmt.sh | less -R +G' dummy-arg \
+  cat "$ZANVIL_DIR/config/k9s/fixtures/logs-sample.jsonl"
+```
+
+Expected: `36 ok, 0 echec(s)`, puis le rendu complet dans `less` — ce second appel reproduit l'invocation exacte de k9s, deux pipes compris.
+
+- [ ] **Step 8 : Commit**
+
+```bash
+git add config/k9s/plugins.yaml modules/kube/kube_config.zsh
+git commit -m "feat(k9s): plugin Ctrl-L — explorateur de logs interactif
+
+Corrige au passage la description des plugins log-json-*, qui creditait
+humanlog alors que le formatage est assure par jq."
+```
+
+---
+
+## Self-review
+
+**Couverture de la spec** — chaque section a sa tâche :
+
+| Exigence de la spec | Tâche |
+|---|---|
+| Horodatage `HH:mm:ss.SSS`, heure seule, 3 champs reconnus, colonne vide si absent | 1 |
+| Niveau complété à 5, 3 champs reconnus, défaut `INFO`, couleurs conservées | 1 |
+| Ligne non-JSON réémise à l'identique | 1 (statique), 5 (`--pairs`) |
+| Thread entre crochets, tronqué à 20, omis si absent | 2 |
+| Logger abrégé `%logger{36}`, omis si absent, pas de tiret orphelin | 2 |
+| Ni thread ni logger complétés à largeur fixe | 2 |
+| Stack trace : 4 champs reconnus, `\n` restitués, indentation, gris | 3 |
+| Champs extra : `clé=valeur`, 2e ligne alignée, `trace_id`/`span_id`/`trace_flags` masqués | 4 |
+| Message : `\n` restitués en statique, `↵` en `--pairs` | 1 (capture), 5 (`oneline`) |
+| Contrat `--pairs` : 1 ligne pour 1 ligne, TAB + JSON source, indicateur `⤷` | 5 |
+| Codes ANSI embarqués, indépendants du TTY | 1 (`\u001b`) |
+| `fzf` : `--ansi --multi --delimiter --with-nth=1`, filtrage natif | 6 |
+| Bindings `ctrl-y`, `ctrl-o`, `⏎`, `?` | 6 |
+| Preview `jq -C .` avec repli texte brut | 6 |
+| Presse-papier `pbcopy`/`wl-copy`/`xclip`, bindings retirés si absent | 6 |
+| Repli `less -R` si `fzf` absent | 6 |
+| Flag `-h`/`--help`, option inconnue → code 2 | 1 (implémentation), 5 (cas de test) |
+| Plugins `Ctrl-L` scopes `po` et `containers`, arbitrage du raccourci | 7 |
+| Correction de la mention `humanlog` | 7 |
+| `kube_help` | 7 |
+| Fixtures `logs-sample.jsonl`, 10 cas du tableau de vérification | 1 (création), 3-5 (exploitation) |
+| Vérification de bout en bout reproduisant l'invocation k9s | 7 |
+
+**Hors périmètre, conforme à la spec** : `klog` n'est pas modifié, aucun mode `--follow` interactif, pas de compteurs par niveau dans le header, aucun nettoyage de `~/.config/k9s` ni de `k9s.log`.
+
+**Cohérence des noms** — fonctions `jq` : `c`, `pad`, `trunc`, `hhmmss`, `level_color` (Task 1), `abbrev_logger` (Task 2), `short_exception` (Task 3), `oneline` (Task 5). Variables : `$lvl`, `$hh`, `$msg` (1), `$thr`, `$log`, `$thr_plain`, `$log_plain`, `$sep`, `$pre_plain`, `$head` (2), `$st` (3), `$extra` (4), `$pairs` (argument, déclaré en 1, consommé en 5). Scripts : `k9s-log-fmt.sh`, `k9s-log-view.sh`, `k9s-log-fmt.test.sh`. Aucun renommage entre tâches.
+
+**Comptage cumulé des assertions** : 7 (T1) → 13 (T2) → 20 (T3) → 25 (T4) → 34 (T5) → 36 (T6). Les totaux annoncés aux étapes « constater le succès » suivent cette progression.

--- a/web/docs/superpowers/plans/2026-07-28-k9s-log-viewer.md
+++ b/web/docs/superpowers/plans/2026-07-28-k9s-log-viewer.md
@@ -276,7 +276,11 @@ printf '%s\n' '{"@timestamp":"2026-07-28T08:00:00.123Z","level":"INFO","thread_n
 
 printf '%s\n' '{"level":"DEBUG","logger_name":"com.boulanger.foo.bar.baz.qux.EnormousServiceImplementation","message":"x"}' \
     | "$FMT" | assert_contains "logger de plus de 36 caracteres abrege" \
-    "c.b.f.b.b.q.EnormousServiceImplementation - x"
+    "…b.b.q.EnormousServiceImplementation - x"
+
+printf '%s\n' '{"level":"DEBUG","logger_name":"UneClasseSansAucunPointDontLeNomDepasseTrenteSixCaracteres","message":"x"}' \
+    | "$FMT" | assert_contains "logger sans point de plus de 36 caracteres tronque" \
+    "…DontLeNomDepasseTrenteSixCaracteres - x"
 
 printf '%s\n' '{"level":"TRACE","thread_name":"http-nio-8080-exec-with-a-very-long-name","logger_name":"com.Pool","message":"x"}' \
     | "$FMT" | assert_contains "thread de plus de 20 caracteres tronque" \
@@ -351,7 +355,7 @@ try (
 - [ ] **Step 4 : Lancer le vérificateur pour constater le succès**
 
 Run: `scripts/tests/k9s-log-fmt.test.sh`
-Expected: `13 ok, 0 echec(s)`.
+Expected: `14 ok, 0 echec(s)`.
 
 - [ ] **Step 5 : Commit**
 
@@ -444,7 +448,7 @@ Et remplacer la dernière expression `$head` par :
 - [ ] **Step 4 : Lancer le vérificateur pour constater le succès**
 
 Run: `scripts/tests/k9s-log-fmt.test.sh`
-Expected: `20 ok, 0 echec(s)`.
+Expected: `21 ok, 0 echec(s)`.
 
 - [ ] **Step 5 : Vérifier le rendu sur les fixtures**
 
@@ -539,7 +543,7 @@ L'ordre compte : les extras se placent juste sous le message, la stack trace fer
 - [ ] **Step 4 : Lancer le vérificateur pour constater le succès**
 
 Run: `scripts/tests/k9s-log-fmt.test.sh`
-Expected: `25 ok, 0 echec(s)`.
+Expected: `26 ok, 0 echec(s)`.
 
 - [ ] **Step 5 : Vérifier le rendu complet sur les fixtures**
 
@@ -655,7 +659,7 @@ Et remplacer le `catch $line` final par :
 - [ ] **Step 4 : Lancer le vérificateur pour constater le succès**
 
 Run: `scripts/tests/k9s-log-fmt.test.sh`
-Expected: `34 ok, 0 echec(s)`.
+Expected: `35 ok, 0 echec(s)`.
 
 - [ ] **Step 5 : Commit**
 
@@ -782,7 +786,7 @@ Notes d'implémentation :
 - [ ] **Step 4 : Lancer le vérificateur pour constater le succès**
 
 Run: `scripts/tests/k9s-log-fmt.test.sh`
-Expected: `36 ok, 0 echec(s)`.
+Expected: `37 ok, 0 echec(s)`.
 
 - [ ] **Step 5 : Vérifier l'interactif à la main**
 
@@ -939,7 +943,7 @@ bash -c '"$@" | '"$ZANVIL_DIR"'/scripts/k9s-log-fmt.sh | less -R +G' dummy-arg \
   cat "$ZANVIL_DIR/config/k9s/fixtures/logs-sample.jsonl"
 ```
 
-Expected: `36 ok, 0 echec(s)`, puis le rendu complet dans `less` — ce second appel reproduit l'invocation exacte de k9s, deux pipes compris.
+Expected: `37 ok, 0 echec(s)`, puis le rendu complet dans `less` — ce second appel reproduit l'invocation exacte de k9s, deux pipes compris.
 
 - [ ] **Step 8 : Commit**
 
@@ -986,4 +990,4 @@ humanlog alors que le formatage est assure par jq."
 
 **Cohérence des noms** — fonctions `jq` : `c`, `pad`, `trunc`, `hhmmss`, `level_color` (Task 1), `abbrev_logger` (Task 2), `short_exception` (Task 3), `oneline` (Task 5). Variables : `$lvl`, `$hh`, `$msg` (1), `$thr`, `$log`, `$thr_plain`, `$log_plain`, `$sep`, `$pre_plain`, `$head` (2), `$st` (3), `$extra` (4), `$pairs` (argument, déclaré en 1, consommé en 5). Scripts : `k9s-log-fmt.sh`, `k9s-log-view.sh`, `k9s-log-fmt.test.sh`. Aucun renommage entre tâches.
 
-**Comptage cumulé des assertions** : 7 (T1) → 13 (T2) → 20 (T3) → 25 (T4) → 34 (T5) → 36 (T6). Les totaux annoncés aux étapes « constater le succès » suivent cette progression.
+**Comptage cumulé des assertions** : 7 (T1) → 14 (T2) → 21 (T3) → 26 (T4) → 35 (T5) → 37 (T6). Les totaux annoncés aux étapes « constater le succès » suivent cette progression.

--- a/web/docs/superpowers/plans/2026-07-28-k9s-log-viewer.md
+++ b/web/docs/superpowers/plans/2026-07-28-k9s-log-viewer.md
@@ -63,7 +63,12 @@ set -uo pipefail
 ROOT="${ZANVIL_DIR:-$HOME/.zanvil}"
 FMT="$ROOT/scripts/k9s-log-fmt.sh"
 FIXTURES="$ROOT/config/k9s/fixtures/logs-sample.jsonl"
-pass=0 fail=0
+
+# Temp directory pour les compteurs (escape subshell issue)
+TEST_TMPDIR=$(mktemp -d) || { echo "mktemp failed" >&2; exit 2; }
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+echo 0 > "$TEST_TMPDIR/pass"
+echo 0 > "$TEST_TMPDIR/fail"
 
 # Retire les codes ANSI : les assertions portent sur le texte, pas les couleurs.
 strip_ansi() { sed $'s/\033\\[[0-9;]*m//g'; }
@@ -74,11 +79,11 @@ assert_contains() {
     out=$(strip_ansi)
     if [[ "$out" == *"$needle"* ]]; then
         printf '  ok   %s\n' "$label"
-        pass=$((pass + 1))
+        echo $(($(cat "$TEST_TMPDIR/pass") + 1)) > "$TEST_TMPDIR/pass"
     else
         printf '  FAIL %s\n       attendu : %s\n       obtenu  : %s\n' \
             "$label" "$needle" "$out"
-        fail=$((fail + 1))
+        echo $(($(cat "$TEST_TMPDIR/fail") + 1)) > "$TEST_TMPDIR/fail"
     fi
 }
 
@@ -88,11 +93,11 @@ assert_equals() {
     out=$(strip_ansi)
     if [[ "$out" == "$needle" ]]; then
         printf '  ok   %s\n' "$label"
-        pass=$((pass + 1))
+        echo $(($(cat "$TEST_TMPDIR/pass") + 1)) > "$TEST_TMPDIR/pass"
     else
         printf '  FAIL %s\n       attendu : %s\n       obtenu  : %s\n' \
             "$label" "$needle" "$out"
-        fail=$((fail + 1))
+        echo $(($(cat "$TEST_TMPDIR/fail") + 1)) > "$TEST_TMPDIR/fail"
     fi
 }
 
@@ -120,6 +125,8 @@ printf '%s\n' '{"@timestamp":"2026-07-28T08:00:03+02:00","level":"INFO","message
     | "$FMT" | assert_contains "horodatage sans millisecondes" "08:00:03.000 INFO  Offset"
 
 echo
+pass=$(cat "$TEST_TMPDIR/pass")
+fail=$(cat "$TEST_TMPDIR/fail")
 printf '%d ok, %d echec(s)\n' "$pass" "$fail"
 [[ $fail -eq 0 ]]
 ```
@@ -130,7 +137,7 @@ Rendre exécutable : `chmod +x scripts/tests/k9s-log-fmt.test.sh`
 
 Run: `scripts/tests/k9s-log-fmt.test.sh`
 
-Expected: FAIL sur les 6 premiers cas. Le format actuel produit `2026-07-28T08:00:00.123Z |INFO| Demarrage termine` — horodatage complet, niveau encadré de barres. Le cas « texte brut réémis à l'identique » passe déjà (comportement existant à ne pas casser).
+Expected: FAIL sur 5 des 7 cas. Le format actuel produit `2026-07-28T08:00:00.123Z |INFO| Demarrage termine` — horodatage complet, niveau encadré de barres. Deux cas passent déjà et servent de garde-fous de non-régression : « texte brut réémis à l'identique » et « JSON malformé traité comme du texte brut » — le `catch` du filtre actuel les couvre.
 
 - [ ] **Step 3 : Réécrire le filtre**
 

--- a/web/docs/superpowers/plans/2026-07-28-k9s-log-viewer.md
+++ b/web/docs/superpowers/plans/2026-07-28-k9s-log-viewer.md
@@ -400,6 +400,10 @@ printf '%s\n' "$STACK_JSON" \
 printf '%s\n' "$STACK_JSON" | "$FMT" | strip_ansi | wc -l | tr -d ' ' \
     | assert_equals "un evenement avec stack occupe 4 lignes" "4"
 
+printf '%s\n' '{"level":"ERROR","logger_name":"com.Foo","message":"Boom","stack_trace":"java.lang.IllegalStateException: Boom\n\tat com.Foo.bar(Foo.java:17)\n"}' \
+    | "$FMT" | strip_ansi | wc -l | tr -d ' ' \
+    | assert_equals "stack avec newline final : pas de ligne parasite" "3"
+
 printf '%s\n' '{"level":"ERROR","message":"Boom","exception":"java.lang.NullPointerException: null"}' \
     | "$FMT" | assert_contains "champ exception reconnu" "  java.lang.NullPointerException: null"
 
@@ -441,14 +445,14 @@ Et remplacer la dernière expression `$head` par :
   $head
   + (if $st == "" then ""
      else "\n" + c("2";
-       ($st | gsub("\t"; "    ") | split("\n") | map("  " + .) | join("\n")))
+       ($st | gsub("\t"; "    ") | sub("\n+$"; "") | split("\n") | map("  " + .) | join("\n")))
      end)
 ```
 
 - [ ] **Step 4 : Lancer le vérificateur pour constater le succès**
 
 Run: `scripts/tests/k9s-log-fmt.test.sh`
-Expected: `21 ok, 0 echec(s)`.
+Expected: `22 ok, 0 echec(s)`.
 
 - [ ] **Step 5 : Vérifier le rendu sur les fixtures**
 
@@ -534,7 +538,7 @@ Puis remplacer l'expression finale par :
      end)
   + (if $st == "" then ""
      else "\n" + c("2";
-       ($st | gsub("\t"; "    ") | split("\n") | map("  " + .) | join("\n")))
+       ($st | gsub("\t"; "    ") | sub("\n+$"; "") | split("\n") | map("  " + .) | join("\n")))
      end)
 ```
 
@@ -543,7 +547,7 @@ L'ordre compte : les extras se placent juste sous le message, la stack trace fer
 - [ ] **Step 4 : Lancer le vérificateur pour constater le succès**
 
 Run: `scripts/tests/k9s-log-fmt.test.sh`
-Expected: `26 ok, 0 echec(s)`.
+Expected: `27 ok, 0 echec(s)`.
 
 - [ ] **Step 5 : Vérifier le rendu complet sur les fixtures**
 
@@ -646,7 +650,7 @@ Puis remplacer l'expression finale (celle construite en Task 4) par :
         else "\n" + (" " * ($pre_plain | length)) + c("2"; $extra) end)
      + (if $st == "" then ""
         else "\n" + c("2";
-          ($st | gsub("\t"; "    ") | split("\n") | map("  " + .) | join("\n"))) end)
+          ($st | gsub("\t"; "    ") | sub("\n+$"; "") | split("\n") | map("  " + .) | join("\n"))) end)
    end)
 ```
 
@@ -659,7 +663,7 @@ Et remplacer le `catch $line` final par :
 - [ ] **Step 4 : Lancer le vérificateur pour constater le succès**
 
 Run: `scripts/tests/k9s-log-fmt.test.sh`
-Expected: `35 ok, 0 echec(s)`.
+Expected: `36 ok, 0 echec(s)`.
 
 - [ ] **Step 5 : Commit**
 
@@ -786,7 +790,7 @@ Notes d'implémentation :
 - [ ] **Step 4 : Lancer le vérificateur pour constater le succès**
 
 Run: `scripts/tests/k9s-log-fmt.test.sh`
-Expected: `37 ok, 0 echec(s)`.
+Expected: `38 ok, 0 echec(s)`.
 
 - [ ] **Step 5 : Vérifier l'interactif à la main**
 
@@ -943,7 +947,7 @@ bash -c '"$@" | '"$ZANVIL_DIR"'/scripts/k9s-log-fmt.sh | less -R +G' dummy-arg \
   cat "$ZANVIL_DIR/config/k9s/fixtures/logs-sample.jsonl"
 ```
 
-Expected: `37 ok, 0 echec(s)`, puis le rendu complet dans `less` — ce second appel reproduit l'invocation exacte de k9s, deux pipes compris.
+Expected: `38 ok, 0 echec(s)`, puis le rendu complet dans `less` — ce second appel reproduit l'invocation exacte de k9s, deux pipes compris.
 
 - [ ] **Step 8 : Commit**
 
@@ -990,4 +994,4 @@ humanlog alors que le formatage est assure par jq."
 
 **Cohérence des noms** — fonctions `jq` : `c`, `pad`, `trunc`, `hhmmss`, `level_color` (Task 1), `abbrev_logger` (Task 2), `short_exception` (Task 3), `oneline` (Task 5). Variables : `$lvl`, `$hh`, `$msg` (1), `$thr`, `$log`, `$thr_plain`, `$log_plain`, `$sep`, `$pre_plain`, `$head` (2), `$st` (3), `$extra` (4), `$pairs` (argument, déclaré en 1, consommé en 5). Scripts : `k9s-log-fmt.sh`, `k9s-log-view.sh`, `k9s-log-fmt.test.sh`. Aucun renommage entre tâches.
 
-**Comptage cumulé des assertions** : 7 (T1) → 14 (T2) → 21 (T3) → 26 (T4) → 35 (T5) → 37 (T6). Les totaux annoncés aux étapes « constater le succès » suivent cette progression.
+**Comptage cumulé des assertions** : 7 (T1) → 14 (T2) → 22 (T3) → 27 (T4) → 36 (T5) → 38 (T6). Les totaux annoncés aux étapes « constater le succès » suivent cette progression.

--- a/web/docs/superpowers/plans/2026-07-28-k9s-log-viewer.md
+++ b/web/docs/superpowers/plans/2026-07-28-k9s-log-viewer.md
@@ -749,7 +749,7 @@ fi
 # --- construction des options ------------------------------------------------
 strip_ansi='sed "s/\x1b\[[0-9;]*m//g"'
 
-header="⏎ evenement complet   ?  preview"
+header="⏎ evenement complet   ? apercu JSON"
 opts=(
     --ansi
     --multi
@@ -759,13 +759,13 @@ opts=(
     --prompt="log > "
     --header="$header"
     --preview="printf '%s' {2..} | jq -C . 2>/dev/null || printf '%s' {2..}"
-    --preview-window="right:50%:wrap"
+    --preview-window="right:50%:wrap:hidden"
     --bind="?:toggle-preview"
     --bind="enter:execute(printf '%s' {2..} | \"$FMT\" | less -R)"
 )
 
 if [[ -n "$clip" ]]; then
-    header="ctrl-y copier   ctrl-o JSON   ⏎ evenement complet   ?  preview"
+    header="ctrl-y copier   ctrl-o JSON   ⏎ evenement complet   ? apercu JSON"
     opts+=(
         --header="$header"
         # Copie le texte rendu, sans ANSI ni indicateur de stack.
@@ -980,7 +980,7 @@ humanlog alors que le formatage est assure par jq."
 | Codes ANSI embarqués, indépendants du TTY | 1 (`\u001b`) |
 | `fzf` : `--ansi --multi --delimiter --with-nth=1`, filtrage natif | 6 |
 | Bindings `ctrl-y`, `ctrl-o`, `⏎`, `?` | 6 |
-| Preview `jq -C .` avec repli texte brut | 6 |
+| Preview `jq -C .` avec repli texte brut, replié au démarrage (`hidden`) | 6 |
 | Presse-papier `pbcopy`/`wl-copy`/`xclip`, bindings retirés si absent | 6 |
 | Repli `less -R` si `fzf` absent | 6 |
 | Flag `-h`/`--help`, option inconnue → code 2 | 1 (implémentation), 5 (cas de test) |

--- a/web/docs/superpowers/plans/2026-07-28-k9s-log-viewer.md
+++ b/web/docs/superpowers/plans/2026-07-28-k9s-log-viewer.md
@@ -14,7 +14,7 @@
 - **Aucun caractère ESC littéral dans les sources.** Les couleurs sont produites par `jq` via l'échappement `\u001b` (validé sur jq 1.7). Le fichier actuel contient des ESC bruts invisibles : ils disparaissent en Task 1.
 - **Le rendu ne dépend jamais de la détection d'un TTY.** k9s exécute le plugin derrière deux pipes ; toute logique `[[ -t 1 ]]` casserait les couleurs.
 - **`k9s-log-fmt.sh` reste un filtre pur** : pas de fichier temporaire, pas de lecture de `/dev/tty`, pas d'appel réseau. C'est ce qui le rend testable et réutilisable par `klog`.
-- **Contrat `--pairs` :** le nombre de lignes en sortie est **strictement égal** au nombre de lignes en entrée. Tout le mode interactif en dépend (`fzf` indexe par ligne).
+- **Contrat `--pairs` :** le nombre de lignes en sortie est **strictement égal** au nombre de lignes en entrée — `fzf` indexe par ligne. De plus, le **premier champ ne contient jamais de tabulation** (`--with-nth=1` n'afficherait que le fragment qui la précède), et le **second champ reste identique octet pour octet à la ligne d'entrée** (`{2..}` récupère tous les champs à partir du second, donc une ligne d'entrée contenant elle-même une tabulation round-trip correctement même si le nombre de champs dépasse 2).
 - **Largeurs :** niveau complété à 5 caractères ; thread tronqué à 20 avec `…` ; logger abrégé à 36 selon la règle `%logger{36}`. **Ni le thread ni le logger ne sont complétés** à largeur fixe.
 - **Une ligne d'entrée non-JSON est réémise à l'identique**, sans préfixe ni couleur (comportement actuel, à préserver).
 - **Champs masqués :** `trace_id`, `span_id`, `trace_flags` ne sont jamais affichés dans la ligne rendue.
@@ -627,7 +627,7 @@ Dans `JQ_FILTER`, ajouter après `def short_exception` :
 
 ```jq
 # Rend une chaine sure pour une ligne unique.
-def oneline: gsub("\n"; "↵") | gsub("\t"; " ");
+def oneline: gsub("\n"; "↵") | gsub("\r"; "") | gsub("\t"; " ");
 ```
 
 Le message est déjà capturé par `(.message // .msg // "" | tostring) as $msg` ; en mode `--pairs`, il doit passer par `oneline`. Remplacer sa capture par :
@@ -641,7 +641,7 @@ Puis remplacer l'expression finale (celle construite en Task 4) par :
 ```jq
   (if $pairs then
      $head
-     + (if $st == "" then "" else " " + c("2"; "⤷ " + ($st | short_exception)) end)
+     + (if $st == "" then "" else " " + c("2"; "⤷ " + ($st | short_exception | oneline)) end)
      + (if $extra == "" then "" else "  " + c("2"; ($extra | oneline | trunc(120))) end)
      + "\t" + $line
    else
@@ -657,13 +657,13 @@ Puis remplacer l'expression finale (celle construite en Task 4) par :
 Et remplacer le `catch $line` final par :
 
 ```jq
-) catch (if $pairs then $line + "\t" + $line else $line end)
+) catch (if $pairs then ($line | oneline) + "\t" + $line else $line end)
 ```
 
 - [ ] **Step 4 : Lancer le vérificateur pour constater le succès**
 
 Run: `scripts/tests/k9s-log-fmt.test.sh`
-Expected: `36 ok, 0 echec(s)`.
+Expected: `39 ok, 0 echec(s)`.
 
 - [ ] **Step 5 : Commit**
 
@@ -790,7 +790,7 @@ Notes d'implémentation :
 - [ ] **Step 4 : Lancer le vérificateur pour constater le succès**
 
 Run: `scripts/tests/k9s-log-fmt.test.sh`
-Expected: `38 ok, 0 echec(s)`.
+Expected: `41 ok, 0 echec(s)`.
 
 - [ ] **Step 5 : Vérifier l'interactif à la main**
 
@@ -947,7 +947,7 @@ bash -c '"$@" | '"$ZANVIL_DIR"'/scripts/k9s-log-fmt.sh | less -R +G' dummy-arg \
   cat "$ZANVIL_DIR/config/k9s/fixtures/logs-sample.jsonl"
 ```
 
-Expected: `38 ok, 0 echec(s)`, puis le rendu complet dans `less` — ce second appel reproduit l'invocation exacte de k9s, deux pipes compris.
+Expected: `41 ok, 0 echec(s)`, puis le rendu complet dans `less` — ce second appel reproduit l'invocation exacte de k9s, deux pipes compris.
 
 - [ ] **Step 8 : Commit**
 
@@ -994,4 +994,4 @@ humanlog alors que le formatage est assure par jq."
 
 **Cohérence des noms** — fonctions `jq` : `c`, `pad`, `trunc`, `hhmmss`, `level_color` (Task 1), `abbrev_logger` (Task 2), `short_exception` (Task 3), `oneline` (Task 5). Variables : `$lvl`, `$hh`, `$msg` (1), `$thr`, `$log`, `$thr_plain`, `$log_plain`, `$sep`, `$pre_plain`, `$head` (2), `$st` (3), `$extra` (4), `$pairs` (argument, déclaré en 1, consommé en 5). Scripts : `k9s-log-fmt.sh`, `k9s-log-view.sh`, `k9s-log-fmt.test.sh`. Aucun renommage entre tâches.
 
-**Comptage cumulé des assertions** : 7 (T1) → 14 (T2) → 22 (T3) → 27 (T4) → 36 (T5) → 38 (T6). Les totaux annoncés aux étapes « constater le succès » suivent cette progression.
+**Comptage cumulé des assertions** : 7 (T1) → 14 (T2) → 22 (T3) → 27 (T4) → 39 (T5) → 41 (T6). Les totaux annoncés aux étapes « constater le succès » suivent cette progression.

--- a/web/docs/superpowers/specs/2026-07-28-k9s-log-viewer-design.md
+++ b/web/docs/superpowers/specs/2026-07-28-k9s-log-viewer-design.md
@@ -50,12 +50,12 @@ fzf --ansi --multi --delimiter=$'\t' --with-nth=1
 |--------|--------|
 | *(saisie)* | Filtrage fuzzy natif. `'motif` pour une correspondance exacte. Le compteur de matches de `fzf` tient lieu de décompte par niveau. |
 | `Tab` | Marque une ligne (sélection multiple). |
-| `ctrl-y` | Copie le texte rendu des lignes sélectionnées, codes ANSI et stack trace retirés. Sans sélection, la ligne sous le curseur. |
+| `ctrl-y` | Copie le texte rendu des lignes sélectionnées, codes ANSI retirés. L'indicateur `⤷ NomException` fait partie du texte rendu et reste donc dans la copie ; la stack trace complète, elle, n'y figure jamais puisqu'elle n'est pas dans la ligne. Sans sélection, la ligne sous le curseur. |
 | `ctrl-o` | Copie le JSON source complet. |
 | `⏎` | Rejoue l'événement seul dans `k9s-log-fmt.sh` en mode statique, ouvert dans `less -R` : stack trace complète, puis retour à l'explorateur. |
-| `?` | Bascule le panneau de preview. |
+| `?` | Déplie ou replie le panneau de preview. **Il démarre replié** : les lignes rendues sont longues et le JSON source ne sert qu'à l'inspection ponctuelle, donc la liste occupe toute la largeur par défaut. |
 
-Le preview affiche `jq -C .` sur le JSON source, avec repli sur la ligne brute quand `jq` échoue (log non-JSON).
+Le preview affiche `jq -C .` sur le JSON source, avec repli sur la ligne brute quand `jq` échoue (log non-JSON). Il est déclaré `hidden`, donc replié au démarrage.
 
 Le presse-papier est résolu une fois au démarrage : `pbcopy`, sinon `wl-copy`, sinon `xclip -selection clipboard`. Si aucun n'est disponible, les bindings de copie sont retirés et le header le signale. Si `fzf` est absent, le viewer se rabat sur `less -R` en n'affichant que le premier champ.
 

--- a/web/docs/superpowers/specs/2026-07-28-k9s-log-viewer-design.md
+++ b/web/docs/superpowers/specs/2026-07-28-k9s-log-viewer-design.md
@@ -1,0 +1,180 @@
+# k9s — rendu logback et explorateur de logs interactif
+
+## Problème
+
+Le plugin k9s `Shift-L` formate les logs JSON via `scripts/k9s-log-fmt.sh`, mais son rendu reste pauvre par rapport à une console logback :
+
+- `logger_name` et `thread_name` sont supprimés et **jamais affichés** — impossible de savoir quelle classe ou quel thread a émis l'événement ;
+- une stack trace arrive sous forme de champ JSON aux `\n` échappés, illisible sur une seule ligne ou noyée dans les champs extra ;
+- le rendu est déversé dans `less`, sans moyen de copier un événement, ni de filtrer autrement qu'avec la recherche de `less`.
+
+Un bug distinct a été corrigé en amont de cette spec : le `plugins.yaml` déployé référençait `$ZSH_ENV_DIR` (nom d'avant le renommage `zsh_env` → `zanvil`). k9s ne résolvant pas cette clé, le chemin du script devenait vide et `less` s'ouvrait sur zéro ligne. `kube_k9s_setup` résout désormais `$ZANVIL_DIR` à la copie.
+
+## Solution
+
+Deux scripts aux responsabilités disjointes, exposés par deux plugins k9s :
+
+```
+Shift-L  kubectl logs … | k9s-log-fmt.sh          | less -R +G
+Ctrl-L   kubectl logs … | k9s-log-fmt.sh --pairs  | k9s-log-view.sh
+```
+
+`k9s-log-fmt.sh` reste un filtre pur `stdin → stdout`, sans état ni fichier temporaire : il gagne le pattern logback et le rendu des stack traces. `k9s-log-view.sh` prend en charge l'interaction et ignore tout du format des logs.
+
+Le formatage ne connaît pas le viewer, le viewer ne connaît pas le format. Le mode statique conserve le streaming, et reste donc le seul compatible avec un éventuel `--follow`.
+
+## Interface
+
+### `scripts/k9s-log-fmt.sh`
+
+Filtre sans argument obligatoire. Un seul flag :
+
+| Flag | Effet |
+|------|-------|
+| *(aucun)* | Rendu multi-ligne : stack trace complète indentée, champs extra sur une seconde ligne alignée. |
+| `--pairs` | **Une ligne de sortie par ligne d'entrée** : texte rendu, TAB, JSON source. Stack trace réduite à un indicateur, champs extra concaténés en fin de ligne. |
+
+Une ligne d'entrée qui n'est pas du JSON valide est réémise telle quelle (comportement actuel, conservé). En `--pairs`, elle occupe le premier champ et se retrouve dupliquée dans le second.
+
+### `scripts/k9s-log-view.sh`
+
+Lit sur stdin un flux au format `--pairs` et lance `fzf` :
+
+```
+fzf --ansi --multi --delimiter=$'\t' --with-nth=1
+```
+
+`--with-nth=1` masque le JSON source à l'affichage, mais `{2..}` reste accessible aux bindings et au preview. Pas de buffer : `fzf` consomme le flux en continu, l'affichage est progressif.
+
+| Touche | Action |
+|--------|--------|
+| *(saisie)* | Filtrage fuzzy natif. `'motif` pour une correspondance exacte. Le compteur de matches de `fzf` tient lieu de décompte par niveau. |
+| `Tab` | Marque une ligne (sélection multiple). |
+| `ctrl-y` | Copie le texte rendu des lignes sélectionnées, codes ANSI et stack trace retirés. Sans sélection, la ligne sous le curseur. |
+| `ctrl-o` | Copie le JSON source complet. |
+| `⏎` | Rejoue l'événement seul dans `k9s-log-fmt.sh` en mode statique, ouvert dans `less -R` : stack trace complète, puis retour à l'explorateur. |
+| `?` | Bascule le panneau de preview. |
+
+Le preview affiche `jq -C .` sur le JSON source, avec repli sur la ligne brute quand `jq` échoue (log non-JSON).
+
+Le presse-papier est résolu une fois au démarrage : `pbcopy`, sinon `wl-copy`, sinon `xclip -selection clipboard`. Si aucun n'est disponible, les bindings de copie sont retirés et le header le signale. Si `fzf` est absent, le viewer se rabat sur `less -R` en n'affichant que le premier champ.
+
+## Format de rendu
+
+Calqué sur le pattern console logback `%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg` :
+
+```
+08:00:00.123 INFO  [main] c.b.f.FooService - Démarrage terminé
+08:00:01.456 ERROR [nio-8080-exec-2] c.b.f.BarClient - Timeout amont
+  java.lang.IllegalStateException: Timeout amont
+      at com.boulanger.foo.BarClient.send(BarClient.java:17)
+      ... 24 more
+08:00:02.001 WARN  [scheduling-1] c.b.f.Cleanup - 3 orphelins ignorés
+                                  http.status=503  retry=2
+```
+
+**Horodatage** — `HH:mm:ss.SSS`, heure seule, extraite du champ ISO par troncature de la partie date. La date reste consultable dans le preview du mode interactif. Champs reconnus, dans l'ordre : `@timestamp`, `timestamp`, `time`. Si aucun n'est présent, la colonne est remplie d'espaces pour préserver l'alignement.
+
+**Niveau** — complété à 5 caractères (`%-5level`). Champs reconnus : `level`, `severity`, `lvl` ; défaut `INFO`. Couleurs inchangées : rouge gras pour `ERROR`/`FATAL`/`CRITICAL`, jaune gras pour `WARN`/`WARNING`, cyan pour `DEBUG`/`TRACE`, vert gras sinon.
+
+**Thread** — `thread_name`, entre crochets, tronqué à 20 caractères avec `…` au-delà. Omis si le champ est absent.
+
+**Logger** — `logger_name`, abrégé selon la règle `%logger{36}` : si le nom dépasse 36 caractères, chaque segment de package est réduit à son initiale, la classe finale étant toujours préservée (`com.boulanger.foo.FooService` → `c.b.f.FooService`). Si le résultat dépasse encore 36 caractères, il est tronqué par la gauche derrière `…`. Omis si le champ est absent.
+
+**Ni le thread ni le logger ne sont complétés à largeur fixe** — c'est le comportement de logback, et un padding cumulé sur les deux colonnes repousserait le message à plus de 80 caractères du bord.
+
+**Message** — `message`, sinon `msg`. Les séquences `\n` et `\t` qu'il contient sont restituées ; en mode `--pairs`, elles sont remplacées par `↵` et un espace pour garantir l'unicité de la ligne.
+
+**Stack trace** — premier champ présent parmi `stack_trace`, `exception`, `stacktrace`, `throwable`. En mode statique, les `\n` sont restitués et chaque ligne est préfixée de deux espaces, en gris. En mode `--pairs`, la stack est réduite au nom court de l'exception extrait de sa première ligne, précédé de `⤷` (`⤷ IllegalStateException`).
+
+**Champs extra (MDC)** — tout ce qui reste après retrait des champs ci-dessus et de `trace_id`, `span_id`, `trace_flags`, rendu en `clé=valeur` séparés par deux espaces, en gris. Sur une seconde ligne indentée en mode statique ; concaténés en fin de ligne et tronqués à 120 caractères en mode `--pairs`. `trace_id` et `span_id` restent masqués — ils encombrent la ligne et sont consultables dans le preview.
+
+Les codes ANSI restent embarqués dans les chaînes produites par `jq`, comme aujourd'hui : le rendu ne dépend pas de la détection d'un TTY, ce qui est nécessaire puisque k9s exécute le plugin à travers deux pipes.
+
+## Déroulé
+
+Mode statique, `Shift-L` sur un pod :
+
+1. k9s suspend son UI et exécute `bash -c '"$@" | … | less -R +G'`.
+2. `kubectl logs --tail 500 --all-containers` écrit sur le pipe.
+3. `k9s-log-fmt.sh` transforme chaque ligne, en flux.
+4. `less -R +G` s'ouvre en fin de log. `q` rend le terminal à k9s.
+
+Mode interactif, `Ctrl-L` sur un pod :
+
+1. Idem, mais `k9s-log-fmt.sh --pairs | k9s-log-view.sh`.
+2. `k9s-log-view.sh` résout le presse-papier, construit les bindings, exécute `fzf` en lui passant le flux.
+3. L'utilisateur filtre, marque, copie, ou ouvre un événement dans `less`.
+4. `Esc` quitte `fzf` et rend le terminal à k9s.
+
+## Modifications
+
+### `scripts/k9s-log-fmt.sh`
+
+Réécriture du filtre `jq`. Le mode est passé à `jq` via `--argjson pairs true|false` plutôt que par deux filtres dupliqués. Ajout du parsing d'argument `--pairs`, et de deux fonctions `jq` : `abbrev_logger` et `short_exception`.
+
+### `scripts/k9s-log-view.sh`
+
+Nouveau, exécutable. Résolution du presse-papier, construction du tableau d'options `fzf`, exécution. Repli `less -R` si `fzf` est absent.
+
+### `config/k9s/plugins.yaml`
+
+Deux entrées supplémentaires, `log-view-pod` (scope `po`) et `log-view-container` (scope `containers`), sur `Ctrl-L`, calquées sur les entrées `log-json-*` existantes. Correction au passage de la description des plugins `log-json-*`, qui mentionne `humanlog` alors que le formatage est assuré par `jq`.
+
+`Ctrl-L` est à confirmer : `tcell` peut l'intercepter comme un rafraîchissement d'écran. Vérification dans `k9s.log` après déploiement ; repli sur `Shift-F` en cas de conflit.
+
+### `config/k9s/fixtures/logs-sample.jsonl`
+
+Nouveau. Jeu de fixtures permettant de rejouer le rendu sans cluster (voir Vérification).
+
+### `modules/kube/kube_config.zsh`
+
+Ajout de la ligne `Ctrl-L` dans `kube_help`, section k9s.
+
+## Hors périmètre
+
+- Brancher `klog` sur `k9s-log-fmt.sh` — il affiche encore du JSON brut. Le formatteur restant un filtre pur, le branchement sera trivial.
+- Mode `--follow` interactif : `fzf` exige un flux fini pour rester utilisable.
+- Compteurs par niveau dans le header de `fzf` : imposerait de bufferiser tout le flux avant le premier affichage.
+- Nettoyage des vestiges repérés pendant le diagnostic : `~/.config/k9s/hotkeys.yaml` divergent et inutilisé sur macOS, `k9s.log` à 12,6 Mo saturé par un `CRDs load Fail` toutes les 15 s (droits RBAC manquants sur `customresourcedefinitions`).
+
+## Vérification
+
+Le projet n'a pas de framework de test et shellspec a été écarté. La vérification repose sur des fixtures rejouables sans cluster :
+
+```bash
+scripts/k9s-log-fmt.sh         < config/k9s/fixtures/logs-sample.jsonl
+scripts/k9s-log-fmt.sh --pairs < config/k9s/fixtures/logs-sample.jsonl | scripts/k9s-log-view.sh
+```
+
+Cas couverts par les fixtures, et attente pour chacun :
+
+| Cas | Attente |
+|-----|---------|
+| JSON complet (timestamp, level, thread, logger, message, MDC) | Ligne au pattern logback, MDC sur la seconde ligne. |
+| Ligne de texte brut (non-JSON) | Statique : réémise à l'identique, sans préfixe ni couleur. `--pairs` : `ligne<TAB>ligne`, affichée à l'identique par `fzf`, preview en repli sur le texte brut. |
+| JSON malformé (accolade manquante) | Traité comme du texte brut, réémis à l'identique. |
+| Événement avec `stack_trace` | Statique : stack indentée sur plusieurs lignes. `--pairs` : `⤷ NomException`, une seule ligne. |
+| Logger de plus de 36 caractères | Packages réduits à leur initiale, classe préservée. |
+| Thread de plus de 20 caractères | Tronqué avec `…`. |
+| `level` absent | `INFO`, en vert. |
+| `thread_name` et `logger_name` absents | Colonnes omises, pas de crochets vides ni de tiret orphelin. |
+| Message contenant `\n` | Statique : retour à la ligne restitué. `--pairs` : `↵`, une seule ligne. |
+| Champ `severity` au lieu de `level` | Niveau reconnu et coloré. |
+
+Contrôle du contrat `--pairs`, qui conditionne tout le mode interactif :
+
+```bash
+# Le nombre de lignes en sortie doit égaler le nombre de lignes en entrée
+wc -l < config/k9s/fixtures/logs-sample.jsonl
+scripts/k9s-log-fmt.sh --pairs < config/k9s/fixtures/logs-sample.jsonl | wc -l
+```
+
+Vérification de bout en bout, en reproduisant l'invocation exacte de k9s :
+
+```bash
+bash -c '"$@" | '"$ZANVIL_DIR"'/scripts/k9s-log-fmt.sh | less -R +G' dummy-arg \
+  cat "$ZANVIL_DIR/config/k9s/fixtures/logs-sample.jsonl"
+```
+
+Puis, dans k9s après `kube_k9s_setup` : `Shift-L` et `Ctrl-L` sur un pod réel, et relecture de `k9s.log` pour confirmer l'absence de warning `No k9s environment matching key` et de conflit de raccourci.


### PR DESCRIPTION
## Origine

Le plugin k9s `Shift-L` ouvrait un pager vide. Le `plugins.yaml` **déployé** référençait encore `$ZSH_ENV_DIR`, variable d'avant le renommage `zsh_env` → `zanvil` ; k9s ne résolvant pas la clé (`No k9s environment matching key` dans son log), le chemin du script devenait vide et le pipe ne produisait rien.

`kube_k9s_setup` résout désormais `$ZANVIL_DIR` **à la copie** : le plugin ne dépend plus d'une variable héritée par k9s, et le warning disparaît.

## Ce que la branche apporte

Deux scripts aux responsabilités disjointes, deux plugins :

```
Shift-L  kubectl logs … | k9s-log-fmt.sh          | less -R +G
Ctrl-L   kubectl logs … | k9s-log-fmt.sh --pairs  | k9s-log-view.sh
```

**`scripts/k9s-log-fmt.sh`** — filtre pur `stdin → stdout`, un seul programme `jq`. Rendu calqué sur `%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg` : thread tronqué à 20, logger abrégé selon la règle logback, stack traces restituées et indentées, champs MDC sur une seconde ligne alignée. Les codes ANSI sont embarqués via l'échappement unicode de `jq` — le rendu ne dépend jamais de la détection d'un TTY, ce qui est nécessaire puisque k9s exécute le plugin derrière deux pipes.

```
08:00:01.456 ERROR [http-nio-8080-exec-2] c.b.f.BarClient - Timeout amont
                                                            http.status=503
  java.lang.IllegalStateException: Timeout amont
      at com.boulanger.foo.BarClient.send(BarClient.java:17)
```

**`scripts/k9s-log-view.sh`** — explorateur `fzf`. Filtrage et recherche natifs, aperçu JSON via `jq -C` (replié par défaut, `?` le déplie), `ctrl-y` copie le texte rendu, `ctrl-o` le JSON source, `⏎` rejoue l'événement seul dans le formatteur pour voir la stack complète. Le viewer ignore tout du format des logs : il ne manipule que deux champs.

Le couplage passe par la sortie `--pairs` : une ligne par événement, texte rendu, TAB, JSON source. Trois invariants, chacun testé — nombre de lignes égal à l'entrée (`fzf` indexe par ligne), champ 1 sans tabulation (`--with-nth=1` tronquerait l'affichage), champ 2 identique octet pour octet (`{2..}` alimente l'aperçu et la copie).

## Vérification

`scripts/tests/k9s-log-fmt.test.sh` — **53 assertions**, sans dépendance (shellspec écarté). Les compteurs vivent dans des fichiers sous un `mktemp -d` : les assertions s'exécutent en dernier étage de pipeline, donc dans des sous-shells. Le harnais sort en code non nul quand une assertion casse — vérifié par injection.

`config/k9s/fixtures/logs-sample.jsonl` permet de rejouer le rendu sans cluster :

```bash
scripts/k9s-log-fmt.sh         < config/k9s/fixtures/logs-sample.jsonl
scripts/k9s-log-fmt.sh --pairs < config/k9s/fixtures/logs-sample.jsonl | scripts/k9s-log-view.sh
```

Cas couverts : niveaux textuels et numériques (pino/bunyan), les quatre champs de stack trace, logger dotté et sans point, tabulations et retours chariot, JSON malformé, texte brut, absence de chaque champ, et la normalisation des codes de sortie du viewer via un faux `fzf`.

## Notes de revue

Sept défauts ont été trouvés en cours de route, dont **cinq provenaient du plan** et non de l'implémentation : un harnais qui ne pouvait jamais échouer, la troncature `%logger{36}` supprimée pour satisfaire une assertion mal calibrée, une ligne parasite après chaque stack trace terminée par un saut de ligne, des fuites de tabulation dans `--pairs`, et un `level` numérique qui renvoyait l'événement en JSON brut. Le plan a été amendé à chaque fois plutôt que de figer le comportement fautif dans un test.

Deux corrections viennent de l'usage réel : la popup `exit status 130` à chaque sortie de l'explorateur (le 130 de `fzf` sur `Esc` est une sortie normale, désormais normalisé — le code 2, vraie erreur, reste propagé), et `thread_name`/`logger_name` qui ne passaient pas par `oneline`, où un saut de ligne produisait deux lignes pour un événement et désynchronisait l'indexation.

## Hors périmètre

- Brancher `klog` sur le formatteur — il affiche encore du JSON brut ; le texte d'aide a été reformulé pour ne pas promettre la parité.
- Mode `--follow` interactif : `fzf` exige un flux fini.
- Nettoyage des vestiges relevés au diagnostic : `~/.config/k9s/hotkeys.yaml` divergent et inutilisé sur macOS, `k9s.log` saturé par un `CRDs load Fail` toutes les 15 s faute de droits RBAC sur `customresourcedefinitions`.

Spec et plan : `web/docs/superpowers/specs/2026-07-28-k9s-log-viewer-design.md`, `web/docs/superpowers/plans/2026-07-28-k9s-log-viewer.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
