### PR TITLE
test(gaveldrop): l'explorateur de logs migre, et stdout est maîtrisé

### DIFF
--- a/gaveldrop.yaml
+++ b/gaveldrop.yaml
@@ -1,8 +1,11 @@
 cases: tests/cases/**/*.yaml
 
-# Les quatre outils de modules/tools/. Declares ici, ils sont shadowes par defaut, ce qui rend leur
-# branche « binaire present » testable sans avoir a les installer. Les cas qui testent l autre branche
-# s y soustraient un par un avec `setup.hide` : la declaration vaut pour la suite, la cle vaut pour un
-# cas, et le plus specifique decide.
+# Les quatre outils de modules/tools/. Declares ici, ils sont shadowes par defaut, ce qui
+# rend leur branche « binaire present » testable sans avoir a les installer. Les cas qui
+# testent l autre branche s y soustraient un par un avec `setup.hide` : la declaration
+# vaut pour la suite, la cle vaut pour un cas, et le plus specifique decide.
+#
+# fzf sert les cas du viewer : les uns le simulent pour choisir son code de sortie, un
+# autre le cache pour eprouver le repli. Les deux coexistent depuis la v0.1.1.
 fake:
-  bins: [posting, delta, lazygit, atuin]
+  bins: [posting, delta, lazygit, atuin, fzf]

--- a/scripts/tests/k9s-log-fmt.test.sh
+++ b/scripts/tests/k9s-log-fmt.test.sh
@@ -3,19 +3,16 @@
 # Usage : scripts/tests/k9s-log-fmt.test.sh
 set -uo pipefail
 
-# Ce fichier ne couvre plus que ce qui reste hors de portee des cas gaveldrop de
-# tests/cases/k9s/ — 50 cas y couvrent desormais le rendu, les egalites et les
-# comptages, ces derniers devenus des egalites sur la sortie entiere.
+# Ce fichier ne couvre plus que ce qui reste hors de portee des cas gaveldrop — 57 cas
+# couvrent desormais le rendu, les egalites, les comptages et le viewer.
 #
-# Restent ici :
-#   - les mesures qui exigent de decouper la sortie avant de comparer : `cut -f2-`
-#     pour le JSON source, `awk -F'\t' '{print NF}'` pour le nombre de champs. Une
-#     egalite sur la ligne entiere les couvrirait, mais l attendu contiendrait une
-#     tabulation litterale au milieu d un JSON — illisible dans un fichier de cas ;
-#   - le contrat --pairs verifie sur la fixture de dix lignes, ou l assertion porte
-#     sur le rapport entre le nombre de lignes entrantes et sortantes ;
-#   - les trois sections du viewer, qui pilotent un faux fzf, son PATH et son code
-#     de sortie.
+# Restent ici les seules mesures qui exigent de decouper la sortie avant de comparer :
+# `cut -f2-` pour isoler le JSON source, et `awk -F'\t' '{print NF}'` pour compter les
+# champs. Une egalite sur la ligne entiere les couvrirait, mais l attendu porterait une
+# tabulation litterale au milieu d un JSON — illisible dans un fichier de cas.
+#
+# S y ajoute le contrat --pairs verifie sur la fixture de dix lignes, ou l assertion porte
+# sur le rapport entre le nombre de lignes entrantes et sortantes.
 #
 # Ces assertions ne sont donc pas un oubli de migration.
 
@@ -24,8 +21,8 @@ FMT="$ROOT/scripts/k9s-log-fmt.sh"
 FIXTURES="$ROOT/config/k9s/fixtures/logs-sample.jsonl"
 
 # Repertoire temporaire pour les compteurs : les assertions tournent en fin de
-# pipeline (donc dans une sous-shell) ou une simple variable ne survivrait pas
-# a l issue du pipe ; on passe donc par des fichiers.
+# pipeline (donc dans une sous-shell) ou une simple variable ne survivrait pas a l issue
+# du pipe ; on passe donc par des fichiers.
 TEST_TMPDIR=$(mktemp -d) || { echo "mktemp failed" >&2; exit 2; }
 trap 'rm -rf "$TEST_TMPDIR"' EXIT
 echo 0 > "$TEST_TMPDIR/pass"
