### PR TITLE
docs(site): rattraper le retard de la doc en ligne

### DIFF
--- a/tests/bin/undocumented-modules
+++ b/tests/bin/undocumented-modules
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Imprime les guards de module qui ne sont pas cites dans la doc en ligne.
+#
+# Une sortie vide signifie que tout module portant un .module.toml est documente. Ce
+# script ne juge rien : il rapporte un ecart, et c est le cas gaveldrop
+# tests/cases/docs/site-documents-every-module.yaml qui decide si l ecart est
+# acceptable.
+#
+# Le sens de la comparaison est deliberement asymetrique. Tout guard declare par un
+# .module.toml DOIT etre documente : c est un module que l utilisateur peut activer.
+# L inverse est legitime — ZANVIL_MODULE_NUSHELL et ZANVIL_MODULE_MISE sont lus par
+# core/aliases.zsh et rc.zsh sans passer par un .module.toml, et meritent leur place
+# dans la doc.
+set -uo pipefail
+
+ROOT="${ZANVIL_DIR:-$HOME/.zanvil}"
+DOC="$ROOT/web/site/src/content/docs/configuration.md"
+
+if [[ ! -f "$DOC" ]]; then
+    printf 'undocumented-modules: page introuvable: %s\n' "$DOC" >&2
+    exit 2
+fi
+
+declares=$(find "$ROOT/modules" -name '.module.toml' -exec grep -h '^guard' {} + \
+           | sed 's/.*"\(.*\)"/\1/' | sort -u)
+documentes=$(grep -ohE 'ZANVIL_MODULE_[A-Z_]+' "$DOC" | sort -u)
+
+comm -23 <(printf '%s\n' "$declares") <(printf '%s\n' "$documentes")

--- a/tests/cases/docs/site-documents-every-module.yaml
+++ b/tests/cases/docs/site-documents-every-module.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Garde-fou contre la derive de la doc en ligne, ajoute apres un rattrapage de 57
+# commits ou huit modules sur onze manquaient. La sidebar du site etant manuelle, rien
+# ne signalait qu un module nouveau n etait pas documente.
+#
+# Ce cas est inhabituel : son sujet n est pas une fonction de zanvil mais la coherence
+# entre le code et sa documentation. Il tient ici plutot que dans une etape de CI parce
+# qu il se lance avec le reste de la suite, en local comme en integration.
+name: site-documents-every-module
+weight: 7
+setup:
+  env:
+    ZANVIL_DIR: "$GAVELDROP_PROJECT"
+  run: ["$GAVELDROP_PROJECT/tests/bin/undocumented-modules"]
+expect:
+  exit_code: 0
+  stdout:
+    # Une sortie vide, sinon le `got` nomme exactement les guards a documenter — c est
+    # ce que l on veut lire quand ce cas casse.
+    equals: ""

--- a/web/site/astro.config.mjs
+++ b/web/site/astro.config.mjs
@@ -16,9 +16,11 @@ export default defineConfig({
         { label: 'Guides', items: [
           { label: 'Installation', slug: 'installation' },
           { label: 'Configuration', slug: 'configuration' },
+          { label: 'Kubernetes et k9s', slug: 'kubernetes-k9s' },
         ]},
         { label: 'Référence', items: [
           { label: 'Commandes', slug: 'commandes' },
+          { label: 'Tests', slug: 'tests' },
         ]},
       ],
     }),

--- a/web/site/src/content/docs/commandes.md
+++ b/web/site/src/content/docs/commandes.md
@@ -86,6 +86,16 @@ Toutes les commandes `zanvil-*` utilisent un style visuel moderne et compact via
 | `kube_azure [cluster]` | Récupère credentials Azure AKS |
 | `kube_aws [cluster]` | Récupère credentials AWS EKS |
 | `kube_gcp [cluster]` | Récupère credentials GCP GKE |
