### PR TITLE
ci(gaveldrop): action@v1, et publier le rapport avec le site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,6 +6,15 @@ on:
     paths:
       - 'web/site/**'
       - '.github/workflows/pages.yml'
+      # Le rapport publie reflete l etat des tests : il doit etre regenere quand ils
+      # changent, pas seulement quand le site change. Sans ces chemins, le badge
+      # afficherait le verdict d un commit ancien — pire qu aucun badge.
+      - 'tests/**'
+      - 'gaveldrop.yaml'
+      - 'core/**'
+      - 'modules/**'
+      - 'scripts/**'
+      - 'cli/**'
   workflow_dispatch:
 
 permissions:
@@ -22,6 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      # --- le site ---
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -31,6 +42,41 @@ jobs:
         working-directory: web/site
       - run: npm run build
         working-directory: web/site
+
+      # --- le rapport de la suite, publie AVEC le site ---
+      # docs/ci.md de gaveldrop propose un job `pages` dedie. Impossible ici : un depot
+      # n a qu un seul deploiement Pages actif, et celui-ci sert deja la documentation.
+      # Le rapport est donc ecrit dans le dist du site, ce qui donne la meme chose — des
+      # fichiers servis avec leur vrai type a une adresse fixe — sans concurrencer la doc.
+      - name: Install zsh
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq zsh jq
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            cli/target
+          key: ${{ runner.os }}-pages-${{ hashFiles('cli/Cargo.lock') }}
+
+      # Les cinq cas CLI invoquent ce binaire par son chemin.
+      - name: Build the zanvil CLI
+        run: cd cli && cargo build --release
+
+      - uses: Dr0drigues/gaveldrop/action@v1
+        with:
+          install-only: 'true'
+
+      # `|| true` deliberement : un cas qui casse doit produire un badge rouge, pas
+      # empecher le deploiement de la documentation.
+      - name: Write the report into the site
+        run: |
+          gaveldrop \
+            --report-html web/site/dist/rapport.html \
+            --report-badge web/site/dist/badge.svg || true
+          ls -l web/site/dist/rapport.html web/site/dist/badge.svg
+
       - uses: actions/upload-pages-artifact@v3
         with:
           path: web/site/dist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,22 +134,38 @@ jobs:
       # secondes sur « Can't find 'action.yml' ». v0.1.2 la contient — verifie par
       # `git ls-tree v0.1.2:action`.
       #
-      # v0.1.2 est un minimum, pas une preference : c est la version qui apporte
-      # setup.stdin, equals et ignore_ansi, dont depend chaque cas de tests/cases/k9s/,
-      # et deja setup.hide sur un outil fake pour les quatre cas
-      # `*-warns-when-its-binary-is-missing`.
+      # @v1 est un tag mobile, repointe a chaque release — la convention de
+      # actions/checkout@v4. Il evite une PR par version, et il ne suivra pas une v2
+      # dont le format pourrait changer. Les cles dont dependent les cas — setup.stdin,
+      # equals, ignore_ansi, setup.hide sur un outil fake — sont toutes dans 0.1.x, donc
+      # tout v1 les portera. Pour epingler : @v0.1.3, qui ne bougera jamais.
       #
-      # --annotate place l echec sur la ligne de l assertion qui casse, pas dans un log
-      # que personne ne deroule.
+      # Quatre rapports, chacun pour un lecteur :
+      #   --annotate      place l echec sur la ligne de l assertion, dans la PR
+      #   --report-junit  le tableau de bord de la CI
+      #   --report-html   chaque cas se deplie sur ce que le sujet a produit : code de
+      #                   sortie, les deux flux, les outils appeles avec leur compte, les
+      #                   fichiers ecrits. C est la question qu un verdict ne pose pas —
+      #                   « qu a fait mon module », au-dela de savoir si l attente tenait
+      #   --report-badge  un SVG portant le score pondere, vert / ambre / rouge
       - name: Run the cases
-        uses: Dr0drigues/gaveldrop/action@v0.1.2
+        uses: Dr0drigues/gaveldrop/action@v1
         with:
-          args: --annotate --report-junit junit.xml
+          args: >-
+            --annotate
+            --report-junit junit.xml
+            --report-html report.html
+            --report-badge badge.svg
 
