### PR TITLE
feat(k9s): explorateur — Ctrl-R recharge les logs

### DIFF
--- a/config/k9s/plugins.yaml
+++ b/config/k9s/plugins.yaml
@@ -53,7 +53,10 @@ plugins:
       - --tail
       - "500"
 
-  # Explorateur de logs interactif (fzf) — filtrer, rechercher, copier
+  # Explorateur de logs interactif (fzf) — filtrer, rechercher, copier, recharger
+  # ZANVIL_K9S_RELOAD porte la commande a rejouer sur Ctrl-R. Elle est reconstruite
+  # depuis "$*", donc la ligne kubectl n est ecrite qu une fois : "$@" l execute
+  # pour le chargement initial, "$*" la restitue pour le rechargement.
   log-view-pod:
     shortCut: Ctrl-L
     description: Logs interactifs (fzf)
@@ -64,7 +67,7 @@ plugins:
     confirm: false
     args:
       - -c
-      - '"$@" | $ZANVIL_DIR/scripts/k9s-log-fmt.sh --pairs | $ZANVIL_DIR/scripts/k9s-log-view.sh'
+      - 'export ZANVIL_K9S_RELOAD="$* | $ZANVIL_DIR/scripts/k9s-log-fmt.sh --pairs"; "$@" | $ZANVIL_DIR/scripts/k9s-log-fmt.sh --pairs | $ZANVIL_DIR/scripts/k9s-log-view.sh'
       - dummy-arg
       - kubectl
       - logs
@@ -88,7 +91,7 @@ plugins:
     confirm: false
     args:
       - -c
-      - '"$@" | $ZANVIL_DIR/scripts/k9s-log-fmt.sh --pairs | $ZANVIL_DIR/scripts/k9s-log-view.sh'
+      - 'export ZANVIL_K9S_RELOAD="$* | $ZANVIL_DIR/scripts/k9s-log-fmt.sh --pairs"; "$@" | $ZANVIL_DIR/scripts/k9s-log-fmt.sh --pairs | $ZANVIL_DIR/scripts/k9s-log-view.sh'
       - dummy-arg
       - kubectl
       - logs

--- a/modules/kube/kube_config.zsh
+++ b/modules/kube/kube_config.zsh
@@ -1239,7 +1239,7 @@ Kube Config Manager - Commandes disponibles:
   kube_ns          Switch de namespace (interactif)
   k [ctx] [ns]     Ouvre k9s (supporte les alias, "all" pour tous ns)
   k9s: Shift-L     Logs formatés (logback) dans less
-  k9s: Ctrl-L      Logs interactifs (fzf) — filtrer, copier
+  k9s: Ctrl-L      Logs interactifs (fzf) — filtrer, copier, Ctrl-R recharge
   klog [pod] [ctn] Logs d'un pod (selection fzf) — JSON brut, --follow, --previous, --tail N, -n ns
   kube_k9s_setup   Deploie hotkeys + skin k9s depuis le repo
   kube_status      Affiche les configs actuellement chargees

--- a/scripts/k9s-log-view.sh
+++ b/scripts/k9s-log-view.sh
@@ -71,7 +71,23 @@ if [[ -n "$clip" ]]; then
         --bind="ctrl-o:execute-silent(printf '%s\n' {+2..} | $clip)"
     )
 else
-    opts+=(--header="$header   (presse-papier indisponible)")
+    header="$header   (presse-papier indisponible)"
+    opts+=(--header="$header")
+fi
+
+# --- rechargement ------------------------------------------------------------
+# Le plugin k9s passe dans ZANVIL_K9S_RELOAD la commande qui a produit ces
+# lignes. Le viewer n en sait rien de plus : c est une chaine opaque qu il
+# rejoue, donc il continue d ignorer d ou viennent ses lignes et quel format
+# elles ont. Sans la variable, aucun binding : le viewer reste un filtre pur.
+# reload-sync et non reload, pour que la liste ne soit remplacee qu une fois la
+# commande terminee — sinon elle se vide le temps de l appel a kubectl.
+if [[ -n "${ZANVIL_K9S_RELOAD:-}" ]]; then
+    header="ctrl-r recharger   $header"
+    opts+=(
+        --header="$header"
+        --bind="ctrl-r:reload-sync($ZANVIL_K9S_RELOAD)"
+    )
 fi
 
 fzf "${opts[@]}" >/dev/null