+| `kube_k9s_setup` | Déploie hotkeys, skin et plugins k9s depuis le dépôt |
+| `klog [pod] [ctn]` | Logs d'un pod, sélection fzf — suivi continu par défaut, JSON brut |
+
+`klog` accepte `--no-follow`, `-p` pour le conteneur précédent après un crash, `-n` pour le namespace,
+`--tail N` (100 par défaut), `-g` pour filtrer par expression régulière, `-A` pour tous les pods du même
+label `app=`, et `-t` pour les horodatages `kubectl`. Il affiche le JSON tel quel : le rendu formaté est
+du ressort des plugins k9s.
+
+Les trois plugins de logs k9s — `Shift-L`, `Ctrl-L` et `Ctrl-R` — ont leur propre page :
+[Kubernetes et k9s](/zanvil/kubernetes-k9s/).
 
 ## SSH
 
@@ -97,15 +107,34 @@ Toutes les commandes `zanvil-*` utilisent un style visuel moderne et compact via
 | `ssh_remove [host]` | Supprime un host |
 | `ssh_test <host>` | Teste la connexion |
 
-## Tmux
+## Outils tiers
+
+Chaque module d'outil déploie la configuration versionnée du dépôt vers le `$HOME` de la machine. Le
+module ne fait rien si son binaire est absent : il affiche la commande `brew install` correspondante.
 
 | Commande | Description |
 |----------|-------------|
-| `tm [session]` | Attach ou crée une session |
-| `tm-list` | Liste les sessions |
-| `tm-kill [session]` | Tue une session |
-| `tm-project [dir]` | Crée une session projet |
-| `tm-rename [name]` | Renomme la session courante |
+| `delta_setup` | Écrit `~/.gitconfig.d/delta` et ajoute l'`[include]` dans `~/.gitconfig` |
+| `lazygit_setup` | Affiche la configuration active (`LG_CONFIG_FILE`) et l'état de `config-local.yml` |
+| `atuin_setup` | Déploie `~/.config/atuin/config.toml` et affiche le chemin de la base |
+| `posting_setup` | Déploie `~/.config/posting/config.yaml` |
+| `lg` | Lance lazygit en suivant le changement de répertoire à la sortie |
+| `po` | Alias de `posting` |
+
+## Elasticsearch (module work)
+
+Interrogation de l'Elasticsearch interne. `ES_USER` et `ES_PASSWORD` sont attendus dans
+l'environnement — voir `env.d/` et le chiffrement sops.
+
+| Commande | Description |
+|----------|-------------|
+| `work_es_apps [plage]` | Applications par volume sur la plage (défaut `24h`), avec cache d'une heure |
+| `work_es_count <app>` | Compte les événements, avec la fenêtre temporelle observée |
+| `work_es_tail <app>` | Derniers événements d'une application |
+| `work_es_query [METHODE] <chemin>` | Requête brute, corps sur `stdin` avec `-` |
+| `work_fetch_logs` | Récupère les logs d'une application vers un fichier |
+
+Les plages s'écrivent `Xs`, `Xm`, `Xh` ou `Xd`. `work_es_apps --refresh` ignore le cache.
 
 ## Git Hooks
 

--- a/web/site/src/content/docs/configuration.md
+++ b/web/site/src/content/docs/configuration.md
@@ -12,21 +12,20 @@ La configuration se fait via `~/.zanvil/config.zsh`.
 cp ~/.zanvil/examples/config.zsh.example ~/.zanvil/config.zsh
 ```
 
-## Architecture v2
+## Architecture
 
-En v2, la configuration est répartie dans `core/` :
+La configuration est répartie dans `core/` :
 
 | Fichier | Rôle |
 |---------|------|
+| `core/ui.zsh` | Système UI — chargé en premier, fournit les `_ui_*` et la palette du thème |
 | `core/variables.zsh` | Variables d'environnement |
 | `core/aliases.zsh` | Alias globaux |
-| `core/hooks.zsh` | Hooks shell (chpwd, precmd, etc.) |
-| `core/loader.zsh` | Chargement des modules |
-| `core/ui.zsh` | Système UI |
-| `core/commands.zsh` | Commandes zanvil-* |
-| `core/admin.zsh` | Administration |
-| `core/theme.zsh` | Gestion des thèmes |
-| `core/setup.zsh` | Setup initial |
+| `core/loader.zsh` | Découverte et chargement des modules |
+| `core/hooks.zsh` | Init des outils (starship, fzf, mise, zoxide, direnv, `.zanvil.local`) |
+| `core/completions.zsh` | Complétions des commandes core |
+| `core/commands/` | Commandes `zanvil-*` : `commands.zsh`, `admin.zsh`, `theme.zsh`, `setup.zsh`, `check_env_deps.zsh` |
+| `core/lifecycle/` | Cycle de vie : `auto_update.zsh`, `migrate.zsh`, `sync.zsh` |
 
 ## Modules
 
@@ -48,13 +47,34 @@ Chaque module est dans `modules/<name>/` avec un `init.zsh` et optionnellement u
 Configuration manuelle dans `config.zsh` :
 
 ```zsh