@@ -113,93 +110,6 @@ printf '%s\n' '{"level":"INFO","message":"Ligne1\rLigne2"}' | "$FMT" --pairs | c
 
 printf '%s\n' $'col1\tcol2 texte brut' | "$FMT" --pairs | cut -f2- \
     | assert_equals "texte brut avec tabulation : source intacte" $'col1\tcol2 texte brut'
-
-echo
-echo "== viewer (repli sans fzf) =="
-
-VIEW="$ROOT/scripts/k9s-log-view.sh"
-
-# PATH minimal sans fzf : on ne peut pas se fier a /usr/bin:/bin pour exclure
-# fzf (apt l installe la-bas sur Debian/Ubuntu). On construit un bin dedie
-# avec uniquement ce dont le viewer et son repli ont besoin (bash pour le
-# shebang, dirname pour se localiser, sed et less pour l affichage simple).
-mkdir -p "$TEST_TMPDIR/bin"
-ln -s "$(command -v bash)" "$TEST_TMPDIR/bin/bash"
-ln -s "$(command -v dirname)" "$TEST_TMPDIR/bin/dirname"
-ln -s "$(command -v sed)" "$TEST_TMPDIR/bin/sed"
-ln -s "$(command -v less)" "$TEST_TMPDIR/bin/less"
-
-# Le viewer doit se rabattre sur un affichage simple et n afficher que le
-# premier champ. LESS=-FX evite d ouvrir un pager interactif.
-printf '%s\n' '{"level":"INFO","message":"Bonjour"}' \
-    | "$FMT" --pairs \
-    | env PATH="$TEST_TMPDIR/bin" LESS="-FX" "$VIEW" \
-    | assert_contains "repli sans fzf : premier champ affiche" "INFO  Bonjour"
-
-printf '%s\n' '{"level":"INFO","message":"Bonjour"}' \
-    | "$FMT" --pairs \
-    | env PATH="$TEST_TMPDIR/bin" LESS="-FX" "$VIEW" \
-    | assert_equals "repli sans fzf : JSON source masque" "             INFO  Bonjour"
-
-echo
-echo "== viewer (code de sortie) =="
-
-# k9s affiche une popup d erreur des que le plugin sort non nul. Quitter fzf par
-# Esc rend 130, et un filtre sans correspondance rend 1 : deux sorties normales.
-# Un faux fzf permet de verifier la normalisation sans TTY.
-_fake_fzf() {
-    printf '#!/bin/sh\nexit %s\n' "$1" > "$TEST_TMPDIR/bin/fzf"
-    chmod +x "$TEST_TMPDIR/bin/fzf"
-}
-
-# L entree passe par un fichier, pas par un pipe, et c est la CI Linux qui l a
-# impose : le faux fzf sort immediatement sans lire son entree, donc jq recevait un
-# SIGPIPE et sortait en 2. Avec `pipefail` actif, le code mesure alors le pipeline
-# entier au lieu du viewer — ces trois assertions verifiaient autre chose que ce
-# qu elles annoncaient. Sur macOS le timing le masquait, d ou le passage inapercu.
-printf '%s\n' '{"level":"INFO","message":"x"}' | "$FMT" --pairs > "$TEST_TMPDIR/pairs.txt"
-
-_fake_fzf 130
-env PATH="$TEST_TMPDIR/bin" "$VIEW" < "$TEST_TMPDIR/pairs.txt" >/dev/null 2>&1
-printf '%s\n' "$?" | assert_equals "fzf annule (130) : sortie normalisee a 0" "0"
-
-_fake_fzf 1
-env PATH="$TEST_TMPDIR/bin" "$VIEW" < "$TEST_TMPDIR/pairs.txt" >/dev/null 2>&1
-printf '%s\n' "$?" | assert_equals "aucune correspondance (1) : sortie normalisee a 0" "0"
-
-_fake_fzf 2
-env PATH="$TEST_TMPDIR/bin" "$VIEW" < "$TEST_TMPDIR/pairs.txt" >/dev/null 2>&1
-printf '%s\n' "$?" | assert_equals "erreur fzf (2) : code preserve" "2"
-
-rm -f "$TEST_TMPDIR/bin/fzf"
-
-echo
-echo "== viewer (raccourci de rechargement) =="
-
-# Le viewer ignore sa source : il ne recoit qu une chaine opaque a reexecuter,
-# que le plugin k9s lui passe dans ZANVIL_K9S_RELOAD. Un faux fzf qui recrache
-# ses arguments suffit a verifier que le binding est construit — ou absent.
-# Il ecrit sur stderr : le viewer redirige la sortie de fzf vers /dev/null.
-_fake_fzf_echo_args() {
-    printf '#!/bin/sh\nfor a in "$@"; do printf "%%s\\n" "$a" >&2; done\n' \
-        > "$TEST_TMPDIR/bin/fzf"
-    chmod +x "$TEST_TMPDIR/bin/fzf"
-}
-
-_fake_fzf_echo_args
-
-# Entree par fichier, pour la meme raison que la section precedente : ce faux fzf
-# ne lit pas son entree non plus.
-env PATH="$TEST_TMPDIR/bin" ZANVIL_K9S_RELOAD='kubectl logs p | fmt --pairs' \
-    "$VIEW" < "$TEST_TMPDIR/pairs.txt" 2>&1 >/dev/null \
-    | grep -c 'ctrl-r:reload-sync(kubectl logs p | fmt --pairs)' \
-    | assert_equals "ZANVIL_K9S_RELOAD definie : binding ctrl-r construit" "1"
-
-env PATH="$TEST_TMPDIR/bin" "$VIEW" < "$TEST_TMPDIR/pairs.txt" 2>&1 >/dev/null \
-    | grep -c 'ctrl-r' \
-    | assert_equals "ZANVIL_K9S_RELOAD absente : aucun binding ctrl-r" "0"
-
-rm -f "$TEST_TMPDIR/bin/fzf"
 
 echo
 echo "== thread et logger : identifiants sur une seule ligne =="

