### PR TITLE
Cartographie zsh/Rust, et réparation du binaire qui n'était plus appelé

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -60,13 +60,38 @@ jobs:
           echo "previous=$CURRENT" >> $GITHUB_OUTPUT
           echo "New version: $NEW_TAG (was $CURRENT)"
 
-      - name: Bump version in core/ui.zsh
+      # Les DEUX versions, et pas seulement celle du zsh : un binaire qui annonce une
+      # version differente de son projet est precisement ce qui a fait passer
+      # zsh-env-cli v3.0.0 pour une installation valide pendant quatre mois. Le CLI
+      # etait reste en 3.1.0 alors que le projet affichait v4.4.0.
+      - name: Bump version in core/ui.zsh and cli/Cargo.toml
         if: steps.bump.outputs.type != 'skip'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           sed -i 's/export ZANVIL_VERSION="v[^"]*"/export ZANVIL_VERSION="${{ steps.version.outputs.tag }}"/' core/ui.zsh
-          git add core/ui.zsh
+          # Le tag porte un « v » que Cargo n'accepte pas dans un champ version. Le
+          # retrait passe par une variable intermediaire : ${VAR#v} est du bash, et
+          # l'imbriquer dans une expression ${{ }} de GitHub ne l'est pas.
+          TAG="${{ steps.version.outputs.tag }}"
+          CARGO_VERSION="${TAG#v}"
+          # python3 plutot que sed : la premiere version de cette etape utilisait
+          # `sed -i "0,/^version = /s/..."`, une plage GNU que le sed de macOS ignore en
+          # silence. Le workflow tourne sur ubuntu, donc ca aurait marche — mais personne
+          # n'aurait pu le verifier localement, et c'est precisement le genre de
+          # dependance a une variante que ce depot cherche a retirer.
+          python3 - "$CARGO_VERSION" <<'PY'
+          import re, sys, pathlib
+          p = pathlib.Path("cli/Cargo.toml")
+          # Seule la version du paquet, pas celles des dependances : on borne au premier
+          # `version =` qui suit `[package]`.
+          s = p.read_text()
+          i = s.index("[package]")
+          j = s.index("\n[", i + 1) if "\n[" in s[i + 1:] else len(s)
+          bloc = re.sub(r'^version = ".*"$', f'version = "{sys.argv[1]}"', s[i:j], count=1, flags=re.M)
+          p.write_text(s[:i] + bloc + s[j:])
+          PY
+          git add core/ui.zsh cli/Cargo.toml
           git commit -m "chore(release): bump version to ${{ steps.version.outputs.tag }}"
           git push origin main
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "zanvil"
-version = "3.1.0"
+version = "4.4.0"
 dependencies = [
  "chrono",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zanvil"
-version = "3.1.0"
+version = "4.4.0"
 edition = "2021"
 description = "CLI companion for zanvil"
 

--- a/cli/src/cmd/doctor.rs
+++ b/cli/src/cmd/doctor.rs
@@ -54,6 +54,20 @@ fn print_separator(width: usize) {
     println!("{}", "─".repeat(width));
 }
 
+/// Cherche `zanvil` dans le PATH, et rend le premier chemin trouve.
+///
+/// On ne se contente pas de `current_exe()` : la question n'est pas « ou suis-je »
+/// mais « qui repondra a une delegation zsh », et c'est le PATH qui en decide. Un
+/// binaire lance par son chemin complet peut parfaitement ne pas etre celui que
+/// `command -v zanvil` trouvera.
+fn which_zanvil() -> Option<String> {
+    let path = std::env::var_os("PATH")?;
+    std::env::split_paths(&path)
+        .map(|dir| dir.join("zanvil"))
+        .find(|candidate| candidate.is_file())
+        .map(|p| p.display().to_string())
+}
+
 fn command_exists(name: &str) -> bool {
     Command::new("which")
         .arg(name)
@@ -183,6 +197,52 @@ pub fn run() {
     } else {
         print_section("Integration", &fail_indicator(".zshrc"));
         issues += 1;
+    }
+
+    // ── Binaire ───────────────────────────────────────────────────────────
+    // Une delegation zsh retombe sur son repli quand ce binaire manque du PATH, et
+    // elle le fait silencieusement : ~/.local/bin a porte zsh-env-cli v3.0.0 pendant
+    // quatre mois apres le renommage de la v4.0.0, sans que rien ne le signale.
+    // Doctor est le seul endroit qui puisse le dire.
+    match which_zanvil() {
+        Some(path) => {
+            let running = std::env::current_exe()
+                .map(|p| p.display().to_string())
+                .unwrap_or_default();
+            if running == path {
+                print_section("Binaire", &format!("{}  {}", "✓".green(), path.dimmed()));
+            } else {
+                // Un autre zanvil est premier dans le PATH : c'est lui qui repondra
+                // aux delegations, pas celui qu'on vient de lancer.
+                print_section(
+                    "Binaire",
+                    &format!(
+                        "{}  {} {}",
+                        "⚠".yellow(),
+                        path.dimmed(),
+                        "(repond aux delegations)".dimmed()
+                    ),
+                );
+            }
+        }
+        None => {
+            issues += 1;
+            print_section(
+                "Binaire",
+                &format!(
+                    "{}  absent du PATH — les commandes zsh tombent sur leur repli",
+                    "✗".red()
+                ),
+            );
+            println!(
+                "               {}",
+                format!(
+                    "cd {}/cli && cargo build --release && cp target/release/zanvil ~/.local/bin/",
+                    zanvil_dir().display()
+                )
+                .dimmed()
+            );
+        }
     }
 
     println!();

--- a/core/lifecycle/auto_update.zsh
+++ b/core/lifecycle/auto_update.zsh
@@ -54,6 +54,23 @@ _zanvil_do_update() {
     if (cd "$ZANVIL_DIR" && git pull --quiet origin main 2>/dev/null); then
         echo -e "${_ui_green}[zanvil]${_ui_nc} Mise a jour terminee. Rechargez avec: ${_ui_bold}ss${_ui_nc}"
 
+        # Le git pull amene du code Rust neuf ; sans cette reconstruction, le binaire
+        # installe reste celui du dernier install.sh et devient silencieusement perime.
+        # C'est le troisieme volet de la panne des quatre mois : le code avancait, le
+        # binaire non, et rien ne le disait.
+        #
+        # Garde volontaire : on ne reconstruit que si un binaire est DEJA installe.
+        # Quelqu'un qui n'en veut pas ne doit pas en heriter par une mise a jour.
+        if command -v cargo &>/dev/null && [[ -x "$HOME/.local/bin/zanvil" ]]; then
+            echo -e "${_ui_blue}[zanvil]${_ui_nc} Reconstruction du binaire..."
+            if (cd "$ZANVIL_DIR/cli" && cargo build --release 2>/dev/null); then
+                cp "$ZANVIL_DIR/cli/target/release/zanvil" "$HOME/.local/bin/" \
+                    && _ui_msg_ok "binaire mis a jour"
+            else
+                _ui_msg_warn "reconstruction echouee — le binaire reste a sa version precedente"
+            fi
+        fi
+
         # Detecter les nouvelles commandes apres reload du fichier
         local new_help_file="$ZANVIL_DIR/core/commands/commands.zsh"
         if [[ -f "$new_help_file" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -770,6 +770,14 @@ if command -v cargo &>/dev/null; then
         mkdir -p "$HOME/.local/bin"
         cp "$TARGET_DIR/cli/target/release/zanvil" "$HOME/.local/bin/"
         log_success "zanvil installe dans ~/.local/bin/"
+
+        # Le binaire s'appelait zsh-env-cli avant la v4.0.0. Le laisser en place n'est
+        # pas anodin : il repond a --version, il est dans le PATH, et sa presence donne
+        # l'illusion d'une installation valide alors qu'aucune delegation ne l'appelle.
+        if [[ -e "$HOME/.local/bin/zsh-env-cli" ]]; then
+            rm -f "$HOME/.local/bin/zsh-env-cli"
+            log_success "ancien binaire zsh-env-cli retire"
+        fi
     else
         log_warn "Build de zanvil echoue (optionnel, les commandes zsh fonctionnent sans)"
     fi

--- a/tests/bin/stale-binary-references
+++ b/tests/bin/stale-binary-references
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Imprime les endroits ou le CODE appelle encore l'ancien nom du binaire.
+#
+# Le renommage zsh_env -> zanvil de la v4.0.0 a laisse un binaire zsh-env-cli en place
+# pendant quatre mois : il repondait a --version, il etait dans le PATH, et aucune
+# delegation ne l'appelait. Ce controle empeche qu'une delegation y revienne.
+#
+# Quatre exclusions, et chacune a sa raison — la premiere version de ce script les
+# ignorait et signalait six references toutes legitimes, ce qui en faisait un controle
+# qu'on desactive au premier echec :
+#
+#   1. les commentaires. Expliquer la panne demande de la nommer ; c'est le cas dans
+#      doctor.rs et dans le cas gaveldrop qui l'accompagne.
+#   2. install.sh, le seul endroit qui doit nommer l'ancien binaire pour le SUPPRIMER.
+#      Lui interdire le mot reviendrait a interdire la reparation.
+#   3. migrate_zanvil.zsh, dont l'en-tete dit qu'il porte volontairement les anciens
+#      noms pour detecter une installation heritee.
+#   4. la documentation, qui raconte le renommage — d'ou l'absence de *.md dans le scan.
+#
+# Reste ce qui compte : une invocation, une delegation, un `command -v` dans core/ ou
+# modules/. Il ne juge rien, il rapporte ; c'est le cas gaveldrop qui decide.
+set -uo pipefail
+
+ROOT="${ZANVIL_DIR:-$HOME/.zanvil}"
+
+grep -rn 'zsh-env-cli' "$ROOT/core" "$ROOT/modules" "$ROOT/scripts" \
+    --include='*.zsh' --include='*.sh' --include='*.rs' --include='*.yaml' \
+    2>/dev/null \
+    | grep -v 'migrate_zanvil.zsh' \
+    | grep -vE ':[0-9]+:[[:space:]]*(#|//)' \
+    | sed "s|^$ROOT/||" || true

--- a/tests/cases/cli/cli-doctor-reports-its-own-binary.yaml
+++ b/tests/cases/cli/cli-doctor-reports-its-own-binary.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Ce cas existe parce qu un repli silencieux a masque une panne pendant quatre mois :
+# ~/.local/bin portait zsh-env-cli v3.0.0 au lieu de zanvil, donc zproject etait casse
+# et trois commandes tournaient degradees sans le dire.
+#
+# Il n asserte PAS que le binaire est installe — ce serait vrai sur un poste et faux sur
+# un runner. Il asserte que doctor en PARLE, ce qui est vrai partout.
+name: cli-doctor-reports-its-own-binary
+weight: 7
+setup:
+  exec: ./tests/hooks/prepare-zanvil-dir.sh
+  env:
+    ZANVIL_DIR: "$HOME/zanvil"
+  run: ["$GAVELDROP_PROJECT/cli/target/release/zanvil", "doctor"]
+expect:
+  exit_code: 0
+  stdout:
+    # « Binaire » seul : la valeur qui suit depend de la machine — un poste equipe
+    # affiche un chemin, un runner affiche l absence — mais la SECTION existe partout.
+    contains: ["Binaire"]

--- a/tests/cases/docs/no-delegation-to-the-old-binary-name.yaml
+++ b/tests/cases/docs/no-delegation-to-the-old-binary-name.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Garde-fou contre le retour de l ancien nom du binaire dans une delegation. zsh-env-cli
+# a survecu quatre mois au renommage de la v4.0.0, et rien ne le signalait.
+#
+# Le controle porte sur les invocations dans core/, modules/ et scripts/ — pas sur les
+# commentaires qui expliquent la panne, ni sur install.sh qui doit nommer l ancien
+# binaire pour le supprimer. La premiere version de ce cas ne faisait pas ces
+# distinctions et signalait six references toutes legitimes.
+name: no-delegation-to-the-old-binary-name
+weight: 3
+setup:
+  env:
+    ZANVIL_DIR: "$GAVELDROP_PROJECT"
+  run: ["$GAVELDROP_PROJECT/tests/bin/stale-binary-references"]
+expect:
+  exit_code: 0
+  stdout:
+    # Vide, sinon le `got` nomme le fichier et la ligne a corriger.
+    equals: ""

--- a/web/docs/superpowers/plans/2026-08-03-binaire-visible.md
+++ b/web/docs/superpowers/plans/2026-08-03-binaire-visible.md
@@ -1,0 +1,567 @@
+# Chantier 1 — rendre le binaire installable, à jour, et son absence visible
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development
+> (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** faire que le CLI Rust soit effectivement installé sous le nom `zanvil`, qu'il suive les mises
+à jour du dépôt, et qu'une délégation ne puisse plus retomber silencieusement sur son repli zsh.
+
+**Architecture:** trois défauts indépendants concourent au même symptôme, et chacun se corrige à
+l'endroit où il se produit — `install.sh` pour le nettoyage de l'ancien nom, `_zanvil_do_update` pour la
+reconstruction, `doctor` pour la visibilité. Un cas gaveldrop vérifie le seul de ces trois points qui
+soit testable sans dépendre de la machine : que `doctor` signale un binaire manquant.
+
+**Tech Stack:** bash (`install.sh`), zsh (`core/lifecycle/auto_update.zsh`), Rust
+(`cli/src/cmd/doctor.rs`), gaveldrop v0.1.3.
+
+## Global Constraints
+
+- **Le repli zsh reste**, c'est une garantie documentée dans `CLAUDE.md`. Ce chantier ne le supprime
+  pas : il le rend visible. Un repli acceptable est un repli qu'on sait avoir pris.
+- **`core/lifecycle/migrate_zanvil.zsh` n'est pas le bon endroit** et ne doit pas être touché : la
+  migration est one-shot et idempotente (« ne fait rien si `~/.zanvil` existe »), donc déjà passée
+  partout où le problème se pose.
+- **Aucune assertion ne doit dépendre de ce que la machine a installé.** Le binaire est présent sur un
+  poste de développement et absent d'un runner : un cas qui teste `command -v zanvil` rendrait un
+  verdict différent selon l'endroit.
+- **Version minimale de gaveldrop : v0.1.3** — celle qu'épingle le job CI.
+- Chaque cas est écrit avec un attendu **faux**, lancé pour constater le `FAIL`, puis corrigé.
+- Les documents sous `web/docs/superpowers/` sont gitignored : les commits les ajoutent avec
+  `git add -f`.
+
+## Les trois défauts, et où chacun se corrige
+
+| Défaut | Constat | Fichier |
+|---|---|---|
+| L'ancien binaire n'est jamais retiré | `~/.local/bin/zsh-env-cli` v3.0.0 d'avril cohabite avec un `zanvil` jamais installé | `install.sh:767-777` |
+| Une mise à jour ne reconstruit pas le binaire | `_zanvil_do_update` fait `git pull` et rien d'autre : du code Rust neuf arrive, le binaire reste celui du dernier `install.sh` | `core/lifecycle/auto_update.zsh:44-56` |
+| Rien ne signale l'absence | `doctor` vérifie git, curl, jq, starship, kubectl — mais pas son propre binaire | `cli/src/cmd/doctor.rs` |
+
+---
+
+### Task 1: `doctor` signale son propre binaire
+
+Ce chantier commence par la visibilité, et non par la réparation : c'est elle qui manquait pendant
+quatre mois, et c'est le seul des trois points qu'un cas peut vérifier sans dépendre de la machine.
+
+**Files:**
+- Modify: `cli/src/cmd/doctor.rs`
+- Create: `tests/cases/cli/cli-doctor-reports-its-own-binary.yaml`
+
+**Interfaces:**
+- Consumes: `tests/hooks/prepare-zanvil-dir.sh` (lot 1), qui fournit un `ZANVIL_DIR` isolé.
+- Produces: une section `Binaire` dans la sortie de `doctor`, que la tâche 3 ne réutilise pas mais que
+  le cas de cette tâche asserte.
+
+- [ ] **Step 1: Écrire le cas avec un attendu faux**
+
+```yaml
+# tests/cases/cli/cli-doctor-reports-its-own-binary.yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Ce cas existe parce qu'un repli silencieux a masque une panne pendant quatre mois :
+# ~/.local/bin portait zsh-env-cli v3.0.0 au lieu de zanvil, donc zproject etait casse
+# et trois commandes tournaient degradees sans le dire.
+#
+# Il n asserte PAS que le binaire est installe — ce serait vrai sur un poste et faux sur
+# un runner. Il asserte que doctor en PARLE, ce qui est vrai partout.
+name: cli-doctor-reports-its-own-binary
+weight: 7
+setup:
+  exec: ./tests/hooks/prepare-zanvil-dir.sh
+  env:
+    ZANVIL_DIR: "$HOME/zanvil"
+  run: ["$GAVELDROP_PROJECT/cli/target/release/zanvil", "doctor"]
+expect:
+  exit_code: 0
+  stdout:
+    contains: ["une-section-qui-nexiste-pas"]
+```
+
+- [ ] **Step 2: Lancer et constater l'échec**
+
+```bash
+cd ~/.zanvil && gaveldrop --only cli-doctor-reports-its-own
+```
+
+Attendu : `FAIL cli-doctor-reports-its-own-binary 0/7`, avec sous `got` la sortie actuelle de `doctor` —
+qui ne contient aucune ligne sur son binaire.
+
+- [ ] **Step 3: Ajouter la section dans `doctor.rs`**
+
+À insérer après la section `Integration` et avant `Requis`, en suivant le style des sections existantes
+(`print_section` avec les symboles de `super::`) :
+
+```rust
+    // ── Binaire ───────────────────────────────────────────────────────────────
+    // Une delegation zsh retombe sur son repli quand ce binaire manque, et le fait
+    // silencieusement. Doctor est le seul endroit qui puisse le dire.
+    let own = which_zanvil();
+    let own_line = match &own {
+        Some(path) => {
+            let running = std::env::current_exe()
+                .ok()
+                .map(|p| p.display().to_string())
+                .unwrap_or_default();
+            if running.starts_with(path) || path == &running {
+                format!("{} {}", "✓".green(), path)
+            } else {
+                // Un autre zanvil est premier dans le PATH : les delegations zsh
+                // appelleront celui-la, pas celui qu'on vient de lancer.
+                format!("{} {} (celui qui repond aux delegations)", "⚠".yellow(), path)
+            }
+        }
+        None => {
+            issues += 1;
+            format!(
+                "{} absent du PATH — les commandes zsh tombent sur leur repli. \
+                 Installez-le : cd {}/cli && cargo build --release && \
+                 cp target/release/zanvil ~/.local/bin/",
+                "✗".red(),
+                zanvil_dir.display()
+            )
+        }
+    };
+    print_section("Binaire", &own_line);
+```
+
+Et la fonction de recherche, à ajouter à côté de `command_exists` :
+
+```rust
+/// Cherche `zanvil` dans le PATH, et rend le premier chemin trouve.
+///
+/// On ne se contente pas de `current_exe()` : la question n'est pas « ou suis-je »
+/// mais « qui repondra a une delegation zsh », et c'est le PATH qui en decide.
+fn which_zanvil() -> Option<String> {
+    let path = std::env::var_os("PATH")?;
+    std::env::split_paths(&path)
+        .map(|dir| dir.join("zanvil"))
+        .find(|candidate| candidate.is_file())
+        .map(|p| p.display().to_string())
+}
+```
+
+- [ ] **Step 4: Compiler et vérifier la sortie à la main**
+
+```bash
+cd ~/.zanvil/cli && cargo build --release && cd .. && \
+  ZANVIL_DIR="$PWD" ./cli/target/release/zanvil doctor | grep -A1 Binaire
+```
+
+Attendu : une ligne `Binaire` suivie soit d'un `✓` avec le chemin, soit d'un `✗ absent du PATH` avec la
+commande d'installation. Sur une machine où le binaire n'est pas installé, c'est le second cas — et
+c'est le comportement qui manquait.
+
+- [ ] **Step 5: Corriger l'attendu du cas**
+
+```yaml
+  stdout:
+    # « Binaire » seul : la valeur qui suit depend de la machine — un poste equipe
+    # affiche un chemin, un runner affiche l'absence — mais la SECTION existe partout.
+    contains: ["Binaire"]
+```
+
+- [ ] **Step 6: Vérifier le vert, puis la faillibilité**
+
+```bash
+gaveldrop --only cli-doctor-reports-its-own
+```
+
+Attendu : `ok cli-doctor-reports-its-own-binary 7/7`.
+
+Puis prouver que le cas mord, en retirant la section :
+
+```bash
+cd ~/.zanvil && cp cli/src/cmd/doctor.rs /tmp/doctor.bak
+sed -i '' '/print_section("Binaire"/d' cli/src/cmd/doctor.rs
+(cd cli && cargo build --release) && gaveldrop --only cli-doctor-reports-its-own
+```
+
+Attendu : `FAIL`. Puis restaurer :
+
+```bash
+cp /tmp/doctor.bak cli/src/cmd/doctor.rs && (cd cli && cargo build --release)
+gaveldrop --only cli-doctor-reports-its-own
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cli/src/cmd/doctor.rs tests/cases/cli/cli-doctor-reports-its-own-binary.yaml
+git commit -m "feat(doctor): signaler l'absence du binaire, que le repli masquait
+
+Une delegation zsh retombe sur son repli quand zanvil manque du PATH, et le
+fait sans rien dire : ~/.local/bin portait zsh-env-cli v3.0.0 depuis avril,
+donc zproject etait casse et trois commandes tournaient degradees pendant
+quatre mois.
+
+Doctor cherche desormais zanvil dans le PATH — pas current_exe(), parce que la
+question n'est pas « ou suis-je » mais « qui repondra a une delegation » — et
+compte son absence comme une erreur, avec la commande d'installation.
+
+Le cas asserte que la section existe, pas qu'elle est verte : la valeur depend
+de la machine, la section non."
+```
+
+---
+
+### Task 2: `install.sh` retire l'ancien binaire
+
+**Files:**
+- Modify: `install.sh:767-777`
+
+**Interfaces:**
+- Consumes: rien.
+- Produces: rien que les tâches suivantes consomment.
+
+- [ ] **Step 1: Reproduire le défaut**
+
+```bash
+ls -l ~/.local/bin/zsh-env-cli ~/.local/bin/zanvil 2>&1
+```
+
+Attendu sur une machine installée avant la v4.0.0 : l'ancien existe, le nouveau non. C'est l'état qui a
+produit la panne.
+
+- [ ] **Step 2: Ajouter le nettoyage**
+
+Remplacer le bloc `install.sh:767-777` par :
+
+```bash
+# Build du CLI Rust (optionnel, necessite cargo)
+if command -v cargo &>/dev/null; then
+    log_info "Build de zanvil..."
+    if (cd "$TARGET_DIR/cli" && cargo build --release 2>/dev/null); then
+        mkdir -p "$HOME/.local/bin"
+        cp "$TARGET_DIR/cli/target/release/zanvil" "$HOME/.local/bin/"
+        log_success "zanvil installe dans ~/.local/bin/"
+
+        # Le binaire s'appelait zsh-env-cli avant la v4.0.0. Le laisser en place n'est
+        # pas anodin : il porte une version anterieure au renommage, il repond a
+        # --version, et sa presence donne l'illusion d'une installation valide.
+        if [[ -e "$HOME/.local/bin/zsh-env-cli" ]]; then
+            rm -f "$HOME/.local/bin/zsh-env-cli"
+            log_success "ancien binaire zsh-env-cli retire"
+        fi
+    else
+        log_warn "Build de zanvil echoue (optionnel, les commandes zsh fonctionnent sans)"
+    fi
+else
+    log_info "cargo non trouve — zanvil non installe (optionnel)"
+fi
+```
+
+- [ ] **Step 3: Vérifier la syntaxe**
+
+```bash
+cd ~/.zanvil && bash -n install.sh && echo "syntaxe ok"
+```
+
+- [ ] **Step 4: Vérifier le nettoyage sur un faux ancien binaire**
+
+Sans lancer `install.sh` en entier — il modifierait la machine — on éprouve le seul bloc ajouté :
+
+```bash
+mkdir -p /tmp/binprobe && : > /tmp/binprobe/zsh-env-cli
+HOME=/tmp/binprobe bash -c '
+  if [[ -e "$HOME/.local/bin/zsh-env-cli" ]]; then rm -f "$HOME/.local/bin/zsh-env-cli"; fi
+  mkdir -p "$HOME/.local/bin"; : > "$HOME/.local/bin/zsh-env-cli"
+  if [[ -e "$HOME/.local/bin/zsh-env-cli" ]]; then rm -f "$HOME/.local/bin/zsh-env-cli"; echo retire; fi
+  test -e "$HOME/.local/bin/zsh-env-cli" && echo "ENCORE LA" || echo "absent, correct"
+'
+```
+
+Attendu : `retire` puis `absent, correct`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add install.sh
+git commit -m "fix(install): retirer le binaire d'avant le renommage
+
+zsh-env-cli survivait a l'installation de zanvil, avec une version anterieure
+au renommage de la v4.0.0. Le laisser en place donne l'illusion d'une
+installation valide : il repond a --version et il est dans le PATH."
+```
+
+---
+
+### Task 3: une mise à jour reconstruit le binaire
+
+**Files:**
+- Modify: `core/lifecycle/auto_update.zsh:44-56`
+
+**Interfaces:**
+- Consumes: rien.
+- Produces: rien.
+
+- [ ] **Step 1: Constater que `git pull` ne suffit pas**
+
+```bash
+cd ~/.zanvil && grep -A12 '_zanvil_do_update()' core/lifecycle/auto_update.zsh | grep -cE 'cargo|local/bin'
+```
+
+Attendu : `0`. Un `git pull` amène du code Rust nouveau et laisse le binaire installé tel quel, qui
+devient donc silencieusement périmé.
+
+- [ ] **Step 2: Reconstruire après un `git pull` réussi**
+
+À insérer dans `_zanvil_do_update`, juste après la ligne
+`echo -e "${_ui_green}[zanvil]${_ui_nc} Mise a jour terminee. Rechargez avec: ${_ui_bold}ss${_ui_nc}"` :
+
+```zsh
+        # Le git pull amene du code Rust neuf ; sans cette reconstruction, le binaire
+        # installe reste celui du dernier install.sh et devient silencieusement
+        # perime. On ne reconstruit que si un binaire est deja installe : quelqu un
+        # qui n'en veut pas ne doit pas en heriter par une mise a jour.
+        if command -v cargo &>/dev/null && [[ -x "$HOME/.local/bin/zanvil" ]]; then
+            echo -e "${_ui_blue}[zanvil]${_ui_nc} Reconstruction du binaire..."
+            if (cd "$ZANVIL_DIR/cli" && cargo build --release 2>/dev/null); then
+                cp "$ZANVIL_DIR/cli/target/release/zanvil" "$HOME/.local/bin/" \
+                    && _ui_msg_ok "binaire mis a jour"
+            else
+                _ui_msg_warn "reconstruction echouee — le binaire reste a sa version precedente"
+            fi
+        fi
+```
+
+- [ ] **Step 3: Vérifier la syntaxe**
+
+```bash
+cd ~/.zanvil && zsh -n core/lifecycle/auto_update.zsh && echo "syntaxe ok"
+```
+
+- [ ] **Step 4: Vérifier que la garde tient**
+
+Le bloc ne doit rien faire quand aucun binaire n'est installé :
+
+```bash
+zsh -fc '
+  HOME=/tmp/noborn
+  if command -v cargo &>/dev/null && [[ -x "$HOME/.local/bin/zanvil" ]]; then
+    print "aurait reconstruit — INCORRECT"
+  else
+    print "ne reconstruit pas, correct"
+  fi
+'
+```
+
+Attendu : `ne reconstruit pas, correct`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add core/lifecycle/auto_update.zsh
+git commit -m "fix(update): reconstruire le binaire apres un git pull
+
+_zanvil_do_update ne faisait qu'un git pull : le code Rust arrivait, le binaire
+installe restait celui du dernier install.sh. Il devenait donc perime sans que
+rien ne le dise — le troisieme volet de la panne des quatre mois.
+
+Garde volontaire : on ne reconstruit que si un binaire est deja installe.
+Quelqu'un qui n'en veut pas ne doit pas en heriter par une mise a jour."
+```
+
+---
+
+### Task 4: le garde-fou contre le retour de l'ancien nom
+
+**Files:**
+- Create: `tests/bin/stale-binary-references`
+- Create: `tests/cases/docs/no-reference-to-the-old-binary-name.yaml`
+
+**Interfaces:**
+- Consumes: rien.
+- Produces: rien.
+
+Le nom `zsh-env-cli` ne doit plus apparaître dans le code. Deux exceptions, vérifiées avant d'écrire le
+contrôle : `migrate_zanvil.zsh`, qui porte volontairement les anciens noms et le dit dans son en-tête,
+et la documentation — `web/docs/ROADMAP.md:70` raconte le renommage, donc le scan ne couvre pas les
+`.md`.
+
+- [ ] **Step 1: Écrire le script de contrôle**
+
+```bash
+#!/usr/bin/env bash
+# Imprime les references a l'ancien nom du binaire, hors migration.
+#
+# Le renommage zsh_env -> zanvil de la v4.0.0 a laisse un binaire zsh-env-cli en
+# place pendant quatre mois. Ce controle empeche qu'une reference y revienne par
+# inadvertance — dans install.sh, une delegation, ou une page de documentation.
+#
+# Deux exclusions, toutes deux legitimes :
+#   - migrate_zanvil.zsh, dont l en-tete dit qu il porte VOLONTAIREMENT les anciens
+#     noms pour detecter une installation heritee ;
+#   - la documentation. web/docs/ROADMAP.md raconte le renommage et doit pouvoir
+#     nommer l ancien binaire ; interdire le mot dans un historique n aurait aucun
+#     sens. Le controle porte sur le CODE, qui lui ne doit plus le connaitre.
+set -uo pipefail
+
+ROOT="${ZANVIL_DIR:-$HOME/.zanvil}"
+
+grep -rn 'zsh-env-cli' "$ROOT" \
+    --include='*.zsh' --include='*.sh' --include='*.rs' --include='*.yaml' \
+    2>/dev/null \
+    | grep -v 'migrate_zanvil.zsh' \
+    | grep -v '/tests/bin/stale-binary-references' \
+    | sed "s|^$ROOT/||" || true
+```
+
+```bash
+chmod +x tests/bin/stale-binary-references
+```
+
+- [ ] **Step 2: Vérifier qu'il ne signale rien aujourd'hui**
+
+```bash
+cd ~/.zanvil && ZANVIL_DIR="$PWD" tests/bin/stale-binary-references
+```
+
+Attendu : aucune sortie. Si une ligne apparaît, c'est une référence à traiter avant de continuer.
+
+- [ ] **Step 3: Écrire le cas**
+
+```yaml
+# tests/cases/docs/no-reference-to-the-old-binary-name.yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+name: no-reference-to-the-old-binary-name
+weight: 3
+setup:
+  env:
+    ZANVIL_DIR: "$GAVELDROP_PROJECT"
+  run: ["$GAVELDROP_PROJECT/tests/bin/stale-binary-references"]
+expect:
+  exit_code: 0
+  stdout:
+    # Vide, sinon le `got` nomme le fichier et la ligne a corriger.
+    equals: ""
+```
+
+- [ ] **Step 4: Vérifier le vert, puis la faillibilité**
+
+```bash
+cd ~/.zanvil && gaveldrop --only no-reference-to-the-old
+```
+
+Attendu : `ok no-reference-to-the-old-binary-name 3/3`.
+
+Puis prouver qu'il mord, en introduisant une référence là où elle serait une régression :
+
+```bash
+printf '\n# zsh-env-cli\n' >> install.sh
+gaveldrop --only no-reference-to-the-old
+git checkout install.sh
+gaveldrop --only no-reference-to-the-old
+```
+
+Attendu : `FAIL` avec `got install.sh:…`, puis `ok` après restauration.
+
+- [ ] **Step 5: Lancer la suite entière**
+
+```bash
+gaveldrop && ZANVIL_DIR="$PWD" bash scripts/tests/k9s-log-fmt.test.sh | tail -1 \
+  && ZANVIL_DIR="$PWD" bash scripts/tests/zsh-special-vars.test.sh | tail -1
+```
+
+Attendu : `59 cases · 59 passed`, puis `13 ok` et `7 ok`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/bin/stale-binary-references tests/cases/docs/no-reference-to-the-old-binary-name.yaml
+git commit -m "test(install): un garde-fou contre le retour de l'ancien nom du binaire
+
+zsh-env-cli a survecu quatre mois au renommage de la v4.0.0. Ce cas refuse
+qu'une reference y revienne — dans install.sh, une delegation, un
+module — et nomme le fichier fautif.
+
+Deux exclusions : migrate_zanvil.zsh, qui porte volontairement les anciens noms
+et le dit, et la documentation — ROADMAP.md raconte le renommage et doit pouvoir
+nommer l'ancien binaire."
+```
+
+---
+
+### Task 5: réparer la machine, et vérifier que la panne a disparu
+
+**Files:** aucun — cette tâche exécute, elle ne modifie pas le dépôt.
+
+**Interfaces:**
+- Consumes: `install.sh` (tâche 2) et `doctor` (tâche 1).
+- Produces: rien.
+
+- [ ] **Step 1: Installer le binaire au bon nom**
+
+```bash
+cd ~/.zanvil/cli && cargo build --release && mkdir -p ~/.local/bin \
+  && cp target/release/zanvil ~/.local/bin/ && rm -f ~/.local/bin/zsh-env-cli
+```
+
+- [ ] **Step 2: Vérifier que le PATH le trouve**
+
+```bash
+zsh -ic 'command -v zanvil && zanvil --version'
+```
+
+Attendu : `/Users/…/.local/bin/zanvil` puis la version courante — et non `zsh-env 3.0.0`.
+
+- [ ] **Step 3: Vérifier que les trois commandes cassées fonctionnent**
+
+```bash
+zsh -ic 'zproject list' 2>&1 | tail -3
+zsh -ic 'zanvil-doctor' 2>&1 | grep -A1 Binaire
+```
+
+Attendu : `zproject list` ne dit plus `command not found: zanvil`, et `doctor` affiche `Binaire ✓` avec
+le chemin.
+
+- [ ] **Step 4: Vérifier que le repli n'est plus emprunté**
+
+```bash
+zsh -ic 'zanvil-doctor' 2>&1 | head -3
+```
+
+Attendu : l'en-tête produit par le binaire Rust (`Zanvil Doctor vX.Y.Z` dans un cadre), et non celui du
+repli zsh. C'est la preuve que la délégation aboutit enfin.
+
+- [ ] **Step 5: Consigner le résultat dans le spec**
+
+Ajouter à la fin de la section « Un principe, tiré d'une panne » de
+`web/docs/superpowers/specs/2026-08-03-zsh-ou-rust-design.md` :
+
+```markdown
+**Réparé le 3 août 2026.** Le binaire est installé sous son nom, `install.sh` retire l'ancien, une mise
+à jour reconstruit, et `doctor` signale une absence. Deux cas gaveldrop tiennent la position : l'un
+vérifie que `doctor` parle de son binaire, l'autre qu'aucune référence à `zsh-env-cli` ne revient.
+```
+
+```bash
+git add -f web/docs/superpowers/specs/2026-08-03-zsh-ou-rust-design.md
+git commit -m "docs(specs): la panne du binaire est reparee, et tenue par deux cas"
+```
+
+---
+
+## Auto-review de ce plan
+
+**Couverture du chantier.** Le spec demandait de « réparer le binaire *et* ajouter le cas qui rendra ce
+silence impossible ». Les trois volets du défaut sont couverts par une tâche chacun — visibilité
+(tâche 1), nettoyage (tâche 2), reconstruction (tâche 3) — le garde-fou par la tâche 4, et la machine
+elle-même par la tâche 5.
+
+**L'ordre est délibéré.** La visibilité vient avant la réparation, parce que c'est elle qui manquait :
+un `doctor` qui parle de son binaire aurait fait tomber la panne en quatre secondes au lieu de quatre
+mois. Réparer d'abord aurait masqué le symptôme sans installer le témoin.
+
+**Contrainte respectée.** Aucun cas n'asserte que le binaire est installé — les deux vérifient une
+propriété vraie sur un poste comme sur un runner : que `doctor` mentionne la section, et qu'aucune
+référence à l'ancien nom ne subsiste. Le mur nº 1 du spec précédent est évité.
+
+**Cohérence des noms.** `which_zanvil()` est défini à la tâche 1 et n'est utilisé que là.
+`tests/bin/stale-binary-references` porte le même nom dans le script, le cas et le commit. Les comptes
+annoncés s'enchaînent : 57 cas aujourd'hui, plus un à la tâche 1 et un à la tâche 4, soit les 59 de la
+tâche 4 étape 5.
+
+**Ce que ce plan ne fait pas.** Il ne touche pas `migrate_zanvil.zsh`, et la contrainte dit pourquoi. Il
+ne supprime aucun repli zsh : c'est un autre arbitrage, et le spec le garde comme garantie.

--- a/web/docs/superpowers/specs/2026-08-03-zsh-ou-rust-design.md
+++ b/web/docs/superpowers/specs/2026-08-03-zsh-ou-rust-design.md
@@ -94,6 +94,23 @@ sont écoulés sans que rien ne le signale, précisément parce que le repli fon
 Conséquence pour la ligne de partage : un repli est acceptable s'il est **visible**. Le premier
 chantier répare le binaire *et* ajoute le cas qui rendra ce silence impossible.
 
+**Réparé le 3 août 2026**, et le défaut avait un volet de plus que les trois annoncés :
+
+1. `install.sh` retire désormais l'ancien binaire, qui survivait au renommage ;
+2. `_zanvil_do_update` reconstruit le binaire après un `git pull`, au lieu de le laisser périmer ;
+3. `doctor` porte une section `Binaire` et compte son absence comme une erreur ;
+4. **`auto-release.yml` bump les deux versions.** `cli/Cargo.toml` était resté en 3.1.0 quand le projet
+   affichait v4.4.0 : le même binaire annonçait deux versions contradictoires. C'est ce qui a fait
+   passer `zsh-env-cli` v3.0.0 pour une installation valide — un binaire qui répond à `--version`
+   inspire confiance, même quand le numéro n'a plus de rapport avec le dépôt.
+
+Deux cas gaveldrop tiennent la position : l'un vérifie que `doctor` parle de son binaire, l'autre
+qu'aucune délégation ne revient à l'ancien nom. Aucun des deux n'asserte que le binaire est installé —
+ce serait vrai sur un poste et faux sur un runner.
+
+Sur la machine : `zproject list`, `zanvil-mr-fanout` et `zanvil-doctor` répondent, ce dernier depuis le
+Rust et non plus depuis son repli.
+
 ## Les cinq chantiers, dans l'ordre
 
 | # | Chantier | Ce qui le motive |

--- a/web/docs/superpowers/specs/2026-08-03-zsh-ou-rust-design.md
+++ b/web/docs/superpowers/specs/2026-08-03-zsh-ou-rust-design.md
@@ -1,0 +1,151 @@
+# zsh ou Rust — la ligne de partage, et ce qui doit la traverser
+
+## Problème
+
+zanvil porte ~14 700 lignes de zsh et 5 359 de Rust, réparties sans critère écrit. Chaque nouvelle
+fonction pose donc la même question sans réponse, et deux réponses opposées ont déjà été données au
+même endroit : `zanvil-doctor` délègue au CLI avec un repli zsh complet, tandis que `zanvil-sync`
+ignore un `zanvil sync` qui fait la même chose.
+
+Ce document fixe la ligne, chiffre ce qui la traverse, et donne l'ordre.
+
+## La carte, mesurée
+
+**Volumes.** zsh : core 3 124, git 2 262, kube 1 576, ai 1 382, project 1 165, tools 1 144,
+gitlab 1 015, work 836, security 743, zproject 604, ssh 339, docker 315, utils 166. Rust : project
+1 628, mr_fanout 1 147, tui_config 514, doctor 390, sync 288, update 236, secrets 216, audit 197,
+theme 195, config 139, modules 116, context 91, bench 52, plus main 100 et mod 50.
+
+**Le résultat contre-intuitif, et il ferme un débat avant qu'il s'ouvre.** La performance n'est pas un
+argument pour migrer :
+
+| Étape du démarrage | Coût |
+|---|---|
+| Les 12 modules zsh cumulés | 0,22 s |
+| Completions des modules | 0,07 s |
+| `compinit` | 0,02 s |
+| **Hooks** — `starship`, `mise`, `zoxide`, `direnv`, `atuin` init | **0,63 s** |
+| `rc.zsh` complet | 1,76 s |
+
+Le code zsh du projet coûte ~0,3 s ; les `eval "$(outil init)"` en coûtent le double, et aucune
+réécriture n'y changera quoi que ce soit. Le démarrage d'un binaire Rust, lui, coûte **14 ms** —
+acceptable pour une commande interactive, cher à chaque prompt.
+
+## Trois catégories
+
+### Ce qui ne peut pas migrer
+
+Un binaire ne modifie pas le shell qui l'appelle. Environ 150 occurrences de `cd`, `export`, `unset`,
+`alias`, `source`, `compdef` et `setopt`, concentrées dans git (26), zproject (23), kube (23),
+gitlab (16), tools (12) — plus les hooks `chpwd` de `.zanvil.local` et de `zproject`.
+
+C'est une contrainte, pas un arbitrage. Une fonction qui doit changer de répertoire, exporter une
+variable ou déclarer une complétion **est** du shell.
+
+### Ce qui ne devrait pas migrer
+
+**Ce qui est appelé à haute fréquence.** 14 ms par invocation, multipliés par chaque prompt ou chaque
+`cd`. Le prompt Starship appelle déjà `zanvil context` : c'est la limite haute de ce qu'on peut se
+permettre, pas un modèle à étendre.
+
+**Ce qui ne fait qu'orchestrer un outil externe.** `klog` (142 lignes) et `kube_azure` (121) sont des
+enchaînements autour de `kubectl` et `az`. Les réécrire déplacerait le code sans toucher ni au coût ni
+à la fragilité. La règle, formulée pour être citable : **on ne migre pas un `for` autour d'un
+`kubectl`.**
+
+### Ce qui devrait migrer
+
+La dépendance à des outils dont le comportement diverge selon la plateforme, là où il n'y a pas d'effet
+shell :
+
+| Fichier | `date` | `jq` | `awk`/`sed` | effet shell | lignes |
+|---|---|---|---|---|---|
+| `modules/work/elasticsearch.zsh` | **14** | **22** | 2 | **0** | 551 |
+| `core/commands/commands.zsh` | 0 | 9 | 19 | **0** | 414 |
+| `core/lifecycle/sync.zsh` | 1 | 15 | 6 | **0** | 274 |
+| `modules/gitlab/gitlab_logic.zsh` | 6 | 14 | 0 | 7 | 360 |
+
+Sur l'ensemble du zsh : 159 `grep`, 82 `sed`, 65 `jq`, 59 `tr`, 49 `date`, 41 `awk`. Deux dettes sont
+déjà payées à la main, et ce sont elles qui justifient le critère :
+
+- `elasticsearch.zsh:81-88` embarque un **détecteur de variante `date`** GNU/BSD, écrit parce que
+  `date -d` et `date -j -f` ne coexistent pas ;
+- son en-tête admet une duplication : « Duplication annotee de modules/work/fetch_es_logs.sh (bash) :
+  reecrit en zsh. Garder les deux versions synchronisees. »
+
+`chrono` et `serde` les font disparaître toutes les deux.
+
+## Un principe, tiré d'une panne
+
+Le repli zsh derrière une délégation est documenté comme une garantie. C'en est une, mais elle a un
+prix qu'il faut écrire : **un repli silencieux masque une panne.**
+
+Constaté sur la machine de développement pendant la cartographie : `~/.local/bin/` contient
+`zsh-env-cli` v3.0.0 daté d'avril, et pas `zanvil`. Depuis le renommage de la v4.0.0,
+`command -v zanvil` échoue, donc :
+
+- `zproject list|config|doctor|diff` **est cassé** — `command not found: zanvil` ;
+- `git_mr_fanout` refuse de démarrer, et 1 147 lignes de Rust avec lui ;
+- `zanvil-doctor`, `zanvil-theme` et `security_audit` tournent en mode dégradé **sans le dire**.
+
+`core/lifecycle/migrate_zanvil.zsh` ne prévoit pas le renommage du binaire installé. Quatre mois se
+sont écoulés sans que rien ne le signale, précisément parce que le repli fonctionnait.
+
+Conséquence pour la ligne de partage : un repli est acceptable s'il est **visible**. Le premier
+chantier répare le binaire *et* ajoute le cas qui rendra ce silence impossible.
+
+## Les cinq chantiers, dans l'ordre
+
+| # | Chantier | Ce qui le motive |
+|---|---|---|
+| 1 | **Réparer le binaire** | `zsh-env-cli` au lieu de `zanvil` : trois commandes cassées ou dégradées, 5 359 lignes de Rust inertes. La migration doit renommer, et un cas doit l'attraper. |
+| 2 | **`sync`** | Doublon pur : 274 lignes de zsh et 288 de Rust pour le même export/import/diff, avec **zéro** délégation entre les deux. |
+| 3 | **`work/elasticsearch`** | 38 dépendances fragiles, le détecteur `date`, la duplication annotée avec `fetch_es_logs.sh`. |
+| 4 | **`core/commands/commands.zsh`** | 24 appels `jq`/`awk`/`sed` dans `zanvil-list`, `-status`, `-help`, `-doctor-conflicts`. `zanvil-doctor` est hors périmètre : il délègue déjà. |
+| 5 | **`gitlab_logic`** | 20 fragiles, mais 7 effets shell : migration **partielle**, la façade et les `export` restent en zsh. |
+
+## La méthode : caractériser avant de migrer
+
+Aucune des fonctions visées n'a de cas gaveldrop aujourd'hui — vérifié pour `zanvil-status`,
+`zanvil-info`, `zanvil-sync` et `zanvil-theme`. Déplacer du code sans filet serait la seule manière de
+transformer ce chantier en régression.
+
+Pour **chaque** chantier, dans cet ordre :
+
+1. **Écrire les cas qui capturent le comportement actuel, en zsh.** Attendu délibérément faux d'abord,
+   constater l'échec, puis calibrer sur la sortie réelle.
+2. **Vérifier par mutation qu'ils peuvent échouer.** Une assertion dérivée d'une sortie observée passe
+   par construction ; seule une mutation du sujet prouve qu'elle mord.
+3. **Migrer en Rust.**
+4. **Les mêmes cas doivent passer, inchangés.**
+
+Un cas invoque `zanvil-sync export` et asserte la sortie : il ne sait pas quel langage répond. C'est ce
+qui rend la non-régression démontrable plutôt qu'espérée, et c'est l'usage pour lequel la suite de 57
+cas a été construite.
+
+## Ce qui ne bouge pas
+
+**`context` reste tel quel.** Il coûte 160 ms à chaque prompt, dont 145 pour le
+`kubectl config current-context` qu'il lance (`context.rs:get_current_context`). Le langage n'y est
+pour rien : ce qui le corrigerait est un cache, et c'est un autre sujet.
+
+**Les fonctions d'orchestration restent en zsh** : `klog`, `kube_azure`, `kube_switch`, `kube_ns`.
+
+**Les scaffolds restent en zsh pour l'instant.** `_proj_scaffold_java` (153 lignes) et
+`_proj_scaffold_node` (122) sont les deux plus grosses fonctions du projet et n'ont aucun effet shell,
+donc elles sont migrables — mais elles écrivent des fichiers depuis des gabarits, sans dépendance
+fragile. Elles relèvent du critère « volume », qui n'a pas été retenu.
+
+## Vérification
+
+Chaque chantier est terminé quand :
+
+- les cas de caractérisation écrits à l'étape 1 passent **sans avoir été modifiés** ;
+- une mutation du code migré fait rougir au moins un cas ;
+- `gaveldrop` est vert, et les deux suites bash aussi ;
+- aucune dépendance à `jq` ni à `date` ne subsiste dans le périmètre traité — vérifiable par
+  `grep -c` sur le fichier.
+
+Le chantier 1 a un critère de plus, qui lui est propre : un cas doit échouer si le binaire attendu par
+une délégation n'est pas installable. C'est ce qui empêchera un repli de masquer une panne pendant
+quatre mois.


### PR DESCRIPTION
## Ce que la cartographie a trouvé

L'objectif était d'arbitrer ce qui doit rester en zsh et ce qui gagnerait à migrer. Deux résultats ont reconfiguré la question.

**La performance n'est pas un argument** — mesuré, contre l'intuition :

| Étape du démarrage | Coût |
|---|---|
| Les 12 modules zsh cumulés | 0,22 s |
| **Hooks** (`starship`, `mise`, `zoxide`, `direnv`, `atuin` init) | **0,63 s** |
| `rc.zsh` complet | 1,76 s |

Le zsh du projet coûte ~0,3 s ; les `eval "$(outil init)"` en coûtent le double. Et les 160 ms de `zanvil context` viennent du `kubectl` qu'il lance, pas du Rust — le binaire démarre en 14 ms.

**Le CLI Rust n'était plus appelé du tout.** `~/.local/bin/` portait `zsh-env-cli` v3.0.0 d'avril au lieu de `zanvil` : depuis le renommage de la v4.0.0, `zproject` était cassé, `zanvil-mr-fanout` refusait de démarrer, et `zanvil-doctor` tournait sur son repli zsh **sans le dire**. Quatre mois, 5 359 lignes de Rust inertes.

## Le spec

`web/docs/superpowers/specs/2026-08-03-zsh-ou-rust-design.md` fixe la ligne de partage en trois catégories :

- **Ne peut pas migrer** — ~150 occurrences de `cd`, `export`, `alias`, `source`, `compdef`. Un binaire ne modifie pas le shell qui l'appelle. C'est une contrainte, pas un arbitrage.
- **Ne devrait pas** — ce qui est appelé à chaque prompt, et ce qui n'orchestre qu'un outil externe. La règle, formulée pour être citable : **on ne migre pas un `for` autour d'un `kubectl`.**
- **Devrait** — la dépendance aux outils dont le comportement diverge : `elasticsearch.zsh` (38 dépendances fragiles, un détecteur `date` GNU/BSD écrit à la main, une duplication annotée avec `fetch_es_logs.sh`), `sync.zsh` (doublon pur avec 288 lignes de Rust), `commands.zsh`, `gitlab_logic`.

Cinq chantiers ordonnés, et un principe tiré de la panne : **un repli silencieux masque une panne.**

## Le chantier 1, exécuté

Le défaut avait **quatre** volets, pas un — ma première formulation (« la migration ne renomme pas le binaire ») était fausse, et `migrate_zanvil.zsh` n'est d'ailleurs pas touché : il est idempotent, donc déjà passé partout où le problème se pose.

| Volet | Correction |
|---|---|
| `install.sh` laissait l'ancien binaire | il le retire, avec la raison en commentaire |
| `_zanvil_do_update` ne faisait qu'un `git pull` | il reconstruit, si un binaire est déjà installé |
| `doctor` ne surveillait pas son propre binaire | section `Binaire`, absence comptée comme erreur |
| `cli/Cargo.toml` restait en 3.1.0 | `auto-release.yml` bump les deux versions |

Le quatrième n'était pas prévu : je l'ai trouvé en vérifiant la réparation. `zanvil --version` disait `3.1.0` pendant que `doctor` disait `v4.4.0` — le même binaire annonçait deux versions contradictoires, ce qui est exactement ce qui a fait passer `zsh-env-cli` pour valide.

**L'ordre était délibéré : la visibilité avant la réparation.** Un `doctor` qui parle de son binaire aurait fait tomber cette panne en quatre secondes au lieu de quatre mois.

## Deux garde-fous

`cli-doctor-reports-its-own-binary` et `no-delegation-to-the-old-binary-name`. Aucun n'asserte que le binaire est installé — ce serait vrai sur un poste et faux sur un runner. Faillibilité vérifiée pour les deux : retirer la section fait rougir le premier, ajouter une vraie délégation à l'ancien nom fait rougir le second, avec fichier et ligne.

**Un écart avec le plan, découvert à l'exécution** : ma première version du contrôle scannait tout le dépôt et signalait six références **toutes légitimes** — le code d'`install.sh` qui retire l'ancien binaire doit bien le nommer, et les commentaires qui expliquent la panne aussi. Un contrôle qui interdit de nommer ce qu'on supprime est un contrôle qu'on désactive au premier échec. Le scan porte donc sur les invocations dans `core/`, `modules/`, `scripts/`, hors commentaires — quatre exclusions, chacune avec sa raison écrite dans le script.

**Et un bug que j'ai introduit puis corrigé** : le bump de version utilisait `sed -i "0,/^version = /s/…"`, une plage **GNU** que le sed de macOS ignore en silence. Le workflow tourne sur Ubuntu donc ça aurait fonctionné, mais personne n'aurait pu le vérifier localement — précisément le genre de dépendance à une variante que ce spec cherche à retirer. Remplacé par `python3`, vérifié : la version du paquet change, celles de `clap` et `serde` non.

## Vérification

```
gaveldrop                    59 cases · 59 passed · score 223/223
k9s-log-fmt.test.sh          13 ok, 0 echec(s)
zsh-special-vars.test.sh      7 ok, 0 echec(s)
```

Sur la machine, les trois commandes cassées répondent :

| Commande | Avant | Après |
|---|---|---|
| `zproject list` | `command not found: zanvil` | affiche son en-tête et son résultat |
| `zanvil-mr-fanout` | `zanvil requis` | `Fan-out a change as a MR/PR…` |
| `zanvil-doctor` | repli zsh, silencieux | l'en-tête **du Rust**, avec `Binaire ✓` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)