-# Activer/désactiver les modules
-ZANVIL_MODULE_GITLAB=true    # Scripts GitLab
-ZANVIL_MODULE_DOCKER=true    # Utilitaires Docker
-ZANVIL_MODULE_NVM=true       # Auto-switch Node
-ZANVIL_MODULE_NUSHELL=false  # Intégration Nushell
-ZANVIL_MODULE_KUBE=true      # Gestion Kubernetes
+# Modules metier
+ZANVIL_MODULE_GITLAB=true     # Alias GitLab, clone de groupes, statut PAT
+ZANVIL_MODULE_KUBE=true       # Gestion kubeconfig (kube_select, Azure/AWS/GCP)
+ZANVIL_MODULE_DOCKER=true     # Utilitaires Docker (dex, dstop)
+ZANVIL_MODULE_SECURITY=false  # Audit de securite et scan de secrets
+ZANVIL_MODULE_AI=false        # Estimation de tokens LLM et contexte repo
+ZANVIL_MODULE_ZPROJECT=false  # Contexte projet par shell, via le CLI Rust
+ZANVIL_MODULE_TOOLS=false     # mise hooks, test runner, profiler zsh
+
+# Outils tiers — chacun deploie sa configuration avec <outil>_setup
+ZANVIL_MODULE_DELTA=true      # Pager syntaxique pour git diff
+ZANVIL_MODULE_LAZYGIT=true    # TUI Git ergonomique (alias lg)
+ZANVIL_MODULE_ATUIN=true      # Historique shell enrichi SQLite (fuzzy search)
+ZANVIL_MODULE_POSTING=true    # Client HTTP TUI (alias po)
+
+# Integrations
+ZANVIL_MODULE_MISE=true       # Gestionnaire de versions (Node, Java, Maven)
+ZANVIL_MODULE_NUSHELL=true    # Integration Nushell
 ```
+
+Un module dont le guard est absent de `config.zsh` reste inactif. Les modules `git`, `ssh`, `utils`,
+`project` et `work` n'ont pas de guard : ils sont toujours chargés.
+
+:::note[Migration depuis NVM]
+`ZANVIL_MODULE_NVM` est déprécié au profit de `ZANVIL_MODULE_MISE`, qui gère Node mais aussi Java et
+Maven. `rc.zsh` reporte automatiquement l'ancienne valeur sur la nouvelle et retire `ZANVIL_NVM_LAZY`,
+qui n'a plus d'effet — rien à changer dans un `config.zsh` existant.
+:::
 
 ## Variables dynamiques (env.d/)
 
@@ -112,15 +132,17 @@ zanvil-theme minimal
 
 Le thème actif est enregistré dans `~/.zanvil/.current_theme`.
 
-## NVM (Node Version Manager)
+## Versions de runtimes (mise)
+
+`mise` remplace NVM et couvre Node, Java et Maven. Il est activé par défaut et branché dans
+`core/hooks.zsh`, qui appelle `mise activate zsh` au démarrage si le binaire est présent.
 
 ```zsh