--- a/tests/cases/boot/rc-loads-without-an-error.yaml
+++ b/tests/cases/boot/rc-loads-without-an-error.yaml
@@ -38,6 +38,10 @@ expect:
   exit_code: 0
   stdout:
     contains: ["version=v"]
+    # Un chargement sur un poste configure ne previent de rien. Le hook depose un
+    # .gitlab_secrets factice, donc ce message ne doit pas apparaitre — sans cette
+    # assertion, le bruit sur stdout passait inapercu.
+    absent: ["Le token GitLab est manquant"]
   # Le coeur du cas : l assertion qui n existait nulle part, et qui fait rougir un
   # module casse au chargement.
   stderr:

--- a/tests/cases/viewer/viewer-adds-no-binding-without-a-reload-command.yaml
+++ b/tests/cases/viewer/viewer-adds-no-binding-without-a-reload-command.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Le meme mecanisme, en sens inverse. Sans ZANVIL_K9S_RELOAD, aucun binding ctrl-r ne
+# doit etre construit : la premiere regle ne doit donc jamais matcher. Si elle matchait,
+# elle repondrait 3 et le cas rougirait.
+#
+# C est ce qui garantit que le viewer reste un filtre pur quand on l invoque a la main,
+# hors du plugin k9s.
+name: viewer-adds-no-binding-without-a-reload-command
+weight: 5
+setup:
+  stdin: "             INFO  x\t{\"level\":\"INFO\",\"message\":\"x\"}\n"
+  run: ["$GAVELDROP_PROJECT/scripts/k9s-log-view.sh"]
+fake:
+  rules:
+    - match: { bin: fzf, args_contain: "ctrl-r" }
+      exit: 3
+    - match: { bin: fzf }
+      exit: 130
+    - match: {}
+      exit: 127
+      stderr: "the case did not foresee this call"
+expect:
+  exit_code: 0
+  calls:
+    fzf: 1

