### PR TITLE
docs+test: les echanges de gaveldrop 0.1.12 a l'epreuve, et deux cas qui mordent

### DIFF
--- a/gaveldrop.yaml
+++ b/gaveldrop.yaml
@@ -7,5 +7,10 @@ cases: tests/cases/**/*.yaml
 #
 # fzf sert les cas du viewer : les uns le simulent pour choisir son code de sortie, un
 # autre le cache pour eprouver le repli. Les deux coexistent depuis la v0.1.1.
+# `zanvil` est declare parmi les faux pour une raison differente des autres : ce n est
+# pas une dependance externe, c est notre propre binaire. Une fonction zsh qui delegue
+# fait `command -v zanvil` puis l appelle par son nom, donc seul un faux dans le PATH
+# permet de verifier AVEC QUELS ARGUMENTS elle l appelle. Les cas qui veulent le vrai
+# binaire l invoquent par chemin absolu, que le shadowing du PATH n atteint pas.
 fake:
-  bins: [posting, delta, lazygit, atuin, fzf]
+  bins: [posting, delta, lazygit, atuin, fzf, zanvil]

--- a/tests/cases/cli/cli-lists-its-commands.yaml
+++ b/tests/cases/cli/cli-lists-its-commands.yaml
@@ -6,4 +6,27 @@ setup:
 expect:
   exit_code: 0
   stdout:
-    contains: ["theme", "doctor", "audit"]
+    # Les douze, et pas trois : cette liste est le contrat de delegation entre le
+    # zsh et le Rust. Chaque nom ci-dessous est invoque au moins une fois depuis
+    # core/ ou modules/ — `zanvil project` 47 fois, `zanvil modules` 12,
+    # `zanvil sync` 9 — donc une commande qui disparait du binaire casse une
+    # fonction zsh, et le repli la fera taire.
+    #
+    # C est la panne du chantier 1 sous une autre forme : `git_mr_fanout` est
+    # reste inerte quatre mois parce que rien n assertait que le binaire
+    # repondait encore a `mr-fanout`. Verifie par mutation : renommer
+    # `mr-fanout` en `mrfanout` dans le derive clap ne faisait rougir aucun cas
+    # avant cette liste.
+    contains:
+      - "theme"
+      - "doctor"
+      - "audit"
+      - "context"
+      - "modules"
+      - "bench"
+      - "sync"
+      - "update"
+      - "secrets"
+      - "project"
+      - "mr-fanout"
+      - "config"

--- a/tests/cases/cli/cli-modules-list-reflects-config-zsh.yaml
+++ b/tests/cases/cli/cli-modules-list-reflects-config-zsh.yaml
@@ -31,3 +31,13 @@ expect:
       - "inactif"
       - "Gestion kubeconfig"
       - "Utilitaires Docker"
+      # Les espaces sont volontaires, et c est le seul endroit de la suite ou l on
+      # fige un alignement. Motif : `["KUBE", "actif"]` ne dit pas que les deux sont
+      # sur la MEME ligne, donc une inversion de condition qui echange les statuts
+      # laisse les deux mots presents et l assertion vraie. Verifie par mutation :
+      # `if !enabled` dans modules.rs ne faisait rougir aucun cas avant cette ligne.
+      #
+      # Le cout est assume : changer `{:<12}` en `{:<14}` fera rougir ce cas pour une
+      # raison cosmetique. Un statut faux est un defaut majeur, une largeur de colonne
+      # est un choix qu on assume en mettant le test a jour.
+      - "KUBE         actif"

--- a/tests/cases/cli/cli-modules-list-reflects-config-zsh.yaml
+++ b/tests/cases/cli/cli-modules-list-reflects-config-zsh.yaml
@@ -14,4 +14,20 @@ expect:
     # (modules.rs:46-48). Le hook ecrit KUBE=true et DOCKER=false, donc les deux
     # statuts doivent apparaitre — sans un module inactif, l assertion sur
     # « inactif » ne prouverait rien.
-    contains: ["MODULE", "STATUT", "KUBE", "DOCKER", "actif", "inactif"]
+    #
+    # Les deux DESCRIPTIONS ne sont pas decoratives : elles sont la seule chose
+    # qui distingue la premiere boucle de modules.rs de la seconde. Un module
+    # dont le .module.toml n a pas ete lu reapparait en dessous par config.zsh,
+    # avec son nom et son statut mais sans description — donc une assertion qui
+    # ne porte que sur les noms survit a la perte des metadonnees. Verifie par
+    # mutation : `metas.iter().take(2)` fait tomber neuf modules sur onze et ne
+    # faisait rougir aucun des six cas cli avant cette ligne.
+    contains:
+      - "MODULE"
+      - "STATUT"
+      - "KUBE"
+      - "DOCKER"
+      - "actif"
+      - "inactif"
+      - "Gestion kubeconfig"
+      - "Utilitaires Docker"

--- a/tests/cases/cli/theme-delegates-to-the-cli-with-the-right-subcommand.yaml
+++ b/tests/cases/cli/theme-delegates-to-the-cli-with-the-right-subcommand.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Le trou que ce cas ferme a ete trouve par injection : renommer `zanvil theme` en
+# `zanvil themes` dans core/commands/theme.zsh ne faisait rougir aucun des 59 cas. La
+# delegation cassait, le repli zsh prenait la main, et la suite restait verte — parce
+# que les cas `cli-theme-*` invoquent le binaire par chemin absolu et ne passent jamais
+# par la fonction zsh qui, sur un poste, est le seul point d entree.
+#
+# C est la panne du chantier 1 reproduite a l identique : pendant quatre mois,
+# `command -v zanvil` echouait et trois commandes tournaient en mode degrade sans le
+# dire. Un repli est acceptable s il est visible ; ce cas est ce qui le rend visible.
+name: theme-delegates-to-the-cli-with-the-right-subcommand
+weight: 7
+setup:
+  exec: ./tests/hooks/prepare-zanvil-dir.sh
+  shell: zsh
+  # ui.zsh d abord : theme.zsh utilise les _ui_* et l ordre de chargement compte.
+  source: ["core/ui.zsh", "core/commands/theme.zsh"]
+  call: ["zanvil-theme", "list"]
+  env:
+    ZANVIL_DIR: "$HOME/zanvil"
+fake:
+  rules:
+    # « theme list » et non « theme » : args_contain est une sous-chaine des arguments
+    # joints par des espaces, donc « theme » matcherait aussi « themes ». Ecrit ainsi,
+    # la regle a d abord laisse passer le renommage qu elle etait censee attraper — le
+    # cas ne prouvait rien tant que la mutation ne l avait pas fait rougir.
+    #
+    # Avec l argument suivant, « themes list » ne contient plus « theme list » : le
+    # mauvais nom tombe dans le catch-all, qui compte un appel non prevu. C est ce
+    # mecanisme, et non une assertion sur la sortie, qui attrape le renommage.
+    - match: { bin: zanvil, args_contain: "theme list" }
+      stdout: "Available themes:"
+    - match: {}
+      exit: 127
+      stderr: "the case did not foresee this call"
+expect:
+  exit_code: 0
+  # Un seul appel : la fonction delegue et s arrete la. Si elle repliait en zsh apres
+  # avoir appele le binaire, le compte resterait a 1 mais la sortie changerait — d ou
+  # l assertion sur les deux.
+  calls:
+    zanvil: 1
+  stdout:
+    contains: ["Available themes:"]