-# Lazy loading (recommandé) — charge NVM au premier appel node/npm
-ZANVIL_NVM_LAZY=true
-
-# Chargement immédiat (ajoute ~200ms au démarrage)
-ZANVIL_NVM_LAZY=false
+ZANVIL_MODULE_MISE=true
 ```
+
+Les hooks du module `tools` (`modules/tools/mise_hooks.zsh`) ajoutent la détection du fichier
+`.mise.toml` d'un projet au `cd`.
 
 ## Auto-update
 

--- a/web/site/src/content/docs/kubernetes-k9s.md
+++ b/web/site/src/content/docs/kubernetes-k9s.md
@@ -1,0 +1,137 @@
+---
+title: Kubernetes et k9s
+description: Contextes, namespaces et les trois plugins de logs k9s — rendu logback, explorateur interactif, rechargement.
+---
+
+Le module `kube` gère les kubeconfigs, les alias de contexte, et déploie dans k9s trois plugins qui
+transforment des logs JSON en quelque chose de lisible.
+
+## Alias de contexte
+
+Les noms de contexte Kubernetes réels sont longs. `~/.kube/.context_aliases` associe un nom court à
+chacun :
+
+```
+blg-dev=aks-blg-caasplatform-dev-common-001
+blg-qlf=aks-blg-caasplatform-qlf-common-001
+```
+
+Le fichier est lu par `kube_switch`, par `k` et par le prompt Starship, qui affiche l'alias plutôt que
+le nom complet.
+
+```bash
+kube_switch blg-dev     # bascule sur le contexte complet
+kube_switch             # sélection fzf si aucun argument
+kube_ns                 # sélection du namespace
+k blg-dev default       # k9s sur un contexte et un namespace
+k blg-dev all           # tous les namespaces
+```
+
+## Déployer les plugins
+
+```bash
+kube_k9s_setup
+```
+
+La commande copie hotkeys, skin et `plugins.yaml` vers le répertoire de configuration de k9s, en
+résolvant `$ZANVIL_DIR` **au moment de la copie** : le plugin déployé ne dépend d'aucune variable que
+k9s devrait connaître.
+
+:::caution[Emplacement selon la plateforme]
+k9s ne lit pas `~/.config/k9s/` sur macOS depuis la v0.32 mais
+`~/Library/Application Support/k9s/`. `kube_k9s_setup` écrit au bon endroit ; en cas de doute,
+`k9s info` affiche le chemin réellement utilisé.
+:::
+
+## Les trois plugins
+
+| Touche | Ce que ça fait |
+|--------|----------------|
+| `Shift-L` | Logs formatés façon logback, dans `less` |
+| `Ctrl-L` | Explorateur interactif `fzf` — filtrer, copier, rejouer un événement |
+| `Ctrl-R` | Dans l'explorateur : recharge les logs |
+
+Les deux premiers s'appliquent à un pod comme à un conteneur.
+
+### `Shift-L` — le rendu logback
+
+```
+kubectl logs … | k9s-log-fmt.sh | less -R +G
+```
+
+Le rendu suit le pattern console de logback
+`%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg` :
+
+```
+08:00:00.123 INFO  [main] c.b.f.FooService - Démarrage terminé
+08:00:01.456 ERROR [nio-8080-exec-2] c.b.f.BarClient - Timeout amont
+  java.lang.IllegalStateException: Timeout amont
+      at com.boulanger.foo.BarClient.send(BarClient.java:17)
+      ... 24 more
+08:00:02.001 WARN  [scheduling-1] c.b.f.Cleanup - 3 orphelins ignorés
+                                  http.status=503  retry=2
+```
+
+Ce que le formatteur fait des champs :
+
+- **Horodatage** — l'heure seule, `HH:mm:ss.SSS`. Champs reconnus : `@timestamp`, `timestamp`, `time`.
+  Absent, la colonne est remplie d'espaces pour préserver l'alignement.
+- **Niveau** — complété à cinq caractères. `level`, `severity` ou `lvl`, texte comme numérique
+  (pino, bunyan). Coloré selon la gravité.
+- **Thread** — tronqué à 20 caractères, entre crochets, omis s'il manque.
+- **Logger** — abrégé selon la règle `%logger{36}` : `com.boulanger.foo.FooService` devient
+  `c.b.f.FooService`, la classe finale étant toujours préservée.
+- **Stack trace** — restituée et indentée, depuis `stack_trace`, `exception`, `stacktrace` ou
+  `throwable`.
+- **Champs MDC** — sur une seconde ligne alignée sous le message. `trace_id` et `span_id` sont masqués :
+  ils encombrent la ligne et restent consultables dans l'aperçu de l'explorateur.
+
+Une ligne qui n'est pas du JSON valide est réémise telle quelle.
+
+### `Ctrl-L` — l'explorateur
+
+```
+kubectl logs … | k9s-log-fmt.sh --pairs | k9s-log-view.sh
+```
+
+`fzf` filtre en fuzzy sur le texte rendu, tandis que le JSON source reste accessible aux raccourcis.
+
+| Touche | Action |
+|--------|--------|
+| *(saisie)* | Filtrage fuzzy. `'motif` pour une correspondance exacte |
+| `Tab` | Marque une ligne (sélection multiple) |
+| `Ctrl-R` | Recharge les logs — relance la commande `kubectl` d'origine |
+| `Ctrl-Y` | Copie le texte rendu, codes ANSI retirés |
+| `Ctrl-O` | Copie le JSON source complet |
+| `⏎` | Rejoue l'événement seul dans le formatteur, stack trace complète, dans `less` |
+| `?` | Déplie ou replie l'aperçu JSON — replié au démarrage |
+| `Esc` | Quitte et rend le terminal à k9s |
+
+Le presse-papier est résolu au démarrage : `pbcopy`, sinon `wl-copy`, sinon
+`xclip -selection clipboard`. Si aucun n'est disponible, les raccourcis de copie disparaissent et
+l'en-tête le signale. Si `fzf` est absent, l'explorateur se rabat sur `less`.
+
+`Ctrl-R` rejoue la commande `kubectl` telle qu'elle a été lancée, et ne remplace la liste qu'une fois
+la nouvelle sortie complète — la liste ne se vide pas entre-temps.
+
+:::note[Pas de suivi continu]
+L'explorateur affiche un instantané des 500 dernières lignes, que `Ctrl-R` rafraîchit. Il n'y a pas
+d'équivalent de `tail -f` : `fzf` n'avance pas automatiquement vers les nouvelles lignes, donc un flux
+continu remplirait la liste sans que rien ne bouge à l'écran.
+:::
+
+## Rejouer sans cluster
+
+`config/k9s/fixtures/logs-sample.jsonl` permet d'éprouver le rendu à la main :
+
+```bash
+scripts/k9s-log-fmt.sh         < config/k9s/fixtures/logs-sample.jsonl
+scripts/k9s-log-fmt.sh --pairs < config/k9s/fixtures/logs-sample.jsonl | scripts/k9s-log-view.sh
+```
+
+## Autres plugins déployés
+
+| Touche | Portée | Action |
+|--------|--------|--------|
+| `Shift-Y` | deployments, pods, configmaps | YAML live via `delta`, sinon `bat`, sinon `less` |
+| `Shift-R` | deployments | `rollout restart`, avec confirmation |