--- a/tests/cases/viewer/viewer-binds-ctrl-r-when-a-reload-command-is-given.yaml
+++ b/tests/cases/viewer/viewer-binds-ctrl-r-when-a-reload-command-is-given.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# L assertion n est pas dans expect mais dans la SELECTION de la regle : si le viewer a
+# construit le binding, fzf est invoque avec « ctrl-r:reload-sync » dans ses arguments,
+# donc la premiere regle repond 130 — que le viewer normalise a 0. Sinon c est la seconde
+# qui repond 3, un code que le viewer preserve, et le cas rougit.
+name: viewer-binds-ctrl-r-when-a-reload-command-is-given
+weight: 5
+setup:
+  stdin: "             INFO  x\t{\"level\":\"INFO\",\"message\":\"x\"}\n"
+  env:
+    ZANVIL_K9S_RELOAD: "kubectl logs p | fmt --pairs"
+  run: ["$GAVELDROP_PROJECT/scripts/k9s-log-view.sh"]
+fake:
+  rules:
+    - match: { bin: fzf, args_contain: "ctrl-r:reload-sync" }
+      exit: 130
+    - match: { bin: fzf }
+      exit: 3
+    - match: {}
+      exit: 127
+      stderr: "the case did not foresee this call"
+expect:
+  exit_code: 0
+  calls:
+    fzf: 1

--- a/tests/cases/viewer/viewer-falls-back-to-less-without-fzf.yaml
+++ b/tests/cases/viewer/viewer-falls-back-to-less-without-fzf.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+name: viewer-falls-back-to-less-without-fzf
+weight: 5
+setup:
+  # Le seul cas qui cache fzf plutot que de le simuler : le sujet est justement ce que
+  # fait le viewer quand il ne le trouve pas. Cacher un outil absent est tolere, donc ce
+  # cas se comporte pareil sur un poste equipe et sur un runner nu.
+  hide: [fzf]
+  # Le format --pairs, ecrit a la main : texte rendu, TAB, JSON source. Le sujet est le
+  # viewer, pas le formatteur, donc les codes ANSI sont inutiles ici.
+  stdin: "             INFO  Bonjour\t{\"level\":\"INFO\",\"message\":\"Bonjour\"}\n"
+  env:
+    # Sans quoi less ouvrirait un pager interactif et le cas n aboutirait jamais.
+    LESS: "-FX"
+  run: ["$GAVELDROP_PROJECT/scripts/k9s-log-view.sh"]
+expect:
+  exit_code: 0
+  stdout:
+    ignore_ansi: true
+    # L egalite porte les deux assertions du test bash d un coup : le premier champ est
+    # affiche, et le JSON source ne l est pas.
+    equals: "             INFO  Bonjour"

--- a/tests/cases/viewer/viewer-normalises-a-cancelled-fzf.yaml
+++ b/tests/cases/viewer/viewer-normalises-a-cancelled-fzf.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+name: viewer-normalises-a-cancelled-fzf
+weight: 5
+setup:
+  stdin: "             INFO  x\t{\"level\":\"INFO\",\"message\":\"x\"}\n"
+  run: ["$GAVELDROP_PROJECT/scripts/k9s-log-view.sh"]
+fake:
+  rules:
+    # Une regle NOMMEE, pas le catch-all : un appel servi par `match: {}` est compte
+    # comme imprevu, puisque ce dernier existe pour detecter ce que le cas n a pas
+    # prevu. Le catch-all reste en dernier, et doit rester sans emploi.
+    - match: { bin: fzf }
+      exit: 130
+    - match: {}
+      exit: 127
+      stderr: "the case did not foresee this call"
+expect:
+  # k9s affiche une popup d erreur des que le plugin sort non nul. Esc rend 130 (128 + SIGINT) : une sortie normale, donc normalisee a 0.
+  exit_code: 0
+  # L appel est declare, sinon gaveldrop le compte comme imprevu : le viewer DOIT
+  # invoquer fzf une fois, et une seule.
+  calls:
+    fzf: 1

--- a/tests/cases/viewer/viewer-normalises-an-empty-filter.yaml
+++ b/tests/cases/viewer/viewer-normalises-an-empty-filter.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+name: viewer-normalises-an-empty-filter
+weight: 5
+setup:
+  stdin: "             INFO  x\t{\"level\":\"INFO\",\"message\":\"x\"}\n"
+  run: ["$GAVELDROP_PROJECT/scripts/k9s-log-view.sh"]
+fake:
+  rules:
+    # Une regle NOMMEE, pas le catch-all : un appel servi par `match: {}` est compte
+    # comme imprevu, puisque ce dernier existe pour detecter ce que le cas n a pas
+    # prevu. Le catch-all reste en dernier, et doit rester sans emploi.
+    - match: { bin: fzf }
+      exit: 1
+    - match: {}
+      exit: 127
+      stderr: "the case did not foresee this call"
+expect:
+  # Un filtre sans correspondance rend 1. Normal aussi : l utilisateur a juste trop filtre.
+  exit_code: 0
+  # L appel est declare, sinon gaveldrop le compte comme imprevu : le viewer DOIT
+  # invoquer fzf une fois, et une seule.
+  calls:
+    fzf: 1