--- a/web/docs/superpowers/2026-08-05-demandes-evolution-gaveldrop-echanges.md
+++ b/web/docs/superpowers/2026-08-05-demandes-evolution-gaveldrop-echanges.md
@@ -1,0 +1,358 @@
+# Demandes d'évolution gaveldrop — les échanges, depuis zanvil
+
+**Pour un agent travaillant dans `~/work/misc/gaveldrop`.** Rien n'a été modifié là-bas ; tout ce qui
+suit est décrit, jamais corrigé sur place.
+
+## Ce qui a produit ces demandes
+
+zanvil est passé de la 0.1.5 à la 0.1.12 d'un coup, sans document de mise à jour dans le canal. **Les 59
+cas passent inchangés** : 223/223, en 11,2 s contre 13,8 s — sept versions d'écart, zéro adaptation. La
+deuxième propriété du format tient, et c'est ce qui a permis de travailler sur le reste.
+
+Les quatre findings du rapport 0.1.5 sont corrigés et vérifiés par comportement, pas d'après le
+changelog : le groupe de processus est bien tué (l'enfant tourne pendant le run, zéro après), le nom vide
+est refusé avec les trois arguments demandés, le `..` est résolu avant la comparaison, et `timeout: 0`
+est refusé avec « disarms the guard rather than tightening it ».
+
+Les demandes ci-dessous portent toutes sur les **échanges** (0.1.11/0.1.12), parce que c'est le code le
+plus récent et que zanvil en est le premier consommateur shell. Elles sont classées par ce qu'elles
+coûtent, pas par difficulté.
+
+Le rapport complet, avec les reproductions et ce qui tient :
+`~/.zanvil/web/docs/superpowers/reports/2026-08-05-gaveldrop-0-1-12-echanges.md`.
+
+---
+
+## 1. Bloquant : `docs/shell.md` ne mentionne pas les échanges
+
+C'est la seule demande qui a coûté du travail immédiat. Pour écrire mon premier cas à échanges, j'ai dû
+lire `crates/gaveldrop/src/adapters/process.rs` — le geste exact que la troisième propriété du projet
+cherche à rendre inutile.
+
+Le support existe et il est **double**, ce que rien n'annonce côté doc :
+
+```yaml
+steps:
+  - name: "l ecriture pose l etat"
+    request: { run: ["sh", "-c", "echo ecrit > note.txt"] }   # commande propre a l echange
+    expect: { exit_code: 0 }
+  - name: "la relecture retrouve le meme etat"
+    request: { run: ["sh", "-c", "cat note.txt"] }
+    expect: { stdout: { contains: ["ecrit"] } }
+```
+
+et un échange **sans** `request`, qui réinvoque le `setup.run` — la répétition d'invocation de la #142,
+vérifiée sur `process.rs:504-512`.
+
+**Demandé :** une section « Exchanges » dans `docs/shell.md`, avec les deux formes et une phrase sur ce
+qui est partagé entre échanges. Deux points valent d'y figurer parce qu'ils m'ont coûté un aller-retour
+chacun : **`weight` est requis**, et **`expect:` au niveau du cas l'est aussi** — même quand chaque
+échange porte le sien, il faut écrire `expect: {}`.
+
+Un troisième mérite une phrase, parce qu'il décide de la faisabilité d'un scénario : **l'état de la
+racine isolée persiste entre les échanges**. C'est ce qui rend testable un export suivi d'une relecture,
+et c'est exactement l'usage pour lequel zanvil va s'en servir.
+
+**Écarté :** générer cette section depuis `case.schema.json`. Le schéma dit ce qu'une clé accepte ;
+`shell.md` doit dire ce qu'un `run` répété *signifie* pour un processus, ce qu'aucune description de
+champ ne porte.
+
+## 2. Majeur : le `timeout:` borne chaque échange, pas le cas
+
+Reproduction, contre l'archive publiée de la 0.1.12 :
+
+```yaml
+name: quatre-echanges-bloques
+weight: 1
+timeout: 2
+setup: { run: ["sh", "-c", "true"] }
+steps:
+  - { name: "premier bloque",   request: { run: ["sh", "-c", "while true; do sleep 1; done"] }, expect: {} }
+  - { name: "deuxieme bloque",  request: { run: ["sh", "-c", "while true; do sleep 1; done"] }, expect: {} }
+  - { name: "troisieme bloque", request: { run: ["sh", "-c", "while true; do sleep 1; done"] }, expect: {} }
+  - { name: "quatrieme bloque", request: { run: ["sh", "-c", "while true; do sleep 1; done"] }, expect: {} }
+expect: {}
+```
+
+```console
+FAIL quatre-echanges-bloques  0/1  8.3s
+    timeout
+      expected  the subject exits within 2.0s
+      got       still running after 2.0s, so it was killed. […] it wrote nothing at all
+```
+
+Le cas annonce 2 s et tient **8,3 s**. Le verdict imprime « exits within 2.0s » à trois caractères du
+`8.3s` qu'il vient de mesurer. Un cas à vingt échanges avec `timeout: 30` peut tenir dix minutes en
+annonçant trente secondes.
+
+Le comptage est aussi partiel. Dans `gathered()` :
+
+```rust
+let timed_out_after_ms = steps.iter().filter_map(|seen| seen.timed_out_after_ms).next();
+```
+
+Quatre échanges ont été tués ; le rapport en mentionne un.
+
+**Pourquoi ça mérite mieux qu'une ligne de doc.** C'est le motif du finding `timeout: 0` que la 0.1.6 a
+corrigé en refusant la valeur — une protection qui paraît resserrée et qui se relâche. Ici elle se dilue
+par le nombre d'échanges, et le facteur n'apparaît nulle part : `grep -i timeout docs/*.md` ne renvoie
+rien sur les échanges, et le schéma dit « how many seconds **this case's subject** may run before it is
+killed », au singulier.
+
+**Demandé :** trancher entre les deux lectures, et que le rapport dise laquelle.
+
+- Si `timeout:` borne le **cas**, chaque échange consomme le budget restant, et le verdict reste exact.
+- S'il borne l'**échange**, le dire dans le schéma, écrire « each exchange exits within 2.0s » dans le
+  verdict, et compter les dépassements au lieu d'en garder un.
+
+Ma préférence va au premier : c'est la lecture que le mot « case » induit, et c'est celle qui préserve la
+promesse « la suite ne se bloque pas » indépendamment du nombre d'échanges.
+
+**Écarté :** une clé `timeout_per_step:` séparée. Deux limites à tenir dans la tête pour un format dont
+la valeur est qu'un cas se lit d'un coup — et le jour où elles se contredisent, il faut documenter
+laquelle gagne.
+
+## 3. Majeur : `expect.calls` dans un échange compte depuis le début du cas
+
+| Échange | Appels réels | Ce qu'il voit |
+|---|---|---|
+| `steps[0]` | 1 | **1** ✓ |
+| `steps[1]` | 1 | **2** ✗ |
+| global | 2 | 2 ✓ |
+
+Vérifié par élimination : `calls: { outil: 1 }` au premier échange passe, la même assertion au second
+échoue, `{ outil: 2 }` au second passe. Le journal n'est pas segmenté par échange.
+
+**La conséquence est celle que `writing-cases.md` promet d'éviter.** Cette page défend les assertions qui
+ne cassent pas « the day the subject gains one log line ». Ici, insérer un échange en amont fausse le
+`calls` de tous les suivants, et écrire celui du troisième échange demande de compter les appels des
+deux premiers.
+
+Pour zanvil ça mord tout de suite : les cas du viewer k9s assertent `calls: { fzf: 1 }`, et leur forme
+naturelle en échanges — ouvrir, puis rafraîchir par `Ctrl-R` — verrait 2 au second.
+
+**Le remède est déjà écrit, dans la même boucle.** `process.rs:92-94` segmente les effets fichiers
+ainsi :
+
+```rust
+let before = crate::iso::snapshot::Snapshot::take(iso.root());
+let mut seen = one_run(case, iso, &argv)?;
+seen.files = before.changes_since(iso.root());
+```
+
+**Demandé :** le même avant/après appliqué au journal d'appels, pour que `calls` ait par échange la
+granularité que les fichiers ont déjà. Le global doit continuer à voir le cumul — il est juste
+aujourd'hui.
+
+**Un détail qui explique pourquoi ça n'a pas été vu.** Le commentaire de `gathered()` dit « the last exit
+and **the last call journal**, because that is what "the run" ended as ». Comme le journal est cumulatif,
+« le dernier » vaut « tous » : le résultat global est correct, mais pour une raison différente de celle
+que le commentaire énonce. Le code et son commentaire décrivent deux mécanismes qui coïncident au niveau
+global et divergent par échange. Ça vaut d'être corrigé aussi, sinon la prochaine lecture repart sur la
+même hypothèse — c'est celle sur laquelle je suis parti, et elle m'a fait annoncer un défaut au mauvais
+endroit avant que la sonde me corrige.
+
+**Écarté :** demander aux cas d'écrire des compteurs cumulés. Ça marche et c'est exactement ce que la
+page sur l'écriture des suites déconseille : une assertion dont la valeur dépend de tout ce qui précède
+casse à la première insertion.
+
+## 4. Mécanique : un `calls` violé dans un échange est rapporté comme s'il était global
+
+```console
+FAIL un-appel-par-echange  0/3
+    expect.calls.outil          ← l assertion violee est celle de steps[1]
+      expected  1
+      got       2
+```
+
+On cherche donc un défaut dans le bloc `expect:` du cas, qui est correct. À comparer avec ce que le même
+verdict produit pour `stdout` :
+
+```console
+    steps[1] "le deuxieme se trompe".stdout.contains[0]
+```
+
+`verdict.rs:230` est **la seule des sept vérifications de `check()` à ne pas recevoir le préfixe `at`** :
+
+```rust
+if let Some(expected) = &expect.calls {
+    diffs.extend(calls::check(expected, &observations.calls));   // ← pas de `at`
+}
+```
+
+Ses voisines le prennent toutes — `stdout` via `&format!("{at}.stdout")`, `stderr`, `events`,
+`event_counts`, `invariants`, `status`. Et `verdict/calls.rs:21` écrit le chemin en dur :
+`path: format!("expect.calls.{bin}")`.
+
+**Demandé :** ajouter le paramètre `at` à `calls::check` et composer le chemin comme les six autres.
+Indépendant du nº 3 : cette correction ne rend pas les comptes justes, elle dit seulement où regarder.
+
+## 5. Mineur : « The body was empty » pour un sujet qui n'a pas de body
+
+Un `capture:` sur un sujet process est correctement refusé, et pour la bonne raison — le commentaire de
+`process.rs` la formule mieux que je ne le ferais : « a process answers text, and deciding that its
+output is a JSON document to walk by path would invent a meaning for the format rather than implement
+one ». Mais le message emprunte le vocabulaire du web :
+
+```console
+steps[0] "il capture un identifiant".capture.ident
+  expected  a value at id
+  got       the path yielded no value, so `$ident` stays literal in every later request.
+            The body was empty
+```
+
+Le sujet avait écrit `{"id":7}` sur sa sortie standard. Le lecteur cherche donc pourquoi son sujet n'a
+rien produit, alors qu'il a produit exactement ce qui était attendu, et que le vrai motif est qu'un
+processus n'a pas de body du tout.
+
+**Demandé :** pour l'adaptateur process, dire ce que le commentaire du code dit déjà. La phrase existe,
+elle est juste restée dans la source.
+
+## 6. Mineur : les nœuds JUnit d'échange n'ont pas de durée
+
+```xml
+<testcase name="the run as a whole" classname="gaveldrop.timeout-par-echange" time="4.645"/>
+<testcase name="un et demi"         classname="gaveldrop.timeout-par-echange"/>
+<testcase name="encore un et demi"  classname="gaveldrop.timeout-par-echange"/>
+```
+
+`writing-cases.md` pose que les durées « are reported everywhere and asserted nowhere », et la 0.1.12 a
+ajouté la durée par cas. Les échanges n'en ont pas, ce qui laisse les 4,645 s indécomposables — c'est
+précisément l'information qui aurait rendu le nº 2 visible sans qu'il faille le chercher.
+
+**Demandé :** l'attribut `time` sur les nœuds d'échange, si la durée est déjà mesurée par échange. Si
+elle ne l'est pas, ça ne vaut pas de l'ajouter pour ce seul motif — traitez le nº 2 et celui-ci tombe.
+
+## 7. Documentation seule : `expect.exit_code` sélectionne, ses voisines agrègent
+
+Ce cas passe :
+
+```yaml
+steps:
+  - { name: "celui du milieu echoue vraiment", request: { run: ["sh", "-c", "echo boum >&2; exit 42"] },
+      expect: { stderr: { contains: ["boum"] } } }
+  - { name: "le dernier reussit", request: { run: ["sh", "-c", "echo fini"] },
+      expect: { stdout: { contains: ["fini"] } } }
+expect:
+  exit_code: 0        # ← vrai, et un echange est sorti en 42
+```
+
+**Je ne demande pas de le changer.** `gathered()` l'assume — « that is what "the run" ended as » — la
+définition se défend, et un échange qui échoue exprès au milieu d'un scénario est un usage légitime.
+
+Ce qui manque, c'est de le dire côté utilisateur : `expect.stdout` concatène tous les échanges,
+`expect.exit_code` en sélectionne un. Deux clés voisines dans le même bloc, deux règles d'agrégation
+opposées, aucune des deux écrite dans le schéma. Un cas qui n'observe pas ses échanges un par un croira
+avoir vérifié que rien n'a échoué.
+
+**Demandé :** une phrase dans la description de `exit_code` et une dans celle de `steps`.
+
+---
+
+# Deux demandes nées d'une campagne d'injection
+
+Douze défauts volontaires ont été injectés dans zanvil sur un worktree isolé, classés en mineurs,
+majeurs et complexes, pour mesurer ce que la suite attrape. Rapport complet :
+`~/.zanvil/web/docs/superpowers/reports/2026-08-05-injection-de-defauts-classes.md`.
+
+Résultat : **les quatre défauts majeurs sont tous attrapés**, avec des portées cohérentes — `pad()`
+neutralisé fait rougir 17 cas, un troncage de logger 2, un raccourci disparu 1. Deux trous existaient,
+tous deux comblés côté zanvil. Mais les deux ont demandé une contorsion, et c'est là que portent ces
+demandes.
+
+## 8. `args_contain` ne distingue pas un nom de sous-commande de son préfixe
+
+Le défaut injecté : renommer `zanvil theme` en `zanvil themes` dans une fonction zsh qui délègue. C'est
+la panne réelle de zanvil, rejouée — un binaire renommé a laissé trois commandes en mode dégradé pendant
+quatre mois.
+
+Le cas écrit pour l'attraper :
+
+```yaml
+fake:
+  rules:
+    - match: { bin: zanvil, args_contain: "theme" }
+      stdout: "Available themes:"
+    - match: {}
+      exit: 127
+```
+
+**Il passe aussi sous la mutation.** `args_contain` est documenté comme « substring searched for in the
+arguments joined by spaces », et « themes » contient « theme » : la règle nommée sert le mauvais appel,
+donc le catch-all ne voit rien et `unexpected calls` reste vide.
+
+La parade existe — inclure l'argument suivant :
+
+```yaml
+    - match: { bin: zanvil, args_contain: "theme list" }
+```
+
+« themes list » ne contient plus « theme list », et le cas mord. Mais la règle est désormais couplée à la
+forme complète de l'appel : le jour où la fonction insère un drapeau entre les deux, elle cesse de
+matcher pour une raison qui n'a rien à voir avec ce qu'elle vérifie.
+
+**Demandé :** un critère qui compare un argument comme **mot** plutôt que comme sous-chaîne — soit un
+`args:` qui prend la liste exacte, soit la sémantique « l'un des arguments égale cette valeur ». Le cas
+d'usage n'est pas exotique : vérifier qu'une délégation appelle la bonne sous-commande est le premier
+usage d'un `fake` sur son propre binaire, et distinguer un nom de son préfixe est exactement ce qu'un
+renommage exige.
+
+**Écarté :** une expression régulière dans `args_contain`. Ça résoudrait ce cas et ouvrirait la porte à
+des règles illisibles en revue, ce qui coûterait la première propriété du format. Un critère nommé qui
+dit ce qu'il fait vaut mieux qu'un langage dans une chaîne.
+
+## 9. Rien n'exprime « ces deux fragments sur la même ligne »
+
+Le défaut injecté : inverser `if enabled` en `if !enabled` dans le CLI, ce qui échange tous les statuts
+d'une table `MODULE / STATUT / DESCRIPTION`.
+
+Le cas assertait `contains: ["KUBE", "DOCKER", "actif", "inactif"]`. Les quatre mots restent présents
+après l'inversion, l'assertion reste vraie, et **la sortie est entièrement fausse**. `contains` dit qu'un
+fragment existe, jamais que deux fragments sont associés.
+
+La seule parade disponible est de figer la ligne avec son espacement :
+
+```yaml
+      - "KUBE         actif"
+```
+
+Elle mord, et c'est ce qui est en place aujourd'hui. Le coût est écrit dans le cas : treize espaces
+figés, donc passer `{:<12}` à `{:<14}` — une décision de présentation — fera rougir un test de
+comportement. C'est précisément ce que `writing-cases.md` déconseille : « a case that breaks for that
+reason gets deleted rather than maintained ».
+
+**Demandé :** un moyen d'asserter une association sans figer la mise en forme. La forme la plus proche de
+l'existant serait une entrée de `TextExpectation` qui prend plusieurs fragments à trouver dans une même
+ligne — quelque chose comme `line_contains: [["KUBE", "actif"]]`, dont l'échec dirait quelle ligne a été
+trouvée et ce qui y manquait.
+
+**Écarté :** `equals` sur la sortie entière. C'est possible aujourd'hui et c'est pire : treize lignes
+figées au lieu d'une, et un cas qui rougit dès qu'un module s'ajoute — alors que l'ajout d'un module est
+exactement ce que cette commande doit savoir faire.
+
+---
+
+## Ce qui tient, et qu'il ne faut pas retoucher
+
+Éprouvé et solide, consigné pour que personne n'y touche en corrigeant le reste :
+
+- l'état de la racine isolée **persiste** entre les échanges ;
+- **tous** les échanges tournent, même après un échec, et **toutes** les assertions sont rapportées —
+  le global d'abord, puis les échanges dans l'ordre ;
+- le verdict situe l'assertion par index **et** par nom : `steps[1] "le deuxieme se trompe".stdout.contains[0]` ;
+- un échange **sans nom** donne `<testcase name="step 1">` dans le JUnit, pas le `name=""` que le nom de
+  cas vide produisait — le raisonnement de la #130 est bien appliqué aux échanges, je m'attendais à le
+  trouver à moitié et il ne l'est pas ;
+- les effets **fichiers** sont correctement segmentés par échange ;
+- le **catch-all reste obligatoire**, et le message le justifie ;
+- `steps: []` est accepté et se comporte comme un cas sans échanges ;
+- un échange déclaré mais non effectué est rapporté avec le compte des deux côtés, et l'inverse est
+  traité comme « the same class of surprise as an unexpected call ».
+
+## Une remarque sur le canal
+
+La 0.1.6 à la 0.1.12 sont arrivées sans document dans `docs/superpowers/`. Ce n'est pas un reproche — le
+changelog et les docs suffisaient — mais deux choses m'ont coûté du temps et une aurait tenu en une
+ligne : que **les quatre findings de zanvil étaient traités** (je l'ai vérifié en le testant), et que
+`@v1` avait déjà emmené la CI de zanvil en 0.1.12 sans qu'aucun commit de zanvil ne le dise. Le tag
+mobile fait ce qu'on lui demande ; c'est juste qu'un consommateur ne sait pas quand il change de version.

--- a/web/docs/superpowers/reports/2026-08-03-gaveldrop-0-1-5-stress.md
+++ b/web/docs/superpowers/reports/2026-08-03-gaveldrop-0-1-5-stress.md
@@ -1,0 +1,174 @@
+# Rapport — mise à l'épreuve adversariale de gaveldrop v0.1.5
+
+**Pour le dépôt gaveldrop.** Rien n'y a été modifié. Le dépôt était sur `fix/config-errors-read-once`
+avec des modifications non committées de 21:54 ; **tous les résultats ci-dessous ont donc été rejoués sur
+l'archive publiée de `v0.1.5`**, pour ne pas rapporter contre un travail en cours.
+
+Méthode : fabriquer volontairement des cas pathologiques et regarder si le format les refuse, les
+diagnostique, ou les laisse passer.
+
+## Ce qui tient, et qu'il faut dire d'abord
+
+Quatre comportements ont été éprouvés et sont solides :
+
+**Le timeout tue le sujet, et il l'explique.** Ma première crainte était un `got -1` cryptique ; le
+verdict complet dit exactement ce qu'il faut, avec le remède et une observation :
+
+```
+FAIL subject-that-hangs  0/1  2.0s
+    timeout
+      expected  the subject exits within 2.0s
+      got       still running after 2.0s, so it was killed. Raise `timeout:` on the case if it is
+                meant to take this long, otherwise look at what it was waiting for — it wrote
+                nothing at all
+```
+
+**Le timeout couvre aussi les hooks**, ce qui n'était pas acquis : « A hook that waits for something
+that never comes hangs the suite as thoroughly as a subject does ».
+
+**Deux cas revendiquant un nom sont refusés au chargement**, avec les trois raisons (JUnit malformé, clé
+du rapport HTML, ligne terminale ambiguë).
+
+**`equals` pointe la ligne qui diverge** : `expected line 3 "charlie"` / `got line 3 "CHARLIE" (the
+first 2 lines matched)`.
+
+**`setup.stdin` encaisse 5 Mo** en 110 ms, les 25 000 lignes reçues, et un sujet qui ferme son entrée
+après une ligne (`head -1`) ne produit ni blocage ni erreur.
+
+---
+
+## 1. Le timeout tue le sujet, pas sa descendance
+
+Un sujet qui a lancé un processus en arrière-plan laisse celui-ci vivant après avoir été tué :
+
+```yaml
+name: orph
+timeout: 2
+setup: { run: ["sh", "-c", "$GAVELDROP_PROJECT/relprobe & while true; do sleep 1; done"] }
+```
+
+```console
+avant: 0
+apres: 1
+ 2711     1 sleep 297      ← PPID 1 : reparente a init
+```
+
+`adapters.rs:151` fait `child.kill()`, qui envoie SIGKILL au seul processus direct. Le commentaire des
+lignes 112-114 montre que la survie d'un petit-enfant est connue — « a grandchild can still hold the
+input pipe » — mais elle n'est traitée que pour éviter que le thread d'écriture se bloque, pas pour
+nettoyer le processus.
+
+**Pourquoi ça compte au-delà de l'hygiène.** Un sujet qui démarre un service en arrière-plan est banal :
+c'est le cas de tout `serve:`-like écrit à la main, de tout script qui lance un worker, de tout test
+d'intégration. Sur un runner, l'orphelin tient un port et fait échouer le job suivant pour une raison
+qui n'apparaît nulle part. Et la promesse du timeout — « la suite ne se bloque pas » — devient partielle
+sans que le rapport le dise.
+
+**Piste :** placer le sujet dans son propre groupe de processus (`process_group(0)` sur Unix) et tuer le
+groupe plutôt que le pid. C'est ce que fait `timeout(1)` avec `--kill-after`, et ça vaut aussi pour le
+hook `setup.exec`.
+
+## 2. Un nom de cas vide est accepté
+
+```yaml
+name: ""
+weight: 4
+setup: { run: ["true"] }
+expect: { exit_code: 0 }
+```
+
+```console
+ok     4/4
+```
+
+La ligne terminale ne nomme rien. Le JUnit produit `<testcase name="">`. Et `--only ''` matche tous les
+cas, donc ne peut pas cibler celui-là.
+
+**C'est exactement le raisonnement de #120, appliqué à moitié.** Le message qui refuse deux noms
+identiques dit : « A name is what identifies a case in every report this project writes — a JUnit file
+with two testcases of the same name is malformed for several dashboards, the HTML report keys each
+case's detail by it, and a terminal line naming a failure would not say which file to open. »
+
+Les trois arguments valent tels quels pour le nom vide. Un `<testcase name="">` est malformé pour les
+mêmes tableaux de bord ; une ligne `FAIL     0/4` ne dirait pas davantage quel fichier ouvrir.
+
+À noter, et c'est cohérent : **deux** cas au nom vide sont bien refusés (`2 cases are called ""`). C'est
+le cas unique qui passe.
+
+**Piste :** refuser un `name` vide ou uniquement composé de blancs, au même endroit et avec le même
+message que le doublon.
+
+## 3. Un chemin qui sort de l'isolation par `..` n'est pas détecté
+
+Le même fichier, écrit de deux façons, reçoit deux traitements :
+
+```console
+# "/etc/hosts"
+expected  a resolvable path
+got       path "/etc/hosts" resolves to /etc/hosts, outside the isolated root. Nothing is
+          observed out there, so no assertion about it could ever hold
+
+# "$HOME/../../../../etc/hosts"  — le meme fichier
+expected  written by the subject
+got       not written
+```
+
+La validation refuse le chemin absolu et laisse passer le chemin relatif équivalent, avec un message qui
+désigne la mauvaise cause : « not written » suggère un défaut du sujet, alors que le chemin n'était pas
+observable.
+
+**Ce n'est pas une faille.** L'assertion échoue au lieu de devenir trivialement vraie, donc rien de
+dangereux ne passe. C'est un problème de diagnosticabilité, et il touche la troisième propriété du
+projet : le message envoie chercher un bug dans le sujet là où il faut corriger le cas.
+
+Le raisonnement est déjà écrit dans `docs/adopting.md`, à propos des variables : « a stray `$TYPO` would
+make an `absent` assertion trivially true ». La normalisation manque juste au chemin.
+
+**Piste :** normaliser (`..` compris) avant de comparer à la racine isolée, et réutiliser le message
+existant.
+
+## 4. `timeout: 0` vaut « aucune limite »
+
+```yaml
+name: tz
+timeout: 0
+setup: { run: ["sh", "-c", "while true; do sleep 1; done"] }
+```
+
+```console
+real 8.02          ← tue par un `timeout 8` externe, pas par gaveldrop
+```
+
+Un `0` se lit naturellement comme « le plus strict possible », et produit l'inverse : aucune limite du
+tout. Le cas n'aurait jamais rendu la main.
+
+**Pourquoi ça mérite un refus plutôt qu'une documentation.** Ce projet refuse déjà ce qui est ambigu, et
+le fait bruyamment : `--shard 4/3` est refusé, une suite vide est refusée, un `min_score` supérieur au
+total atteignable est refusé depuis la 0.1.2 — tous au motif qu'un run qui « fait silencieusement moins
+que demandé » est le pire résultat possible. `timeout: 0` est le même cas de figure : il désarme la
+protection en donnant l'impression de la resserrer.
+
+**Piste :** refuser `0` au chargement, avec le choix explicite à faire — retirer la clé pour aucune
+limite, ou donner une durée.
+
+---
+
+## Ce que je n'ai pas réussi à casser
+
+Consigné pour éviter qu'on le retente : un `weight` négatif est refusé par le typage (`expected u32`) ;
+un chemin absolu hors isolation est refusé avec le bon message ; le `--only` répété fonctionne et refuse
+un fragment qui ne matche rien ; les durées par cas et le `slowest —` du résumé sont exacts ; la suite
+de zanvil (59 cas) passe sans changement, en 13,8 s.
+
+## Sur la méthode
+
+Deux de mes conclusions ont été fausses en cours de route, et le dire fait partie du rapport :
+
+- j'ai d'abord cru que le timeout ne s'expliquait pas, parce que je lisais la dernière ligne du verdict
+  (`exit_code got -1`) et non la première ;
+- mon premier test d'orphelin utilisait `sleep 300 --marqueur`, que `sleep` refuse — l'enfant n'avait
+  jamais démarré, et j'ai conclu à tort que le nettoyage était complet. Le finding nº 1 n'existe que
+  parce que j'ai revérifié que la sonde faisait ce qu'elle prétendait.
+
+C'est la même leçon que la vérification par mutation : un test qui passe sans qu'on ait vu son échec ne
+prouve pas ce qu'on croit.

--- a/web/docs/superpowers/reports/2026-08-03-gaveldrop-0-1-5-stress.md
+++ b/web/docs/superpowers/reports/2026-08-03-gaveldrop-0-1-5-stress.md
@@ -7,6 +7,20 @@ l'archive publiée de `v0.1.5`**, pour ne pas rapporter contre un travail en cou
 Méthode : fabriquer volontairement des cas pathologiques et regarder si le format les refuse, les
 diagnostique, ou les laisse passer.
 
+> **Clos le 5 août 2026 — les quatre sont corrigés.** Vérifié contre l'archive publiée de la `v0.1.12`,
+> par comportement et non d'après le changelog :
+>
+> | # | Livré en | Constaté |
+> |---|---|---|
+> | 1. Descendance orpheline après timeout | 0.1.6 (#127) | L'enfant tourne pendant le run (2 processus), **zéro** après. Le groupe entier est tué. |
+> | 2. Nom de cas vide accepté | 0.1.6 (#128), 0.1.7 (#130) | Refusé au chargement, avec les trois arguments demandés — et l'espace insécable l'est aussi. |
+> | 3. Échappement de l'isolation par `..` | 0.1.6 (#125) | Refusé, avec le message du chemin absolu. Le symlink créé par le sujet reste un cas à part, documenté comme tel. |
+> | 4. `timeout: 0` vaut « aucune limite » | 0.1.6 (#128) | Refusé : « disarms the guard rather than tightening it ». |
+>
+> La suite prise à l'envers, dans le rapport
+> [du 5 août sur les échanges](2026-08-05-gaveldrop-0-1-12-echanges.md) : le nº 1 y reparaît sous une
+> autre forme — la limite est bien armée, mais elle borne chaque échange et non le cas.
+
 ## Ce qui tient, et qu'il faut dire d'abord
 
 Quatre comportements ont été éprouvés et sont solides :

--- a/web/docs/superpowers/reports/2026-08-05-gaveldrop-0-1-12-echanges.md
+++ b/web/docs/superpowers/reports/2026-08-05-gaveldrop-0-1-12-echanges.md
@@ -1,0 +1,279 @@
+# Rapport — les échanges de gaveldrop v0.1.12 à l'épreuve
+
+**Pour le dépôt gaveldrop.** Rien n'y a été modifié. Tout a été joué contre l'archive publiée de
+`v0.1.12` (somme de contrôle vérifiée), depuis un répertoire de sondes séparé.
+
+Contexte : zanvil est passé de la 0.1.5 à la 0.1.12 d'un coup, sans document de mise à jour dans le
+canal. Sept versions, dont quatre corrigent des findings du rapport précédent et trois introduisent un
+concept neuf — les échanges. Ce rapport porte sur ce concept, parce que c'est le code le plus récent et
+que zanvil en est le premier consommateur shell.
+
+## D'abord, la non-régression
+
+Les **59 cas de zanvil passent sans une modification** : score 223/223, en 11,2 s contre 13,8 s en
+0.1.5 — 19 % plus rapide. La deuxième propriété du projet tient donc à travers sept versions, ce qui
+est le résultat le plus important de cette session et le seul qui autorisait la suite.
+
+## Ce qui tient, et qu'il faut dire d'abord
+
+Éprouvé et solide :
+
+**L'état de la racine isolée persiste entre les échanges.** Le second lit ce que le premier a écrit.
+C'est la condition pour tester un export suivi d'un import, et c'est exactement l'usage que le chantier
+2 du spec zsh/Rust attendait.
+
+**Tous les échanges tournent, même après un échec, et toutes les assertions sont rapportées.** Deux
+échanges fautifs sur quatre produisent deux verdicts, plus celui de l'assertion globale — dans l'ordre
+global puis échanges. Rien ne s'arrête au premier rouge.
+
+**Le verdict situe l'assertion par index *et* par nom** : `steps[1] "le deuxieme se trompe".stdout.contains[0]`.
+On ouvre le bon fichier et on trouve la bonne ligne sans compter.
+
+**Le finding #130 est bien appliqué aux échanges.** Un échange sans nom donne `<testcase name="step 1">`
+dans le JUnit, pas le `name=""` que le nom de cas vide produisait. Je m'attendais à retrouver là le
+motif « le raisonnement appliqué à moitié » ; il ne s'y trouve pas.
+
+**Les effets fichiers sont correctement segmentés par échange**, via un `Snapshot` avant/après dans la
+boucle (`process.rs:92-94`). C'est ce qui rend le finding nº 3 ci-dessous surprenant : le remède est
+déjà écrit deux lignes plus haut, pour un autre observable.
+
+**`capture` est refusé pour un sujet process, avec sa raison** — « a process answers text, and deciding
+that its output is a JSON document to walk by path would invent a meaning for the format rather than
+implement one ». Le cas est prévenu à `steps[0].capture.<nom>` au lieu d'échouer plus loin sur un nom
+resté littéral.
+
+**Le catch-all reste obligatoire**, et le message le justifie : « without it an unexpected call would
+pass for an expected one, and the case would stop proving anything ».
+
+---
+
+## 1. Le `timeout:` borne chaque échange, pas le cas
+
+```yaml
+name: quatre-echanges-bloques
+timeout: 2
+steps:
+  - { name: "premier bloque",   request: { run: ["sh", "-c", "while true; do sleep 1; done"] }, expect: {} }
+  - { name: "deuxieme bloque",  request: { run: ["sh", "-c", "while true; do sleep 1; done"] }, expect: {} }
+  - { name: "troisieme bloque", request: { run: ["sh", "-c", "while true; do sleep 1; done"] }, expect: {} }
+  - { name: "quatrieme bloque", request: { run: ["sh", "-c", "while true; do sleep 1; done"] }, expect: {} }
+```
+
+```console
+FAIL quatre-echanges-bloques  0/1  8.3s
+    timeout
+      expected  the subject exits within 2.0s
+      got       still running after 2.0s, so it was killed. […] it wrote nothing at all
+```
+
+**Le cas annonce une limite de 2 s et tient 8,3 s.** Le verdict imprime « exits within 2.0s » à trois
+caractères du `8.3s` qu'il vient de mesurer, sans réconcilier les deux. Un cas à vingt échanges avec
+`timeout: 30` peut tenir dix minutes en annonçant trente secondes.
+
+Le comptage est également partiel. `gathered()` fait :
+
+```rust
+let timed_out_after_ms = steps.iter().filter_map(|seen| seen.timed_out_after_ms).next();
+```
+
+`.next()` retient le premier dépassement. Quatre échanges ont été tués ; le rapport en mentionne un.
+
+**Pourquoi ça mérite mieux qu'une ligne de documentation.** C'est le motif exact du finding `timeout: 0`
+de la 0.1.5, que la 0.1.6 a corrigé en refusant la valeur : une protection qui paraît resserrée et qui
+se relâche. Ici elle se dilue par le nombre d'échanges, et le facteur n'apparaît nulle part —
+`grep -i timeout docs/*.md` ne renvoie rien sur les échanges, et le schéma dit « how many seconds **this
+case's subject** may run before it is killed », au singulier.
+
+**Piste.** Deux lectures cohérentes, et le choix vous appartient : soit `timeout:` borne le cas et
+chaque échange consomme le reste du budget, soit il borne l'échange et le dire dans le schéma — auquel
+cas le verdict gagnerait à écrire « each exchange exits within 2.0s » et à compter les dépassements
+plutôt que d'en garder un.
+
+## 2. Le diagnostic du timeout cite la sortie d'un échange postérieur
+
+Deux échanges : le premier boucle sans fin, le second écrit `suivant`.
+
+```console
+FAIL premier-echange-bloque  0/1  2.1s
+    timeout
+      got  still running after 2.0s, so it was killed. Raise `timeout:` on the case if it is meant to
+           take this long, otherwise start from the last thing it said: suivant
+    steps[0] "celui qui ne rend jamais la main".exit_code
+      expected  0
+      got       -1
+```
+
+`suivant` n'a pas été dit par l'échange tué. Il a été dit par le suivant, **après** la mort du premier.
+Le message invite à « partir de la dernière chose qu'il a dite » et désigne une sortie postérieure au
+blocage — la piste part dans le mauvais sens.
+
+La cause est la même agrégation qu'au nº 1 : le message se sert du `stdout` global, qui concatène les
+échanges, alors que le dépassement appartient à un échange précis.
+
+**Ce n'est pas cosmétique.** La troisième propriété du projet est qu'un échec se diagnostique sans lire
+gaveldrop. Ici le lecteur cherche pourquoi son sujet a bloqué juste après avoir écrit `suivant`, alors
+que `suivant` vient d'ailleurs et d'après. C'est le même service que rendait la version sans échanges,
+devenu trompeur du fait qu'il y en a plusieurs.
+
+**Piste.** Prendre la dernière ligne du `stdout` de **l'échange** qui a dépassé, et nommer l'échange
+dans le message comme le fait déjà `steps[0] "…"` juste en dessous.
+
+## 3. `expect.calls` dans un échange compte depuis le début du cas
+
+Deux échanges, un appel au binaire falsifié chacun, chacun assertant le sien :
+
+| Échange | Appels réels | Ce qu'il voit |
+|---|---|---|
+| `steps[0]` | 1 | **1** ✓ |
+| `steps[1]` | 1 | **2** ✗ |
+| global | 2 | 2 ✓ |
+
+```console
+FAIL un-appel-par-echange  0/3
+    expect.calls.outil
+      expected  1
+      got       2
+```
+
+Vérifié par élimination : `calls: { outil: 1 }` au premier échange seul passe, la même assertion au
+second échoue, et `{ outil: 2 }` au second passe. Le journal n'est donc pas segmenté par échange.
+
+**La conséquence pratique est celle que `writing-cases.md` promet d'éviter.** Cette page défend les
+assertions qui ne cassent pas « the day the subject gains one log line » : ici, insérer un échange en
+amont fausse l'assertion `calls` de tous les suivants, et écrire celle du troisième échange demande de
+compter les appels des deux premiers. Pour zanvil ça mord tout de suite : nos cas du viewer k9s
+assertent `calls: { fzf: 1 }`, et leur forme naturelle en échanges — ouvrir, puis rafraîchir par
+`Ctrl-R` — verrait 2 au second.
+
+**Le remède est déjà écrit, deux lignes plus haut.** Dans la même boucle, `process.rs:92-94` segmente
+les effets fichiers ainsi :
+
+```rust
+let before = crate::iso::snapshot::Snapshot::take(iso.root());
+let mut seen = one_run(case, iso, &argv)?;
+seen.files = before.changes_since(iso.root());
+```
+
+Le même avant/après appliqué au journal d'appels donnerait aux `calls` la granularité que les fichiers
+ont déjà.
+
+**Un détail qui explique pourquoi ça n'a pas été vu.** Le commentaire de `gathered()` dit « the last
+exit and **the last call journal**, because that is what "the run" ended as ». Comme le journal est
+cumulatif, « le dernier » vaut « tous » : le global est donc juste, mais pour une raison différente de
+celle que le commentaire énonce. Le code et son commentaire décrivent deux mécanismes qui coïncident au
+niveau global et divergent par échange.
+
+## 4. Un `calls` violé dans un échange est rapporté comme s'il était global
+
+Dans le verdict ci-dessus, le chemin est `expect.calls.outil`. Il ne nomme aucun échange, alors que
+l'assertion violée est celle de `steps[1]`. On cherche donc un défaut dans le bloc `expect:` du cas,
+qui est correct.
+
+`verdict.rs:230` est **la seule des sept vérifications de `check()` à ne pas recevoir le préfixe `at`** :
+
+```rust
+if let Some(expected) = &expect.calls {
+    diffs.extend(calls::check(expected, &observations.calls));   // ← pas de `at`
+}
+```
+
+Ses voisines le prennent toutes — `stdout` via `&format!("{at}.stdout")`, `stderr`, `events`,
+`event_counts`, `invariants`, `status`. Et `verdict/calls.rs:21` écrit le chemin en dur :
+
+```rust
+path: format!("expect.calls.{bin}"),
+```
+
+**Piste.** Ajouter le paramètre `at` à `calls::check` et composer le chemin comme les six autres. C'est
+une correction mécanique, indépendante du nº 3 — elle ne rend pas les comptes justes, elle dit
+seulement où regarder.
+
+## 5. « The body was empty » pour un sujet qui n'a pas de body
+
+Un `capture:` déclaré sur un sujet process est correctement refusé (voir plus haut), mais le message
+emprunte le vocabulaire du web :
+
+```console
+steps[0] "il capture un identifiant".capture.ident
+  expected  a value at id
+  got       the path yielded no value, so `$ident` stays literal in every later request.
+            The body was empty
+```
+
+Le sujet avait écrit `{"id":7}` sur sa sortie standard. Le lecteur va donc chercher pourquoi son sujet
+n'a rien produit, alors qu'il a produit exactement ce qui était attendu — et que le vrai motif est
+qu'un process n'a pas de body du tout.
+
+**Piste.** Pour l'adaptateur process, dire ce que le commentaire du code dit déjà si bien : un process
+répond du texte, il n'y a pas de chemin à parcourir. La phrase existe, elle est juste restée dans la
+source.
+
+## 6. Les nœuds JUnit d'échange n'ont pas de durée
+
+```xml
+<testcase name="the run as a whole" classname="gaveldrop.timeout-par-echange" time="4.645"/>
+<testcase name="un et demi"         classname="gaveldrop.timeout-par-echange"/>
+<testcase name="encore un et demi"  classname="gaveldrop.timeout-par-echange"/>
+<testcase name="et encore"          classname="gaveldrop.timeout-par-echange"/>
+```
+
+`writing-cases.md` pose que les durées « are reported everywhere and asserted nowhere », et la 0.1.12 a
+ajouté la durée par cas. Les échanges n'en ont pas, ce qui laisse les 4,645 s du run indécomposables :
+c'est précisément l'information qui aurait rendu le nº 1 visible sans qu'il faille le chercher.
+
+Mineur seul, utile en même temps que le nº 1.
+
+---
+
+## Un point de documentation, qui n'est pas un défaut
+
+`expect.exit_code` au niveau du cas vaut celui du **dernier** échange. Le cas suivant passe :
+
+```yaml
+steps:
+  - { name: "celui du milieu echoue vraiment", request: { run: ["sh", "-c", "echo boum >&2; exit 42"] },
+      expect: { stderr: { contains: ["boum"] } } }
+  - { name: "le dernier reussit", request: { run: ["sh", "-c", "echo fini"] },
+      expect: { stdout: { contains: ["fini"] } } }
+expect:
+  exit_code: 0        # ← vrai, et un échange est sorti en 42
+```
+
+C'est assumé par `gathered()` — « that is what "the run" ended as ». Je ne demande pas de le changer :
+la définition se défend, et un échange qui échoue exprès au milieu d'un scénario est un usage légitime.
+
+Ce qui manque, c'est de le dire côté utilisateur. `expect.stdout` concatène tous les échanges,
+`expect.exit_code` en sélectionne un : deux clés voisines dans le même bloc, deux règles d'agrégation
+opposées, aucune des deux écrite dans le schéma. Un cas qui n'observe pas ses échanges un par un croira
+avoir vérifié que rien n'a échoué.
+
+## Ce qui manque à côté du code
+
+`docs/shell.md` ne mentionne pas les échanges. Le support existe pourtant, et il est double :
+`request: { run: [...] }` pour une commande propre à l'échange, et un échange **sans** `request` qui
+réinvoque le `setup.run` — la répétition d'invocation de la #142. J'ai dû le lire dans
+`adapters/process.rs` pour l'écrire, ce qui est précisément le geste que la troisième propriété du
+projet cherche à rendre inutile.
+
+Deux détails valent d'y figurer, parce qu'ils m'ont coûté un aller-retour chacun : `weight` est requis,
+et `expect:` au niveau du cas l'est aussi — même quand chaque échange porte le sien, il faut un
+`expect: {}`.
+
+## Ce que je n'ai pas réussi à casser
+
+Consigné pour éviter qu'on le retente : `steps: []` est accepté et se comporte comme un cas sans
+échanges ; un échange déclaré mais non effectué est rapporté avec le compte des deux côtés ; un échange
+anonyme reste localisable (`steps[0]`, et `step 1` dans le JUnit) ; les fichiers écrits par un échange
+sont bien attribués à cet échange ; le nombre d'échanges effectués supérieur au nombre déclaré est
+traité comme « the same class of surprise as an unexpected call ».
+
+## Sur la méthode
+
+Une de mes conclusions a été fausse en cours de route. En lisant `gathered()` — `let calls =
+steps.last()...` — j'ai d'abord annoncé que les `calls` globaux seraient amputés des échanges
+antérieurs, et j'ai construit la sonde pour le prouver. Elle est passée. Le journal étant cumulatif,
+le global est juste et c'est **l'attribution par échange** qui est fausse : le défaut existait, un cran
+à côté de là où le code me l'avait fait attendre.
+
+C'est la même leçon que la vérification par mutation, prise par l'autre bout : une hypothèse tirée de la
+lecture du code se vérifie contre le comportement, pas contre le code.

--- a/web/docs/superpowers/reports/2026-08-05-injection-de-defauts-classes.md
+++ b/web/docs/superpowers/reports/2026-08-05-injection-de-defauts-classes.md
@@ -1,0 +1,165 @@
+# Rapport — douze défauts injectés volontairement, et ce que la suite en attrape
+
+**But :** savoir ce que la suite couvre réellement, et distinguer ce qui relève d'une dette de zanvil de
+ce qui relève d'une limite de gaveldrop.
+
+**Méthode.** Worktree git isolé (`git worktree add`), copie du cache de compilation, référence verte
+établie avant toute injection (59/59). Pour chaque défaut : restaurer, appliquer **en vérifiant que le
+fichier a réellement changé**, reconstruire si le Rust est touché, lancer `gaveldrop` *et* les deux
+suites bash, restaurer. Un harnais fait les douze passes pour que rien ne dépende de mon attention.
+
+La classification n'est pas cosmétique : elle prédit ce qu'on doit exiger de la suite. Un défaut mineur
+qui passe est un choix ; un défaut majeur qui passe est un trou.
+
+## Le tableau
+
+| # | Classe | Défaut injecté | Résultat |
+|---|---|---|---|
+| M1 | mineur | `_ui_check` passe de `✓` à `+` | passe inaperçu — assumé |
+| M2 | mineur | alignement des sections : 14 → 12 colonnes | passe inaperçu — assumé |
+| M3 | mineur | symbole de continuation `⤷` → `>` | **attrapé**, 2 cas |
+| J1 | majeur | le niveau de log n'est plus mis en majuscules | **attrapé**, 1 cas |
+| J2 | majeur | le logger n'est plus tronqué à 36 caractères | **attrapé**, 2 cas |
+| J3 | majeur | le raccourci `Ctrl-R` disparaît du viewer | **attrapé**, 1 cas |
+| J4 | majeur | `pad()` neutralisé, plus aucun alignement | **attrapé**, 17 cas |
+| C1 | complexe | la délégation vise `zanvil themes` au lieu de `zanvil theme` | passait inaperçu → **comblé** |
+| C2 | complexe | `local path=` réintroduit dans une fonction du hook `cd` | gaveldrop non, **lint bash oui** |
+| C3 | complexe | la sortie d'erreur de `jq` est jetée | *mutation équivalente — écartée* |
+| C4 | complexe | le `.module.toml` de kube perd sa description | **attrapé**, 1 cas |
+| C5 | complexe | inversion de condition : les statuts `actif`/`inactif` sont échangés | passait inaperçu → **comblé** |
+
+**Onze défauts réels** — C3 n'en est pas un, voir plus bas. Six attrapés par gaveldrop, un par le lint
+bash, quatre passaient : deux comblés dans ce rapport, deux assumés.
+
+## Les quatre majeurs sont tous attrapés, avec la bonne portée
+
+C'est le résultat qui compte le plus, et la **portée** est aussi informative que la détection :
+
+- `pad()` neutralisé fait rougir **17 cas** — l'alignement traverse tout le formatteur ;
+- le troncage du logger, **2 cas** ; la majuscule du niveau, **1** ; le `Ctrl-R`, **1**.
+
+Aucune portée n'est ni nulle ni totale. Un défaut local fait rougir peu de cas, un défaut transversal en
+fait rougir beaucoup : c'est la signature d'une suite dont les cas testent des choses distinctes plutôt
+que la même chose répétée.
+
+## C3 n'est pas un trou : c'est une mutation équivalente
+
+Ajouter `2>/dev/null` à l'appel `jq` du formatteur ne change **rien** d'observable. Vérifié plutôt que
+supposé :
+
+```console
+$ printf '{ceci nest pas du json\n' | ./scripts/k9s-log-fmt.sh 2>/tmp/err
+{ceci nest pas du json
+$ wc -c </tmp/err
+0
+```
+
+`jq -Rr` lit du texte brut et gère le parsing dans son filtre : il n'écrit jamais sur sa sortie d'erreur,
+même sur du JSON malformé. La mutation est donc sémantiquement neutre, et la compter comme « défaut non
+détecté » aurait gonflé le bilan d'un trou inexistant.
+
+## C2 : la couverture vient d'ailleurs, et c'est légitime
+
+Réintroduire `local path="$1"` dans `_zanvil_local_load` — le bug réel qui cassait `work_es_apps` — ne
+fait rougir aucun cas gaveldrop, et **fait rougir le lint bash** (`zsh-special-vars.test.sh`).
+
+C'est le bon partage. Un `local path=` dans une fonction qu'aucun cas n'appelle ne produit aucun
+comportement observable ; gaveldrop teste des comportements, un lint teste du texte. Exiger de gaveldrop
+qu'il attrape ça reviendrait à lui demander d'être un analyseur statique.
+
+**Mais l'exercice a révélé un piège dans le lint**, et il m'a trompé pendant deux passes. Son
+`ROOT="${ZANVIL_DIR:-$HOME/.zanvil}"` audite le répertoire que la variable désigne, pas celui d'où il est
+lancé. Depuis le worktree, il analysait donc le dépôt principal — sain — et annonçait `7 ok, 0 échec`
+alors que le défaut était sous ses yeux. La CI l'échappe parce qu'elle fait `export ZANVIL_DIR="$PWD"`
+juste avant ; un développeur qui lance le test à la main dans une copie ou un worktree, non.
+
+À corriger : dériver `ROOT` de la position du script, pas de l'environnement. Consigné, non fait ici —
+c'est un défaut de l'outillage de test, pas de la suite.
+
+## C1 : le trou grave, et c'est la panne du chantier 1 qui revient
+
+Renommer `zanvil theme` en `zanvil themes` dans `core/commands/theme.zsh` ne faisait rougir **aucun des
+59 cas**. La délégation cassait, le repli zsh prenait la main, la suite restait verte.
+
+La raison est structurelle : les cas `cli-theme-*` invoquent le binaire **par chemin absolu**
+(`$GAVELDROP_PROJECT/cli/target/release/zanvil`) et ne passent jamais par la fonction zsh, qui est le
+seul point d'entrée sur un poste. Toute la couverture portait sur le Rust ; le raccord entre les deux
+langages n'était testé nulle part.
+
+C'est exactement ce qui a coûté quatre mois : `command -v zanvil` échouait, trois commandes tournaient en
+mode dégradé, et rien ne le disait.
+
+**Comblé** par `tests/cases/cli/theme-delegates-to-the-cli-with-the-right-subcommand.yaml`, qui falsifie
+notre propre binaire pour vérifier avec quels arguments la fonction l'appelle. Le verdict sous mutation :
+
+```console
+FAIL theme-delegates-to-the-cli-with-the-right-subcommand  0/7
+    expect.exit_code            expected 0        got 127
+    expect.stdout.contains[0]   expected "Available themes:"   got (empty)
+    unexpected calls            got zanvil
+```
+
+`zanvil` a été ajouté à `fake.bins` de `gaveldrop.yaml`. Mesuré avant de s'y engager : aucun des 59 cas
+existants ne change, parce que ceux qui veulent le vrai binaire l'invoquent par chemin absolu, que le
+shadowing du `PATH` n'atteint pas.
+
+**Ce cas a d'abord été écrit faux, et c'est le point le plus utile de ce rapport.** Ma première règle
+était `args_contain: "theme"`, et le cas passait *aussi* sous la mutation : `args_contain` est une
+sous-chaîne, et « themes » contient « theme ». Un cas qui ne peut pas échouer ressemble exactement à un
+cas qui passe. Seule la mutation l'a montré.
+
+## C5 : `contains` ne voit pas une association
+
+Inverser `if enabled` en `if !enabled` dans `modules.rs` échange tous les statuts. Le cas assertait
+`["KUBE", "DOCKER", "actif", "inactif"]` : les quatre mots restent présents, l'assertion reste vraie, et
+la sortie est entièrement fausse.
+
+C'est la limite de `contains` sur une table : il dit qu'un fragment existe, jamais que deux fragments
+sont sur la même ligne.
+
+**Comblé** par `- "KUBE         actif"`, la seule expression disponible aujourd'hui. Elle mord :
+
+```console
+    expect.stdout.contains[8]
+      expected  contains "KUBE         actif"
+```
+
+Le coût est assumé et écrit dans le cas : treize espaces figés, donc passer `{:<12}` à `{:<14}` fera
+rougir un test de comportement pour une raison cosmétique. C'est le motif que `writing-cases.md`
+déconseille — « a case that breaks for that reason gets deleted rather than maintained » — et c'est
+pourquoi il en sort une demande à gaveldrop plutôt qu'une satisfaction.
+
+## M1 et M2 : assumés
+
+Le symbole `✓` et la largeur d'alignement des sections ne sont assertés nulle part, et ne le seront pas.
+Les deux sont du ressort du thème : une palette peut légitimement changer un symbole, et un cas qui
+figerait `✓` rougirait au premier thème qui préfère `●`. Le seul symbole asserté dans la suite est celui
+du formatteur k9s (`⤷`), parce que là il fait partie du **format de sortie** que le plugin promet, pas de
+l'habillage.
+
+## Ce que l'exercice demande à gaveldrop
+
+Deux findings nés de l'usage, ajoutés au document de demandes :
+
+1. **`args_contain` ne distingue pas un nom de son préfixe.** « theme » matche « themes ». C'est le motif
+   exact du bug qui a coûté quatre mois à zanvil — un renommage — et la seule parade est d'inclure
+   l'argument suivant (`"theme list"`), ce qui couple la règle à la forme de l'appel.
+2. **Rien n'exprime « ces deux fragments sur la même ligne ».** Il faut figer l'espacement, donc coupler
+   un test de comportement à une décision de présentation.
+
+## Sur la méthode
+
+Trois de mes gestes ont été faux et méritent d'être écrits, parce que deux d'entre eux auraient produit
+un rapport erroné :
+
+- **le harnais annonçait `BUILD-ECHOUE` jamais** : `cargo build 2>&1 | tail -5` rend le code de retour de
+  `tail`, toujours nul. Une mutation Rust qui ne compile pas aurait été mesurée contre l'ancien binaire
+  et comptée comme « passe inaperçu » ;
+- **cinq des douze cibles étaient absentes du code** au premier essai. Le harnais les a signalées au lieu
+  de muter dans le vide, ce qui est la seule raison pour laquelle le tableau ci-dessus veut dire quelque
+  chose ;
+- **le lint bash m'a menti deux fois** avant que je regarde son `ROOT`, et j'ai failli conclure qu'un
+  garde-fou écrit exprès pour ce bug ne mordait pas.
+
+C'est la même leçon que la vérification par mutation, appliquée à l'outillage : un test qui passe sans
+qu'on ait vu son échec ne prouve rien, et cela vaut aussi pour le harnais qui mesure les tests.


### PR DESCRIPTION
Trois commits : le rapport 0.1.5 (jamais mergé, ses quatre findings sont maintenant corrigés), le rapport sur les échanges de la 0.1.12, et deux cas renforcés par mutation.

## Non-régression d'abord

Les **59 cas passent inchangés** sur la 0.1.12 : 223/223, en 11,2 s contre 13,8 s en 0.1.5. Sept versions d'écart, zéro adaptation nécessaire. La CI est sur `@v1`, elle tournait donc déjà en 0.1.12 sans que rien ne l'annonce — c'est le prix du tag mobile, et il est payé.

## Le rapport 0.1.5 est clos

Ses quatre findings sont corrigés en 0.1.6/0.1.7, vérifiés par comportement et non d'après le changelog. La sonde de l'orphelin a été revalidée en comptant l'enfant *pendant* le run — deux processus vivants, zéro après.

## Six défauts sur les échanges

Le concept est neuf (0.1.11/0.1.12) et zanvil en est le premier consommateur shell. Les deux premiers touchent la promesse du timeout :

1. `timeout: 2` avec quatre échanges bloqués donne un cas de **8,3 s**. La limite borne l'échange, pas le cas, et le facteur n'est écrit nulle part. `gathered()` ne retient que le premier dépassement, donc quatre morts sont rapportées comme une.
2. Le diagnostic du timeout cite la dernière ligne du stdout **agrégé**, donc la sortie d'un échange postérieur au blocage : la piste part dans le mauvais sens.
3. `expect.calls` dans un échange compte depuis le début du cas — 2 au lieu de 1. Le remède est déjà écrit deux lignes plus haut, où un `Snapshot` avant/après segmente les effets fichiers.
4. Un `calls` violé dans un échange est rapporté comme `expect.calls.<bin>` : `verdict.rs:230` est la seule des sept vérifications à ne pas recevoir le préfixe `at`.
5. « The body was empty » pour un sujet process, qui n'a pas de body et avait bien écrit sur stdout.
6. Les nœuds JUnit d'échange n'ont pas d'attribut `time`, ce qui laisse les secondes du run indécomposables.

Rien n'a été modifié dans gaveldrop.

## Deux cas qui ne mordaient pas

`writing-cases.md` rapporte l'expérience de l'autre consommateur : huit défauts injectés, cinq attrapés, les trois échappés étaient dans des données non assertées. Appliqué ici, même résultat :

- `metas.iter().take(2)` fait tomber neuf modules sur onze — les six cas cli restaient verts, parce que KUBE et DOCKER réapparaissent par la seconde boucle, avec nom et statut mais sans description.
- `#[command(name = "mrfanout")]` ne faisait rougir aucun cas, alors que les douze sous-commandes sont invoquées depuis le zsh. C'est la panne du chantier 1 sous une autre forme.

Chaque renforcement est passé par le cycle complet : vert sain, rouge muté, restauré et reconstruit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)