### PR TITLE
fix(zsh): variables reservees declarees en local — 5 sites

### DIFF
--- a/modules/git/git_hooks.zsh
+++ b/modules/git/git_hooks.zsh
@@ -36,13 +36,13 @@ hooks_list() {
         [[ "$hook" == *.sample ]] && continue
 
         local name=$(basename "$hook")
-        local status="actif"
+        local hook_status="actif"
 
         if [[ ! -x "$hook" ]]; then
-            status="inactif (non executable)"
+            hook_status="inactif (non executable)"
         fi
 
-        printf "  %-20s %s\n" "$name" "$status"
+        printf "  %-20s %s\n" "$name" "$hook_status"
         found=true
     done
 

--- a/modules/kube/kube_config.zsh
+++ b/modules/kube/kube_config.zsh
@@ -946,13 +946,13 @@ kube_gcp_list() {
     echo "$clusters" | while read -r line; do
         local name=$(echo "$line" | awk '{print $1}')
         local zone=$(echo "$line" | awk '{print $2}')
-        local status=$(echo "$line" | awk '{print $3}')
+        local cluster_status=$(echo "$line" | awk '{print $3}')
         local kubeconfig_file="$KUBE_CONFIGS_DIR/kubeconfig-gke-${name}.yml"
 
         if [[ -f "$kubeconfig_file" ]]; then
-            printf "  [x] %-25s %s (%s)\n" "$name" "$zone" "$status"
+            printf "  [x] %-25s %s (%s)\n" "$name" "$zone" "$cluster_status"
         else
-            printf "  [ ] %-25s %s (%s)\n" "$name" "$zone" "$status"
+            printf "  [ ] %-25s %s (%s)\n" "$name" "$zone" "$cluster_status"
         fi
     done
 

--- a/modules/project/project_switcher.zsh
+++ b/modules/project/project_switcher.zsh
@@ -279,7 +279,7 @@ _proj_path_exists() {
 # Enregistre un projet
 # Usage: proj_add [-n|--name NAME] [-p|--path PATH] [NAME] [PATH]
 proj_add() {
-    local name="" path="" force=false
+    local name="" proj_path="" force=false
 
     # Parser les arguments
     while [[ $# -gt 0 ]]; do
@@ -289,7 +289,7 @@ proj_add() {
                 shift 2
                 ;;
             -p|--path)
-                path="$2"
+                proj_path="$2"
                 shift 2
                 ;;
             -f|--force)
@@ -304,8 +304,8 @@ proj_add() {
                 # Arguments positionnels
                 if [[ -z "$name" ]]; then
                     name="$1"
-                elif [[ -z "$path" ]]; then
-                    path="$1"
+                elif [[ -z "$proj_path" ]]; then
+                    proj_path="$1"
                 fi
                 shift
                 ;;
@@ -313,18 +313,18 @@ proj_add() {
     done
 
     # Valeurs par defaut
-    path="${path:-$PWD}"
+    proj_path="${proj_path:-$PWD}"
 
     # Resoudre le chemin absolu
-    path=$(cd "$path" 2>/dev/null && pwd)
-    if [[ -z "$path" ]]; then
+    proj_path=$(cd "$proj_path" 2>/dev/null && pwd)
+    if [[ -z "$proj_path" ]]; then
         echo "Chemin invalide." >&2
         return 1
     fi
 
     # Verifier si le path existe deja
     local existing_name
-    existing_name=$(_proj_path_exists "$path")
+    existing_name=$(_proj_path_exists "$proj_path")
     if [[ $? -eq 0 ]]; then
         echo "Ce chemin est deja enregistre sous le nom '$existing_name'."
         if [[ "$force" != true ]]; then
@@ -340,7 +340,7 @@ proj_add() {
 
     # Demander le nom si non fourni
     if [[ -z "$name" ]]; then
-        local default_name="${path:t}"
+        local default_name="${proj_path:t}"
         echo -n "Nom du projet [$default_name]: "
         read -r input
         name="${input:-$default_name}"
@@ -367,9 +367,9 @@ proj_add() {
     [[ ! -d "$registry_dir" ]] && /bin/mkdir -p "$registry_dir"
 
     # Ajouter
-    echo "${name}: \"$path\"" >> "$PROJ_REGISTRY_FILE"
+    echo "${name}: \"$proj_path\"" >> "$PROJ_REGISTRY_FILE"
     echo "Projet '$name' enregistre."
-    echo "  Chemin: $path"
+    echo "  Chemin: $proj_path"
 }
 
 # Supprime une entree du registre (fonction interne)

--- a/modules/work/elasticsearch.zsh
+++ b/modules/work/elasticsearch.zsh
@@ -38,7 +38,7 @@ _work_es_require() {
 # Sortie: 1ere ligne = code HTTP, reste = corps de reponse.
 # Return: code de sortie curl (0 = reponse recue, meme en erreur HTTP).
 _work_es_curl() {
-    local method=$1 path=$2 body="${3:-}" max_time="${4:-30}"
+    local method=$1 es_path=$2 body="${3:-}" max_time="${4:-30}"
     local -a opts
     opts=(-s --connect-timeout 5 --max-time "$max_time")
     (( max_time < 5 )) && opts[2,3]=(--connect-timeout "$max_time")
@@ -52,7 +52,7 @@ _work_es_curl() {
     [[ -n "$body" ]] && opts+=(-d "$body")
 
     local out ret
-    out=$(command curl "${opts[@]}" -w $'\n%{http_code}' "$(_work_es_url)/$path" 2>/dev/null)
+    out=$(command curl "${opts[@]}" -w $'\n%{http_code}' "$(_work_es_url)/$es_path" 2>/dev/null)
     ret=$?
     (( ret != 0 )) && return $ret
     # Reordonne: code HTTP en premiere ligne, corps ensuite
@@ -189,8 +189,8 @@ work_es_query() {
         method="${1:u}"
         shift
     fi
-    local path="${1:-}" body="${2:-}"
-    if [[ -z "$path" ]]; then
+    local es_path="${1:-}" body="${2:-}"
+    if [[ -z "$es_path" ]]; then
         _ui_msg_fail "usage: work_es_query [METHOD] PATH [BODY|-]"
         return 1
     fi
@@ -200,7 +200,7 @@ work_es_query() {
     fi
 
     local out code resp
-    out=$(_work_es_curl "$method" "$path" "$body") || {
+    out=$(_work_es_curl "$method" "$es_path" "$body") || {
         _ui_msg_fail "Elasticsearch injoignable: $(_work_es_url)"
         return 1
     }

--- a/scripts/tests/zsh-special-vars.test.sh
+++ b/scripts/tests/zsh-special-vars.test.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Verifie qu aucune fonction ne declare en `local` un nom que zsh reserve.
+# Usage : scripts/tests/zsh-special-vars.test.sh
+#
+# Pourquoi ce test existe : en zsh, `path` est LIEE a `PATH` (tableau <-> scalaire).
+# Un `local path=...` dans une fonction remplace donc le PATH du shell pendant
+# toute la fonction, et plus aucune commande externe n est trouvable. Le symptome
+# est un code 127 sans message si stderr est redirige — ce qui a coute une session
+# de diagnostic sur work_es_apps. `status` est en lecture seule : zsh interrompt la
+# fonction sur « read-only variable: status ».
+set -uo pipefail
+
+ROOT="${ZANVIL_DIR:-$HOME/.zanvil}"
+
+TEST_TMPDIR=$(mktemp -d) || { echo "mktemp failed" >&2; exit 2; }
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+echo 0 > "$TEST_TMPDIR/pass"
+echo 0 > "$TEST_TMPDIR/fail"
+
+assert_equals() {
+    local label="$1" needle="$2" out
+    out=$(cat)
+    if [[ "$out" == "$needle" ]]; then
+        printf '  ok   %s\n' "$label"
+        echo $(($(cat "$TEST_TMPDIR/pass") + 1)) > "$TEST_TMPDIR/pass"
+    else
+        printf '  FAIL %s\n       attendu : %s\n       obtenu  : %s\n' \
+            "$label" "$needle" "$out"
+        echo $(($(cat "$TEST_TMPDIR/fail") + 1)) > "$TEST_TMPDIR/fail"
+    fi
+}
+
+echo "== le piege, documente de facon executable =="
+
+# Ces deux assertions ne testent pas zanvil mais zsh : elles fixent le
+# comportement dont depend tout le reste du fichier.
+zsh -c 'f() { local path=ceci-nest-pas-un-PATH; command -v ls >/dev/null 2>&1 && print trouve || print introuvable; }; f' \
+    | assert_equals "local path= rend les commandes externes introuvables" "introuvable"
+
+zsh -c 'f() { local status=x; print jamais-atteint; }; f 2>&1 | head -1' \
+    | assert_equals "local status= est refuse par zsh" "f: read-only variable: status"
+
+echo
+echo "== lint : aucune declaration locale d un nom reserve =="
+
+# Noms que zsh lie a une variable speciale ou garde en lecture seule. La liste
+# est volontairement courte : uniquement ceux qu un developpeur peut choisir
+# spontanement comme variable locale.
+RESERVED='path|cdpath|fpath|manpath|module_path|status|argv|options|functions|aliases|dirstack|psvar|watch|histchars'
+
+# Trois passes plutot qu une expression unique, pour rester lisible :
+#   1. les lignes qui declarent quelque chose ;
+#   2. tronquees a la premiere substitution de commande — sinon un argument comme
+#      `docker ps -f status=exited` passerait pour une declaration ;
+#   3. celles ou un nom reserve est effectivement affecte. Le dernier filtre
+#      epargne les noms composes (config_path, exit_status).
+hits=$(grep -rnE "(^|[[:space:];])(local|typeset)([[:space:]]+-[a-zA-Z]+)*[[:space:]]" \
+        --include='*.zsh' "$ROOT/core" "$ROOT/modules" 2>/dev/null \
+        | sed 's/\$(.*//' \
+        | grep -E "\b(${RESERVED})=" \
+        | grep -vE '\b[a-z_]+_(path|status|options|functions)=' || true)
+
+if [[ -n "$hits" ]]; then
+    printf '%s\n' "$hits" >&2
+fi
+printf '%s\n' "$(printf '%s' "$hits" | grep -c . || true)" \
+    | assert_equals "aucune variable reservee declaree en local" "0"
+
+echo
+echo "== verification fonctionnelle : _work_es_curl trouve curl =="
+
+# Un faux curl repond comme le vrai avec -w '\n%{http_code}' : corps, saut de
+# ligne, code. Si le PATH est detruit, il n est pas trouve et le code est 127.
+mkdir -p "$TEST_TMPDIR/bin"
+printf '#!/bin/sh\nprintf %s\n' "'{\"ok\":true}\n200'" > "$TEST_TMPDIR/bin/curl"
+chmod +x "$TEST_TMPDIR/bin/curl"
+cp /bin/cat /bin/sed "$TEST_TMPDIR/bin/" 2>/dev/null || true
+
+zsh -c "
+    PATH='$TEST_TMPDIR/bin:/usr/bin:/bin'
+    ES_USER=probe ES_PASSWORD=probe
+    _ui_msg_fail() { print \"FAIL: \$*\"; }
+    source '$ROOT/modules/work/elasticsearch.zsh'
+    out=\$(_work_es_curl POST 'es-apis-*/_search' '{\"size\":0}')
+    print \"\$?\"
+" 2>/dev/null | assert_equals "_work_es_curl : code de sortie 0 (curl trouve)" "0"
+
+zsh -c "
+    PATH='$TEST_TMPDIR/bin:/usr/bin:/bin'
+    ES_USER=probe ES_PASSWORD=probe
+    _ui_msg_fail() { print \"FAIL: \$*\"; }
+    source '$ROOT/modules/work/elasticsearch.zsh'
+    _work_es_curl POST 'es-apis-*/_search' '{\"size\":0}' | head -1
+" 2>/dev/null | assert_equals "_work_es_curl : code HTTP en premiere ligne" "200"
+
+echo
+echo "== verification fonctionnelle : hooks_list liste un hook =="
+
+REPO="$TEST_TMPDIR/repo"
+mkdir -p "$REPO"
+( cd "$REPO" && git init -q )
+printf '#!/bin/sh\nexit 0\n' > "$REPO/.git/hooks/pre-commit"
+chmod +x "$REPO/.git/hooks/pre-commit"
+
+zsh -c "
+    cd '$REPO'
+    source '$ROOT/core/ui.zsh' 2>/dev/null
+    source '$ROOT/modules/git/git_hooks.zsh'
+    hooks_list 2>&1 | grep -c 'read-only variable'
+" 2>/dev/null | assert_equals "hooks_list : aucune erreur read-only" "0"
+
+zsh -c "
+    cd '$REPO'
+    source '$ROOT/core/ui.zsh' 2>/dev/null
+    source '$ROOT/modules/git/git_hooks.zsh'
+    hooks_list 2>/dev/null | grep -c 'pre-commit'
+" 2>/dev/null | assert_equals "hooks_list : le hook pre-commit est liste" "1"
+
+echo
+pass=$(cat "$TEST_TMPDIR/pass")
+fail=$(cat "$TEST_TMPDIR/fail")
+printf '%d ok, %d echec(s)\n' "$pass" "$fail"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
## Symptôme

```
❯ work_es_apps 24h
✗ Requete ES en echec: https://es-observability.prd.api.udb.azr.intranet
```

## Cause racine

En zsh, **`path` est liée à `PATH`** — c'est le même paramètre sous deux formes. Un `local path=...` remplace donc le `PATH` du shell pendant toute la durée de la fonction :

```
PATH_avant=[/Users/…/.pyenv/shims:/Users/…]
PATH_dans_fonction=[es-apis-*/_search]
curl_ret=127
```

`_work_es_curl:41` déclarait `local method=$1 path=$2 …`. `command curl` renvoyait donc `127`, et le `2>/dev/null` de la ligne 55 avalait le `command not found: curl` qui aurait désigné la cause immédiatement.

Ce qui n'était **pas** en cause, vérifié couche par couche : DNS (`10.200.98.39`), TCP 443, TLS, authentification, index et requête — rejouée à la main, elle rend `http=200` avec l'agrégation complète.

`status` relève du même piège pour une autre raison : zsh le garde en lecture seule et interrompt la fonction sur `read-only variable: status`.

## Les cinq sites

| Fichier | Avant | Après | Effet observé |
|---|---|---|---|
| `elasticsearch.zsh:41` | `path=$2` | `es_path` | `127` silencieux — le symptôme rapporté |
| `elasticsearch.zsh:192` | `path=` | `es_path` | `work_es_query` idem |
| `project_switcher.zsh:282` | `path=""` | `proj_path` | `proj_add` vidait le `PATH` dès son entrée |
| `kube_config.zsh:949` | `status=` | `cluster_status` | `read-only variable` (chemin GKE) |
| `git_hooks.zsh:39` | `status=` | `hook_status` | `hooks_list` mourait après son en-tête |

## Vérification

`scripts/tests/zsh-special-vars.test.sh`, 7 assertions, sans dépendance :

- **Le piège documenté de façon exécutable** — deux assertions sur le comportement de zsh lui-même, dont dépend tout le reste du fichier.
- **Un lint** qui refuse la classe entière de bugs sur `core/` et `modules/`. Trois passes plutôt qu'une expression unique : les lignes de déclaration, tronquées à la première substitution de commande — sinon un argument comme `docker ps -f status=exited` passerait pour une déclaration — puis celles où un nom réservé est effectivement affecté.
- **Deux vérifications fonctionnelles** : `_work_es_curl` trouve un faux `curl` et rend `200` en première ligne ; `hooks_list` liste un `pre-commit` dans un dépôt temporaire sans erreur `read-only`.

RED avant correction (5 échecs, dont le `127` exact), GREEN après (`7 ok, 0 echec(s)`). Non-régression : `k9s-log-fmt.test.sh` reste à `53 ok, 0 echec(s)`.

Et sur le terrain, `work_es_apps 24h` répond enfin, `hooks_list` liste ses hooks.

## Reste ouvert, volontairement hors de cette PR

`_work_es_json` renvoie `1` indifféremment pour un échec réseau, un code HTTP non numérique et un HTTP ≥ 400, et `_work_es_curl` jette stderr. Trois causes très différentes pour un seul message — c'est ce qui a transformé un renommage de variable en session d'investigation. Un correctif de diagnosticabilité mérite sa propre PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)