--- a/tests/cases/viewer/viewer-preserves-a-real-fzf-error.yaml
+++ b/tests/cases/viewer/viewer-preserves-a-real-fzf-error.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+name: viewer-preserves-a-real-fzf-error
+weight: 5
+setup:
+  stdin: "             INFO  x\t{\"level\":\"INFO\",\"message\":\"x\"}\n"
+  run: ["$GAVELDROP_PROJECT/scripts/k9s-log-view.sh"]
+fake:
+  rules:
+    # Une regle NOMMEE, pas le catch-all : un appel servi par `match: {}` est compte
+    # comme imprevu, puisque ce dernier existe pour detecter ce que le cas n a pas
+    # prevu. Le catch-all reste en dernier, et doit rester sans emploi.
+    - match: { bin: fzf }
+      exit: 2
+    - match: {}
+      exit: 127
+      stderr: "the case did not foresee this call"
+expect:
+  # 2 est une vraie erreur fzf, et elle doit remonter — c est la seule que k9s doit signaler.
+  exit_code: 2
+  # L appel est declare, sinon gaveldrop le compte comme imprevu : le viewer DOIT
+  # invoquer fzf une fois, et une seule.
+  calls:
+    fzf: 1

--- a/tests/hooks/prepare-zanvil-dir.sh
+++ b/tests/hooks/prepare-zanvil-dir.sh
@@ -55,3 +55,11 @@ done
 printf 'minimal\n' >"$DST/.current_theme"
 
 mkdir -p "$HOME/.config" "$HOME/.kube" "$HOME/work"
+
+# Un jeton GitLab factice, parce que l isolation doit representer un poste CONFIGURE.
+# Sans ce fichier, modules/gitlab/gitlab_logic.zsh:11 previent au chargement et son
+# avertissement se melange a la sortie du sujet — le rapport HTML de gaveldrop l a
+# montre. Avec lui, le cas de chargement peut asserter que rien ne previent, ce qui est
+# plus strict : si le module se remettait a le faire malgre un fichier present, le cas
+# rougirait.
+printf "export GITLAB_TOKEN='jeton-de-test-sans-valeur'\n" >"$HOME/.gitlab_secrets"

--- a/web/site/src/content/docs/tests.md
+++ b/web/site/src/content/docs/tests.md
@@ -27,7 +27,7 @@ cargo install gaveldrop-cli gaveldrop-fake --locked
 Deux suites en bash complètent les cas, pour ce que le format n'exprime pas :
 
 ```bash
-bash scripts/tests/k9s-log-fmt.test.sh      # decoupage de champs, contrat --pairs, viewer
+bash scripts/tests/k9s-log-fmt.test.sh      # decoupage de champs, contrat --pairs
 bash scripts/tests/zsh-special-vars.test.sh # lint des variables reservees zsh
 ```
 
@@ -39,6 +39,7 @@ bash scripts/tests/zsh-special-vars.test.sh # lint des variables reservees zsh
 | CLI Rust | `theme list`, `theme current`, `modules list`, `doctor`, `--help` — code de sortie et contenu de la sortie |
 | Modules d'outils | Les **deux** branches de posting, delta, lazygit et atuin : binaire présent et binaire absent |
 | Rendu k9s | Le pattern logback, les niveaux numériques, l'abréviation du logger, les stack traces, les champs MDC, le mode `--pairs` |
+| Explorateur de logs | Le repli quand `fzf` manque, la normalisation des codes de sortie, et le binding `Ctrl-R` — présent avec une commande de rechargement, absent sans |
 | Documentation | Tout module portant un `.module.toml` est cité dans `configuration.md` — ce garde-fou existe parce que la doc avait dérivé de huit modules |
 
 ## Deux mécanismes qui font l'intérêt de la suite


### PR DESCRIPTION
Les deux points restants, tous deux révélés par le pli du rapport HTML arrivé en v0.1.3.