--- a/web/site/src/content/docs/tests.md
+++ b/web/site/src/content/docs/tests.md
@@ -39,6 +39,7 @@ bash scripts/tests/zsh-special-vars.test.sh # lint des variables reservees zsh
 | CLI Rust | `theme list`, `theme current`, `modules list`, `doctor`, `--help` — code de sortie et contenu de la sortie |
 | Modules d'outils | Les **deux** branches de posting, delta, lazygit et atuin : binaire présent et binaire absent |
 | Rendu k9s | Le pattern logback, les niveaux numériques, l'abréviation du logger, les stack traces, les champs MDC, le mode `--pairs` |
+| Documentation | Tout module portant un `.module.toml` est cité dans `configuration.md` — ce garde-fou existe parce que la doc avait dérivé de huit modules |
 
 ## Deux mécanismes qui font l'intérêt de la suite
 

--- a/web/site/src/content/docs/tests.md
+++ b/web/site/src/content/docs/tests.md
@@ -1,0 +1,103 @@
+---
+title: Tests
+description: La suite de cas gaveldrop, ce qu'elle couvre, et comment la lancer localement.
+---
+
+zanvil est testé par [gaveldrop](https://github.com/Dr0drigues/gaveldrop), un moteur où **un cas est un
+fichier YAML**. Il prépare un environnement isolé, invoque le sujet, observe, et rend un verdict.
+
+Le projet ne change rien pour être testable : aucune instrumentation, aucun mode test dans le code.
+
+## Lancer la suite
+
+```bash
+cd ~/.zanvil
+gaveldrop                    # tous les cas
+gaveldrop --only cli/        # ceux dont le chemin contient « cli/ »
+gaveldrop --watch            # relance à chaque enregistrement
+gaveldrop --verbose          # ce que le moteur a décidé pour chaque cas
+```
+
+Installation, deux binaires — le second est ce qui remplace les dépendances qu'un cas simule :
+
+```bash
+cargo install gaveldrop-cli gaveldrop-fake --locked
+```
+
+Deux suites en bash complètent les cas, pour ce que le format n'exprime pas :
+
+```bash
+bash scripts/tests/k9s-log-fmt.test.sh      # decoupage de champs, contrat --pairs, viewer
+bash scripts/tests/zsh-special-vars.test.sh # lint des variables reservees zsh
+```
+
+## Ce qui est couvert
+
+| Famille | Ce qui est vérifié |
+|---------|--------------------|
+| Chargement | `rc.zsh` charge complètement, `ZANVIL_VERSION` est exposé, et `stderr` ne contient ni `command not found` ni `parse error` |
+| CLI Rust | `theme list`, `theme current`, `modules list`, `doctor`, `--help` — code de sortie et contenu de la sortie |
+| Modules d'outils | Les **deux** branches de posting, delta, lazygit et atuin : binaire présent et binaire absent |
+| Rendu k9s | Le pattern logback, les niveaux numériques, l'abréviation du logger, les stack traces, les champs MDC, le mode `--pairs` |
+
+## Deux mécanismes qui font l'intérêt de la suite
+
+**Le binaire d'un outil peut être simulé.** Tester `posting_setup` supposait jusqu'ici d'installer
+posting sur la machine. Un cas déclare l'outil comme simulé, décide ce qu'il répond, et vérifie ensuite
+le fichier déployé ainsi que le nombre d'appels — sans rien installer.
+
+**Un outil peut aussi être déclaré absent.** C'est l'autre moitié de chaque module : le message
+`brew install …` quand le binaire manque. Le verdict est alors le même sur un poste équipé et sur un
+runner vide, ce qu'une amputation du `PATH` ne garantissait que par accident.
+
+## L'isolation, et pourquoi elle compte ici
+
+Un cas s'exécute avec `HOME` redirigé vers un répertoire temporaire. Les fonctions qui écrivent dans
+`~/.config/…` sont donc observables sans machinerie, et n'altèrent rien sur la machine.
+
+Un hook construit au besoin un `ZANVIL_DIR` **dans** cette isolation, plutôt que de faire pointer les
+cas sur le dépôt. Quatre raisons, toutes constatées :
+
+- `.current_theme` et `config.zsh` ne sont pas versionnés : un cas qui les lirait dans le dépôt rendrait
+  un verdict dépendant de la machine ;
+- `delta_setup` écrit dans `$ZANVIL_DIR/config/lazygit/config.yml` ;
+- `rc.zsh` y écrit `.last_update_check` et `.work_context_cache` ;
+- le dépôt pèse près de deux gigaoctets avec `cli/target`, donc la copie est sélective.
+
+Le `config.zsh` que le hook écrit déclare `ZANVIL_PLUGINS=()` : le cas de chargement n'atteint jamais le
+réseau, là où copier `examples/config.zsh.example` déclencherait un `git clone`.
+
+## En intégration continue
+
+Trois jobs dans `.github/workflows/tests.yml`, sur Ubuntu et macOS :
+
+| Job | Rôle |
+|-----|------|
+| `cases` | La suite gaveldrop, avec les échecs annotés sur la ligne de l'assertion qui casse |
+| `smoke-test` | Présence des fichiers du cœur et des modules, plus les deux suites bash |
+| `rust-cli` | Compilation du CLI |
+
+## Écrire un cas
+
+Un cas nomme ce qu'il fait, ce qu'il invoque, et ce qu'il attend :
+
+```yaml
+name: k9s-uppercases-the-level
+weight: 3
+setup:
+  stdin: |
+    {"@timestamp":"2026-07-28T08:00:01.456Z","level":"error","message":"Boom"}
+  run: ["$GAVELDROP_PROJECT/scripts/k9s-log-fmt.sh"]
+expect:
+  exit_code: 0
+  stdout:
+    ignore_ansi: true
+    equals: "08:00:01.456 ERROR Boom"
+```
+
+`$GAVELDROP_PROJECT` est la racine du dépôt : le répertoire courant, lui, est l'isolation.
+`ignore_ansi` est nécessaire parce que le formatteur colore chaque champ.
+
+Une règle vaut d'être suivie : **écrire l'attendu délibérément faux d'abord**, constater l'échec, puis
+le corriger avec ce que le rapport affiche. Un cas dont on n'a jamais vu l'échec risque de ne pas
+pouvoir échouer du tout — et il ressemblerait alors à de la couverture sans en être.


### PR DESCRIPTION
## Constat

Le site n'avait pas été touché depuis le **27 juillet — 57 commits de retard**, dont deux releases (v4.2.0, v4.3.0).

Le retard était surtout fait d'**absences**, mais j'ai trouvé trois affirmations **fausses** :

| Écart | Réalité |
|---|---|
| `configuration.md` cite `core/commands.zsh`, `core/admin.zsh`, `core/theme.zsh`, `core/setup.zsh` | ces quatre fichiers sont sous `core/commands/` depuis la réorganisation |
| La liste des modules en cite 5 | il y en a **11** avec un guard ; 8 étaient absents (AI, ATUIN, DELTA, LAZYGIT, POSTING, SECURITY, TOOLS, ZPROJECT) |
| Une section documente `ZANVIL_NVM_LAZY` | `rc.zsh:49` la `unset` depuis le passage à `mise` — la variable n'a plus d'effet |
| `commandes.md` documente `tm-list` | le module tmux a été supprimé |

## Corrections

**`configuration.md`** — l'arborescence `core/` réelle, les 11 guards avec les descriptions reprises des `.module.toml`, la mention des 5 modules sans guard (toujours chargés), et une note de migration NVM → mise qui explique que rien n'est à changer dans un `config.zsh` existant.

**`commandes.md`** — `tm-list` retiré, et trois sections ajoutées : les `*_setup` des quatre outils tiers, le module Elasticsearch (`work_es_apps`, `work_es_count`, `work_es_tail`, `work_es_query`, `work_fetch_logs`), et `kube_k9s_setup` / `klog` avec ses options réelles.

## Deux pages que la matière justifiait

**Kubernetes et k9s** — les alias de contexte, `kube_k9s_setup` avec l'avertissement sur l'emplacement macOS (`~/Library/Application Support/k9s/`, pas `~/.config/k9s/`), et les trois plugins de logs : ce que le formatteur fait de chaque champ, la table des raccourcis de l'explorateur, et pourquoi il n'y a pas de suivi continu (`fzf` n'avance pas vers les nouvelles lignes).

**Tests** — la suite de 50 cas : comment la lancer, ce qui est couvert, les deux mécanismes qui font son intérêt (un binaire simulé, un binaire déclaré absent), pourquoi l'isolation compte, et la règle de l'attendu délibérément faux.

Sidebar mise à jour — elle est manuelle, ce qui explique aussi que la dérive passe inaperçue.

## Vérification

Chaque affirmation des nouvelles pages est vérifiée contre le code, pas rédigée de mémoire :

- raccourcis du viewer ← les `--bind` de `k9s-log-view.sh` (`?`, `enter`, `ctrl-y`, `ctrl-o`, `ctrl-r`)
- portées de `Shift-Y` et `Shift-R` ← `plugins.yaml` (deployments/pods/configmaps, deployments)
- options de `klog` ← l'en-tête de `modules/kube/klog.zsh`
- guards et descriptions ← les `.module.toml`
- `--tail 500` ← les 4 occurrences dans `plugins.yaml`

**Deux de mes propres conclusions étaient fausses et ont été corrigées en cours de route** : j'avais déduit que `ZANVIL_MODULE_NUSHELL` était supprimé parce qu'il n'a pas de `.module.toml` — il est bien utilisé (`core/aliases.zsh:80`, `rc.zsh:32`) et reste documenté ; et que `klog` n'existait pas, mon grep ne ciblant que `kube_config.zsh`.

Le site construit : `7 page(s) built`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)