--- a/scripts/tests/k9s-log-fmt.test.sh
+++ b/scripts/tests/k9s-log-fmt.test.sh
@@ -276,6 +276,34 @@ printf '%s\n' "$?" | assert_equals "erreur fzf (2) : code preserve" "2"
 rm -f "$TEST_TMPDIR/bin/fzf"
 
 echo
+echo "== viewer (raccourci de rechargement) =="
+
+# Le viewer ignore sa source : il ne recoit qu une chaine opaque a reexecuter,
+# que le plugin k9s lui passe dans ZANVIL_K9S_RELOAD. Un faux fzf qui recrache
+# ses arguments suffit a verifier que le binding est construit — ou absent.
+# Il ecrit sur stderr : le viewer redirige la sortie de fzf vers /dev/null.
+_fake_fzf_echo_args() {
+    printf '#!/bin/sh\nfor a in "$@"; do printf "%%s\\n" "$a" >&2; done\n' \
+        > "$TEST_TMPDIR/bin/fzf"
+    chmod +x "$TEST_TMPDIR/bin/fzf"
+}
+
+_fake_fzf_echo_args
+
+printf '%s\n' '{"level":"INFO","message":"x"}' | "$FMT" --pairs \
+    | env PATH="$TEST_TMPDIR/bin" ZANVIL_K9S_RELOAD='kubectl logs p | fmt --pairs' \
+        "$VIEW" 2>&1 >/dev/null \
+    | grep -c 'ctrl-r:reload-sync(kubectl logs p | fmt --pairs)' \
+    | assert_equals "ZANVIL_K9S_RELOAD definie : binding ctrl-r construit" "1"
+
+printf '%s\n' '{"level":"INFO","message":"x"}' | "$FMT" --pairs \
+    | env PATH="$TEST_TMPDIR/bin" "$VIEW" 2>&1 >/dev/null \
+    | grep -c 'ctrl-r' \
+    | assert_equals "ZANVIL_K9S_RELOAD absente : aucun binding ctrl-r" "0"
+
+rm -f "$TEST_TMPDIR/bin/fzf"
+
+echo
 echo "== thread et logger : identifiants sur une seule ligne =="
 
 # Un nom de thread ou de logger contenant une tabulation ou un newline casserait

--- a/web/docs/superpowers/specs/2026-07-28-k9s-log-viewer-design.md
+++ b/web/docs/superpowers/specs/2026-07-28-k9s-log-viewer-design.md
@@ -134,7 +134,7 @@ Ajout de la ligne `Ctrl-L` dans `kube_help`, section k9s.
 ## Hors périmètre
 
 - Brancher `klog` sur `k9s-log-fmt.sh` — il affiche encore du JSON brut. Le formatteur restant un filtre pur, le branchement sera trivial.
-- Mode `--follow` interactif : `fzf` exige un flux fini pour rester utilisable.
+- ~~Mode `--follow` interactif : `fzf` exige un flux fini pour rester utilisable.~~ **Rectifié le 30 juillet 2026 :** cette justification est fausse. `fzf` lit son entrée de façon asynchrone et reste utilisable sur un flux continu, et `k9s-log-view.sh` le branche directement sur le pipe — rien n'y attend d'EOF. Deux causes réelles empêchaient le suivi : `kubectl logs` était invoqué sans `-f`, et surtout `jq` sans `--unbuffered` retient sa sortie jusqu'à remplir son tampon, donc rien n'atteindrait `fzf` avant plusieurs kilo-octets. Ce qui rend la phrase `Le mode statique conserve le streaming` de la section Solution également inexacte. Le rechargement à la demande (`Ctrl-R`) est arrivé à la place ; le suivi continu reste à faire et demandera ce `--unbuffered`.
 - Compteurs par niveau dans le header de `fzf` : imposerait de bufferiser tout le flux avant le premier affichage.
 - Nettoyage des vestiges repérés pendant le diagnostic : `~/.config/k9s/hotkeys.yaml` divergent et inutilisé sur macOS, `k9s.log` à 12,6 Mo saturé par un `CRDs load Fail` toutes les 15 s (droits RBAC manquants sur `customresourcedefinitions`).
 