## 1. Le chargement n'était pas silencieux

Le pli montrait ceci, qu'aucun cas ne voyait :

```
rc-loads-without-an-error
  stdout   [WARN] …/.gitlab_secrets introuvable. Le token GitLab est manquant.
           version=v4.4.0
```

`modules/gitlab/gitlab_logic.zsh:11` prévient quand le fichier manque — comportement légitime, mais l'isolation représentait un poste **non configuré**, et ce bruit se mêlait à la sortie du sujet.

Le hook dépose désormais un jeton factice, et le cas asserte que **rien ne prévient** :

```yaml
stdout:
  contains: ["version=v"]
  absent: ["Le token GitLab est manquant"]
```

C'est plus strict qu'avant : si le module se remettait à prévenir malgré un fichier présent, le cas rougirait. Vérifié dans les deux sens — sans le fichier, le cas échoue en affichant le WARN exact.

## 2. L'explorateur de logs migre

**14 assertions bash deviennent 6 cas**, et le test bash tombe de 20 à 13 assertions (129 lignes).

| Cas | Ce qu'il prouve |
|---|---|
| `viewer-falls-back-to-less-without-fzf` | le repli n'affiche que le premier champ — `equals` porte les deux assertions du test bash d'un coup |
| `viewer-normalises-a-cancelled-fzf` | `Esc` rend 130, normalisé à 0 : k9s ne doit pas afficher de popup |
| `viewer-normalises-an-empty-filter` | un filtre sans correspondance rend 1, normalisé aussi |
| `viewer-preserves-a-real-fzf-error` | le code 2 remonte — la seule erreur que k9s doit signaler |
| `viewer-binds-ctrl-r-when-a-reload-command-is-given` | le binding est construit avec `ZANVIL_K9S_RELOAD` |
| `viewer-adds-no-binding-without-a-reload-command` | et **pas** sans — le viewer reste un filtre pur invoqué à la main |

### Les deux cas `Ctrl-R` n'assertent rien dans `expect`

C'est la **sélection de la règle** qui juge :

```yaml
fake:
  rules:
    - match: { bin: fzf, args_contain: "ctrl-r:reload-sync" }
      exit: 130        # normalisé à 0 par le viewer → le cas passe
    - match: { bin: fzf }
      exit: 3          # préservé → le cas rougit
```

Si le binding est construit, `fzf` est invoqué avec `ctrl-r:reload-sync` dans ses arguments et la première règle répond. Sinon la seconde. L'assertion `exit_code: 0` suffit alors à décider.

### Ce que j'ai appris en route

Un appel servi par le catch-all `match: {}` est compté comme **imprévu**, puisque ce dernier existe précisément pour détecter ce que le cas n'a pas prévu. Mes trois premiers cas échouaient sur `unexpected calls fzf` alors que le rapport affichait `calls fzf ×1` — apparemment contradictoire, en réalité cohérent. Les règles sont donc **nommées**, et le catch-all doit rester sans emploi.

`setup.hide` sur un outil **absent** est toléré (vérifié) : le cas du repli se comporte donc pareil sur un poste équipé et sur un runner où `fzf` n'est pas installé.

## Vérification par mutation

Chaque fois sur le cas ciblé, et lui seul :

| Mutation | Résultat |
|---|---|
| Binding `ctrl-r` neutralisé | 1 cas rouge (`binds-ctrl-r`) |
| Normalisation du code 1 retirée | 1 cas rouge (`normalises-an-empty-filter`) |
| Fichier `.gitlab_secrets` non déposé | 1 cas rouge (`rc-loads`) |

## État

```
gaveldrop                    57 cases · 57 passed · score 213/213
k9s-log-fmt.test.sh          13 ok, 0 echec(s)
zsh-special-vars.test.sh      7 ok, 0 echec(s)
```

Le bash restant ne couvre plus que ce qui exige de **découper** la sortie avant de comparer — `cut -f2-` pour le JSON source, `awk -F'\t' NF` pour le nombre de champs — plus le contrat `--pairs` sur la fixture de dix lignes. L'en-tête du fichier le dit.

La page « Tests » du site mentionne la nouvelle famille.

🤖 Generated with [Claude Code](https://claude.com/claude-code)