-      # if: always() — le rapport est le plus utile quand l etape precedente a echoue.
-      - name: Keep the report
+      # if: always() — les rapports sont le plus utiles quand l etape precedente a
+      # echoue. Le HTML est autonome : aucun script, aucune requete reseau, donc il
+      # s ouvre directement depuis l artefact telecharge.
+      - name: Keep the reports
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: cases-${{ matrix.os }}
-          path: junit.xml
+          path: |
+            junit.xml
+            report.html
+            badge.svg

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Architecture hybride <strong>Rust CLI + modules zsh</strong> pour des performanc
 
 <p align="center">
   <a href="https://github.com/Dr0drigues/gaveldrop"><img src="https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/badge.svg" alt="tested with gaveldrop"></a>
+  <a href="https://dr0drigues.github.io/zanvil/rapport.html"><img src="https://dr0drigues.github.io/zanvil/badge.svg" alt="score de la suite"></a>
 </p>
 
 ## Installation


### PR DESCRIPTION
## Le changement demandé

```diff
-        uses: Dr0drigues/gaveldrop/action@v0.1.2
+        uses: Dr0drigues/gaveldrop/action@v1
```

Le tag mobile plutôt que l'épinglage : il évite une PR par release — j'en ai fait **trois aujourd'hui** — et il ne suivra pas une v2 dont le format pourrait changer. Les clés dont dépendent les cas (`setup.stdin`, `equals`, `ignore_ansi`, `setup.hide` sur un outil faké) sont toutes dans 0.1.x, donc tout `v1` les portera.

## Les deux rapports qui manquaient

```yaml
args: >-
  --annotate
  --report-junit junit.xml
  --report-html report.html
  --report-badge badge.svg
```

Vérifié localement, et le pli apprend déjà quelque chose sur zanvil :

```
rc-loads-without-an-error
  what it did   exit 0
  stdout        [WARN] …/.gitlab_secrets introuvable. Le token GitLab est manquant.
                version=v4.4.0
  calls         atuin ×2, delta ×1, lazygit ×1, posting ×1
  files         .zcompdump (50344 bytes), zanvil/.last_update_check (11 bytes),
                zanvil/.work_context_cache (17 bytes)
```

**Le chargement d'un shell n'est pas silencieux** : il émet un avertissement GitLab sur stdout, qu'aucun cas n'asserte. C'est exactement le genre de chose qu'un verdict ne dit pas — j'avais trouvé les écritures dans `$ZANVIL_DIR` par le `also written, not asserted`, avec de la chance.

## Un écart forcé avec la recette de `docs/ci.md`

La recette propose un job `pages` dédié. **Impossible ici** : un dépôt n'a qu'un seul déploiement Pages actif, et celui-ci sert déjà la documentation Astro. Un second job aurait écrasé le site.

Le rapport est donc écrit **dans le `dist` du site**, ce qui donne la même chose — des fichiers servis avec leur vrai type à une adresse fixe — sans concurrencer la doc :

- `https://dr0drigues.github.io/zanvil/rapport.html`
- `https://dr0drigues.github.io/zanvil/badge.svg`

Deux conséquences assumées :

- **`pages.yml` gagne zsh, Rust et gaveldrop.** Il passait ~20 s en Node seul ; il compilera désormais le CLI (avec cache cargo).
- **Son déclencheur s'élargit** à `tests/`, `gaveldrop.yaml`, `core/`, `modules/`, `scripts/`, `cli/`. Sans ces chemins, le badge afficherait le verdict d'un commit ancien — pire qu'aucun badge.

Le `|| true` de la recette est conservé, et il est délibéré : un cas qui casse doit produire un badge **rouge**, pas empêcher le déploiement de la documentation.

## Vérifications

- Le rapport est **autonome** : `grep -c '<script\|src="http\|@import'` → `0`. Il s'ouvre depuis un artefact téléchargé, sans réseau.
- Simulation locale du job : `rapport.html` (25,9 Ko) et `badge.svg` (574 o) atterrissent bien dans `web/site/dist/`, qui reste gitignored.
- Les trois artefacts de `tests.yml` sont uploadés ensemble.

## Note

Le second badge du README pointe vers une URL qui n'existera qu'**après** le premier déploiement suivant le merge. Il sera cassé quelques minutes, le temps que `pages.yml` tourne.

Les deux badges ne disent pas la même chose : l'un qu'une suite existe, l'autre ce qu'elle a trouvé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)