### PR DESCRIPTION
## Origine

L'explorateur `Ctrl-L` affichait un instantané de 500 lignes sans aucun moyen de le rafraîchir.

Le spec du 28 juillet justifiait cette absence par « `fzf` exige un flux fini pour rester utilisable ». **C'est faux**, et le diagnostic l'a établi : `fzf` lit son entrée de façon asynchrone, et `k9s-log-view.sh:77` le branche directement sur le pipe — rien n'y attend d'EOF. Deux causes réelles empêchaient le suivi :

1. `kubectl logs` était invoqué sans `-f` ;
2. surtout, `jq` sans `--unbuffered` retient sa sortie jusqu'à remplir son tampon. Mesuré sur un flux où la seconde ligne arrive 2 s après la première :

```
sans --unbuffered :  [s=54] a    [s=54] b     ← les deux d'un coup, à la fin
avec --unbuffered :  [s=54] a    [s=56] b     ← au fil de l'eau
```

## Pourquoi un rechargement plutôt qu'un suivi continu

`fzf` ne descend pas automatiquement vers les nouvelles lignes : un flux continu remplirait la liste sans que rien ne bouge à l'écran. `reload-sync` correspond à l'usage réel d'un explorateur — on fouille, puis on veut l'état frais.

## Ce que fait cette PR

`ZANVIL_K9S_RELOAD` porte la commande à rejouer. Le viewer n'en sait rien de plus : c'est une chaîne opaque, il continue donc d'ignorer d'où viennent ses lignes et quel format elles ont — la séparation que le spec défendait tient toujours.

```bash
if [[ -n "${ZANVIL_K9S_RELOAD:-}" ]]; then
    header="ctrl-r recharger   $header"
    opts+=(--header="$header" --bind="ctrl-r:reload-sync($ZANVIL_K9S_RELOAD)")
fi
```

Dans `plugins.yaml`, la ligne `kubectl` n'est **écrite qu'une fois** : `"$@"` l'exécute pour le chargement initial, `"$*"` la restitue pour le rechargement.

Trois propriétés tenues :

- **Rétrocompatible** — sans la variable, aucun binding : `… | k9s-log-view.sh` à la main reste un filtre pur.
- **`reload-sync` et non `reload`** — la liste n'est remplacée qu'une fois `kubectl` terminé, donc elle ne se vide pas entre-temps.
- **Le viewer reste ignorant de sa source.**

## Vérification

Deux assertions ajoutées à `k9s-log-fmt.test.sh`, via un faux `fzf` qui recrache ses arguments sur **stderr** (le viewer redirige sa sortie vers `/dev/null`) : binding construit quand la variable est fournie, **absent** sinon. RED avant (`attendu : 1, obtenu : 0`), puis `55 ok, 0 echec(s)`.

Et de bout en bout, avec un faux `kubectl` et un faux `fzf` :

```
BIND=[--bind=ctrl-r:reload-sync(kubectl logs mon-pod -n prod --context ctx
      --tail 500 --all-containers=true | …/k9s-log-fmt.sh --pairs)]
```

## Notes

- `kube_help` mentionne désormais `Ctrl-R`.
- La justification fausse du spec est rectifiée sur place plutôt que supprimée, avec les mesures à l'appui.
- **Le suivi continu reste à faire** : il demandera `--unbuffered` sur `jq` et un raccourci `less -R +F` distinct.
- Après merge, `kube_k9s_setup` est nécessaire pour déployer le plugin (k9s v0.51 lit `~/Library/Application Support/k9s/` sur macOS, pas `~/.config/k9s/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)