### PR TITLE
feat(sync): completer le CLI puis lui deleguer — chantier 2

### DIFF
--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -29,13 +29,24 @@ pub fn read_version() -> String {
     "unknown".to_string()
 }
 
+/// Print a label-aligned section, matching core/ui.zsh `_ui_section` (14 columns).
+pub fn print_section(label: &str, content: &str) {
+    println!("{:<14} {}", label.bold(), content);
+}
+
 /// Print a boxed header with title and version, matching core/ui.zsh _ui_header style
 pub fn print_header(title: &str) {
     let version = read_version();
-    // Title left-aligned, version right-aligned inside the box
-    // Total inner width = 40 (matches zsh _ui_header)
-    let inner_width: usize = 40;
-    let padding = inner_width.saturating_sub(title.len() + version.len());
+    // Title left-aligned, version right-aligned inside the box.
+    //
+    // 42 et non 40, et quatre espaces retires du remplissage plutot que zero : la
+    // bordure faisait 40 caracteres pour une ligne de 44, donc le cadre etait ouvert a
+    // droite dans les sept commandes qui appellent cette fonction. `_ui_header` prend
+    // une largeur de 44 dont 42 d interieur, et compte les deux espaces de chaque cote
+    // — c est ce calcul-la qu il fallait reprendre pour que le Rust et le zsh dessinent
+    // la meme boite.
+    let inner_width: usize = 42;
+    let padding = inner_width.saturating_sub(title.len() + version.len() + 4);
     let border = "─".repeat(inner_width);
     println!("{}", format!("╭{}╮", border).cyan());
     println!(

--- a/cli/src/cmd/sync.rs
+++ b/cli/src/cmd/sync.rs
@@ -57,6 +57,8 @@ pub fn run(action: SyncAction) {
 }
 
 fn export(output: &str) {
+    crate::cmd::print_header("Zanvil Sync Export");
+
     let content = match config::read_config() {
         Ok(c) => c,
         Err(e) => {
@@ -115,7 +117,9 @@ fn export(output: &str) {
         theme,
         theme_light,
         theme_dark,
-        plugins: vec![],
+        // Les plugins etaient exportes comme un tableau vide en dur. Un poste qui en
+        // declarait les perdait a la synchronisation, sans que rien ne le signale.
+        plugins: config::parse_array(&content, "ZANVIL_PLUGINS"),
         auto_update: AutoUpdateConfig {
             enabled: au_enabled,
             frequency: au_freq,
@@ -139,13 +143,32 @@ fn export(output: &str) {
                 eprintln!("{} Erreur: {}", "✗".red(), e);
             } else {
                 println!("{} Config exportee: {}", "✓".green(), output_path.display());
+                println!();
+                // Le meme resume que le zsh imprimait : ce qui vient de partir dans le
+                // fichier, en trois lignes, pour qu on n ait pas a l ouvrir.
+                crate::cmd::print_section("Version", &sync.version);
+                crate::cmd::print_section("Theme", &sync.theme);
+                crate::cmd::print_section("Modules", &compact_modules(&sync.modules));
             }
         }
         Err(e) => eprintln!("{} Serialisation: {}", "✗".red(), e),
     }
 }
 
+/// Rend les modules sur une ligne, comme le resume du zsh les affichait.
+fn compact_modules(modules: &BTreeMap<String, bool>) -> String {
+    let inner: Vec<String> = modules
+        .iter()
+        .map(|(name, enabled)| format!("\"{}\":{}", name, enabled))
+        .collect();
+    format!("{{{}}}", inner.join(","))
+}
+
 fn import(file: &str) {
+    crate::cmd::print_header("Zanvil Sync Import");
+    crate::cmd::print_section("Source", file);
+    println!();
+
     let content = match fs::read_to_string(file) {
         Ok(c) => c,
         Err(e) => {
@@ -188,6 +211,40 @@ fn import(file: &str) {
         }
     }
 
+    // Les cinq reglages que cet import ignorait, alors qu il annoncait « Config
+    // importee » : les deux themes clair/sombre et les trois d auto-update. Un
+    // utilisateur qui synchronisait deux machines croyait sa config alignee.
+    //
+    // Une valeur vide n est pas appliquee : le JSON porte `""` quand la machine
+    // d origine n avait pas le reglage, et poser `CLE=` dans config.zsh donnerait a une
+    // absence la forme d un choix.
+    if !sync.theme_light.is_empty() {
+        config_content = config::set_value(&config_content, "ZANVIL_THEME_LIGHT", &sync.theme_light);
+    }
+    if !sync.theme_dark.is_empty() {
+        config_content = config::set_value(&config_content, "ZANVIL_THEME_DARK", &sync.theme_dark);
+    }
+    config_content = config::set_value(
+        &config_content,
+        "ZANVIL_AUTO_UPDATE",
+        &sync.auto_update.enabled.to_string(),
+    );
+    config_content = config::set_value(
+        &config_content,
+        "ZANVIL_UPDATE_FREQUENCY",
+        &sync.auto_update.frequency.to_string(),
+    );
+    if !sync.auto_update.mode.is_empty() {
+        // Les guillemets sont la convention du fichier pour cette cle, et le zsh les
+        // ecrivait : sans eux, `ss` relirait une valeur nue la ou la config en attend
+        // une citee.
+        config_content = config::set_value(
+            &config_content,
+            "ZANVIL_UPDATE_MODE",
+            &format!("\"{}\"", sync.auto_update.mode),
+        );
+    }
+
     if let Err(e) = config::write_config(&config_content) {
         eprintln!("{} {}", "✗".red(), e);
         return;
@@ -204,6 +261,10 @@ fn import(file: &str) {
 }
 
 fn diff(file: &str) {
+    crate::cmd::print_header("Zanvil Sync Diff");
+    crate::cmd::print_section("Source", file);
+    println!();
+
     let content = match fs::read_to_string(file) {
         Ok(c) => c,
         Err(e) => {
@@ -264,6 +325,33 @@ fn diff(file: &str) {
                 format!("  {:<28} {:<12} {}", format!("ZANVIL_MODULE_{}", name), local_str, remote_str).dimmed()
             );
         }
+    }
+
+    // Le theme etait absent de cette comparaison, donc le compte etait faux : deux
+    // differences annoncees la ou il y en avait trois. Quelqu un qui lisait « 2 » et
+    // importait decouvrait son prompt change a un reglage de plus que ce que la
+    // commande lui avait montre.
+    let local_theme = fs::read_to_string(config::zanvil_dir().join(".current_theme"))
+        .map(|s| s.trim().to_string())
+        .unwrap_or_default();
+    let local_theme_str = if local_theme.is_empty() {
+        "default".to_string()
+    } else {
+        local_theme
+    };
+    if local_theme_str != sync.theme {
+        println!(
+            "  {:<28} {:<12} {}",
+            "theme".yellow(),
+            local_theme_str,
+            sync.theme.cyan()
+        );
+        diffs += 1;
+    } else {
+        println!(
+            "  {}",
+            format!("  {:<28} {:<12} {}", "theme", local_theme_str, sync.theme).dimmed()
+        );
     }
 
     println!();

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -108,6 +108,68 @@ pub fn parse_modules(content: &str) -> Vec<ModuleEntry> {
 
 /// Sets a module to enabled or disabled in the config content.
 /// Returns the updated content, or an error if the module was not found.
+/// Pose `key=value` dans le contenu de config.zsh, en remplaçant la ligne si elle
+/// existe et en l'ajoutant sinon.
+///
+/// Contrairement à `set_module`, ne rend jamais d'erreur : une clé absente est un cas
+/// normal ici. Un poste qui n'a jamais réglé son auto-update n'a pas la ligne, et un
+/// import doit pouvoir la créer — c'est ce que fait `_zanvil_sync_set_config` en zsh,
+/// dont cette fonction reprend le contrat pour que la délégation ne change rien.
+///
+/// La valeur est écrite telle quelle : c'est à l'appelant de mettre les guillemets
+/// quand la convention du fichier les demande, comme pour `ZANVIL_UPDATE_MODE="…"`.
+pub fn set_value(content: &str, key: &str, value: &str) -> String {
+    let target = format!("{}=", key);
+    let replacement = format!("{}={}", key, value);
+
+    let mut found = false;
+    let mut lines: Vec<String> = content
+        .lines()
+        .map(|line| {
+            if line.trim().starts_with(&target) {
+                found = true;
+                replacement.clone()
+            } else {
+                line.to_string()
+            }
+        })
+        .collect();
+
+    if !found {
+        lines.push(replacement);
+    }
+
+    let mut result = lines.join("\n");
+    if content.ends_with('\n') || !found {
+        result.push('\n');
+    }
+    result
+}
+
+/// Lit un tableau zsh `NOM=(a b c)` déclaré sur une seule ligne.
+///
+/// Le format est celui que `install.sh` et les exemples écrivent, et le seul que
+/// `plugins.zsh` sache relire. Un tableau étalé sur plusieurs lignes n'est pas géré —
+/// le zsh ne le gérait pas non plus, et inventer ici une tolérance que le reste du
+/// projet n'a pas ferait diverger l'export de ce que la config veut dire.
+pub fn parse_array(content: &str, key: &str) -> Vec<String> {
+    let target = format!("{}=(", key);
+    content
+        .lines()
+        .map(str::trim)
+        .find(|line| line.starts_with(&target))
+        .and_then(|line| line.split_once('(').map(|(_, rest)| rest))
+        .map(|rest| rest.trim_end_matches(')'))
+        .map(|inner| {
+            inner
+                .split_whitespace()
+                .map(|item| item.trim_matches(['"', '\'']).to_string())
+                .filter(|item| !item.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 pub fn set_module(content: &str, name: &str, enabled: bool) -> Result<String, String> {
     let key = format!("ZANVIL_MODULE_{}", name.to_uppercase());
     let target = format!("{}=", key);

--- a/core/lifecycle/sync.zsh
+++ b/core/lifecycle/sync.zsh
@@ -26,6 +26,10 @@ zanvil-sync() {
 # Export
 # ==============================================================================
 _zanvil_sync_export() {
+    if command -v zanvil &>/dev/null; then
+        zanvil sync export "$@"; return $?
+    fi
+
     local output="${1:-$ZANVIL_DIR/sync.json}"
     local config_file="$ZANVIL_DIR/config.zsh"
 
@@ -108,9 +112,16 @@ _zanvil_sync_import() {
     local input="$1"
     local config_file="$ZANVIL_DIR/config.zsh"
 
+    # La validation reste en zsh, avant la delegation : le refus et son message
+    # d usage sont identiques que le binaire soit la ou non, et un cas peut donc
+    # les asserter sans dependre de l installation.
     if [[ -z "$input" || ! -f "$input" ]]; then
         _ui_msg_fail "Usage: zanvil-sync import <fichier.json>"
         return 1
+    fi
+
+    if command -v zanvil &>/dev/null; then
+        zanvil sync import "$input"; return $?
     fi
 
     _ui_header "Zanvil Sync Import"
@@ -203,6 +214,10 @@ _zanvil_sync_diff() {
     if [[ -z "$input" || ! -f "$input" ]]; then
         _ui_msg_fail "Usage: zanvil-sync diff <fichier.json>"
         return 1
+    fi
+
+    if command -v zanvil &>/dev/null; then
+        zanvil sync diff "$input"; return $?
     fi
 
     if ! command -v jq &>/dev/null; then

--- a/gaveldrop.yaml
+++ b/gaveldrop.yaml
@@ -7,10 +7,5 @@ cases: tests/cases/**/*.yaml
 #
 # fzf sert les cas du viewer : les uns le simulent pour choisir son code de sortie, un
 # autre le cache pour eprouver le repli. Les deux coexistent depuis la v0.1.1.
-# `zanvil` est declare parmi les faux pour une raison differente des autres : ce n est
-# pas une dependance externe, c est notre propre binaire. Une fonction zsh qui delegue
-# fait `command -v zanvil` puis l appelle par son nom, donc seul un faux dans le PATH
-# permet de verifier AVEC QUELS ARGUMENTS elle l appelle. Les cas qui veulent le vrai
-# binaire l invoquent par chemin absolu, que le shadowing du PATH n atteint pas.
 fake:
-  bins: [posting, delta, lazygit, atuin, fzf, zanvil]
+  bins: [posting, delta, lazygit, atuin, fzf]

--- a/gaveldrop.yaml
+++ b/gaveldrop.yaml
@@ -8,4 +8,4 @@ cases: tests/cases/**/*.yaml
 # fzf sert les cas du viewer : les uns le simulent pour choisir son code de sortie, un
 # autre le cache pour eprouver le repli. Les deux coexistent depuis la v0.1.1.
 fake:
-  bins: [posting, delta, lazygit, atuin, fzf]
+  bins: [posting, delta, lazygit, atuin, fzf, starship]

--- a/tests/cases/boot/rc-loads-without-an-error.yaml
+++ b/tests/cases/boot/rc-loads-without-an-error.yaml
@@ -31,6 +31,13 @@ fake:
       stdout: ""
     - match: { bin: atuin, args_contain: "init" }
       stdout: ""
+    # core/hooks.zsh evalue « starship init zsh » au demarrage. Falsifie depuis que le
+    # cas de delegation de theme en a besoin : son repli zsh refuse tout sans starship,
+    # y compris lister des themes versionnes, donc il rendait un verdict different sur
+    # un poste equipe et sur un runner nu. La reponse vide est correcte, comme pour les
+    # quatre autres : elle est passee a eval, et eval de rien ne fait rien.
+    - match: { bin: starship, args_contain: "init" }
+      stdout: ""
     - match: {}
       exit: 127
       stderr: "the case did not foresee this call"
@@ -54,3 +61,4 @@ expect:
     delta: 1
     lazygit: 1
     atuin: 2
+    starship: 1

--- a/tests/cases/cli/cli-modules-list-reflects-config-zsh.yaml
+++ b/tests/cases/cli/cli-modules-list-reflects-config-zsh.yaml
@@ -25,19 +25,27 @@ expect:
     contains:
       - "MODULE"
       - "STATUT"
-      - "KUBE"
-      - "DOCKER"
-      - "actif"
-      - "inactif"
       - "Gestion kubeconfig"
       - "Utilitaires Docker"
-      # Les espaces sont volontaires, et c est le seul endroit de la suite ou l on
-      # fige un alignement. Motif : `["KUBE", "actif"]` ne dit pas que les deux sont
-      # sur la MEME ligne, donc une inversion de condition qui echange les statuts
-      # laisse les deux mots presents et l assertion vraie. Verifie par mutation :
-      # `if !enabled` dans modules.rs ne faisait rougir aucun cas avant cette ligne.
-      #
-      # Le cout est assume : changer `{:<12}` en `{:<14}` fera rougir ce cas pour une
-      # raison cosmetique. Un statut faux est un defaut majeur, une largeur de colonne
-      # est un choix qu on assume en mettant le test a jour.
-      - "KUBE         actif"
+  # L association module/statut, et non les mots pris separement : une inversion de
+  # condition qui echange les statuts laisse « actif » et « inactif » tous les deux
+  # presents dans la sortie, donc un `contains` sur les mots isoles reste vrai alors
+  # que la table est entierement fausse. Verifie par mutation : `if !enabled` dans
+  # modules.rs ne faisait rougir aucun cas avant qu on asserte l association.
+  #
+  # Les valeurs sont comparees comme des MOTS, pas comme des sous-chaines — c est la
+  # difference entre `include` et `contain` dans ce format, et elle decide ici : avec
+  # des sous-chaines, « inactif » contiendrait « actif » et l assertion passerait sur
+  # la table inversee. La premiere version de cette demande a gaveldrop proposait
+  # justement des sous-chaines ; c est leur correction qui la rend mordante.
+  #
+  # Effet secondaire : la comparaison par mot ignore le remplissage, donc passer
+  # `{:<12}` a `{:<14}` ne touche plus rien. La version precedente de ce cas figeait
+  # treize espaces et aurait rougi pour une raison cosmetique.
+  #
+  # `line_includes` demande gaveldrop >= 0.1.14. Une version anterieure refuse le cas
+  # au chargement en nommant le champ inconnu et en listant ceux qu elle accepte, donc
+  # le plancher est explicite et non silencieux.
+    line_includes:
+      - ["KUBE", "actif"]
+      - ["DOCKER", "inactif"]

--- a/tests/cases/cli/theme-delegates-to-the-cli-with-the-right-subcommand.yaml
+++ b/tests/cases/cli/theme-delegates-to-the-cli-with-the-right-subcommand.yaml
@@ -9,6 +9,27 @@
 # C est la panne du chantier 1 reproduite a l identique : pendant quatre mois,
 # `command -v zanvil` echouait et trois commandes tournaient en mode degrade sans le
 # dire. Un repli est acceptable s il est visible ; ce cas est ce qui le rend visible.
+#
+# ── Ce que ce cas peut prouver, et ou ────────────────────────────────────────────
+#
+# Le PATH de l isolation est celui de la machine, donc `command -v zanvil` trouve le
+# binaire la ou il est installe et ne le trouve pas sur un runner nu. Les assertions
+# ci-dessous sont donc ecrites pour etre vraies des DEUX cotes : les noms de themes
+# versionnes apparaissent dans la sortie du CLI comme dans celle du repli, alors que
+# tout le reste differe — le CLI ecrit « Available themes: », le repli dessine un
+# header et marque le theme actif d une etoile.
+#
+# La consequence est assumee : sur un poste equipe, un renommage de la sous-commande
+# fait rougir ce cas parce que clap refuse le nom et que la fonction propage son code
+# de sortie ; sur un runner sans binaire, le renommage n a aucun effet observable, donc
+# rien ne rougit. C est correct — un defaut de delegation n existe que la ou il y a une
+# delegation.
+#
+# Une premiere version comptait les appels avec `fake.bins: [zanvil]`, ce qui prouvait
+# davantage : le nom exact de la sous-commande, verifiable partout. Il a fallu y
+# renoncer parce que `fake.bins` est global — falsifier notre binaire pour ce cas
+# rendait les huit cas de tests/cases/sync/ incapables d atteindre le vrai. Demande
+# n 11 dans le document d evolution.
 name: theme-delegates-to-the-cli-with-the-right-subcommand
 weight: 7
 setup:
@@ -19,27 +40,16 @@ setup:
   call: ["zanvil-theme", "list"]
   env:
     ZANVIL_DIR: "$HOME/zanvil"
-fake:
-  rules:
-    # « theme list » et non « theme » : args_contain est une sous-chaine des arguments
-    # joints par des espaces, donc « theme » matcherait aussi « themes ». Ecrit ainsi,
-    # la regle a d abord laisse passer le renommage qu elle etait censee attraper — le
-    # cas ne prouvait rien tant que la mutation ne l avait pas fait rougir.
-    #
-    # Avec l argument suivant, « themes list » ne contient plus « theme list » : le
-    # mauvais nom tombe dans le catch-all, qui compte un appel non prevu. C est ce
-    # mecanisme, et non une assertion sur la sortie, qui attrape le renommage.
-    - match: { bin: zanvil, args_contain: "theme list" }
-      stdout: "Available themes:"
-    - match: {}
-      exit: 127
-      stderr: "the case did not foresee this call"
 expect:
+  # Le coeur du cas : la fonction rend 0. Une delegation vers un nom que le binaire ne
+  # connait pas propage le code de clap, et c est ce qui attrape le renommage.
   exit_code: 0
-  # Un seul appel : la fonction delegue et s arrete la. Si elle repliait en zsh apres
-  # avoir appele le binaire, le compte resterait a 1 mais la sortie changerait — d ou
-  # l assertion sur les deux.
-  calls:
-    zanvil: 1
   stdout:
-    contains: ["Available themes:"]
+    ignore_ansi: true
+    # Les trois themes versionnes sous config/themes/, donc presents dans la copie
+    # isolee, et nommes par les deux implementations.
+    contains: ["forge", "tokyo-night-pro", "default"]
+  stderr:
+    absent:
+      - "unrecognized subcommand"
+      - "command not found"

--- a/tests/cases/sync/sync-diff-counts-the-theme-as-a-difference.yaml
+++ b/tests/cases/sync/sync-diff-counts-the-theme-as-a-difference.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Le diff du CLI ne compare pas le theme : il annonce « 2 difference(s) » la ou le zsh
+# en voit trois. Un utilisateur qui lit 2, importe, et decouvre son prompt change a un
+# reglage de plus que ce que la commande lui avait montre.
+#
+# Le compte est asserte explicitement, pas seulement les lignes : c est un nombre dans
+# la sortie, et writing-cases.md rappelle qu un defaut se cache volontiers dans un
+# nombre qu aucun cas ne regarde.
+name: sync-diff-counts-the-theme-as-a-difference
+weight: 7
+setup:
+  exec: ./tests/hooks/prepare-sync-fixture.sh
+  shell: zsh
+  source: ["core/ui.zsh", "core/lifecycle/sync.zsh"]
+  call: ["zanvil-sync", "diff", "ref.json"]
+  env:
+    ZANVIL_DIR: "$HOME/zanvil"
+expect:
+  exit_code: 0
+  stdout:
+    ignore_ansi: true
+    contains:
+      - "Zanvil Sync Diff"
+      - "Setting"
+      - "Local"
+      - "Import"
+      - "ZANVIL_MODULE_KUBE"
+      - "ZANVIL_MODULE_DOCKER"
+      # Le theme, sur sa ligne, avec ses deux valeurs.
+      - "theme"
+      - "minimal"
+      - "tokyo-night-pro"
+      # Trois et non deux : les deux modules PLUS le theme.
+      - "3 difference(s)"
+    absent:
+      - "2 difference(s)"
+      - "Configurations identiques"

--- a/tests/cases/sync/sync-export-announces-what-it-wrote.yaml
+++ b/tests/cases/sync/sync-export-announces-what-it-wrote.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# La sortie de l export fait partie du contrat, pas seulement le fichier. CLAUDE.md
+# l exige : « Les commandes zanvil-* doivent avoir un header avec _ui_header ». Le CLI
+# n imprime aujourd hui qu une ligne, donc ce cas dit ce que la migration doit rendre.
+name: sync-export-announces-what-it-wrote
+weight: 5
+setup:
+  exec: ./tests/hooks/prepare-sync-fixture.sh
+  shell: zsh
+  source: ["core/ui.zsh", "core/lifecycle/sync.zsh"]
+  call: ["zanvil-sync", "export"]
+  env:
+    ZANVIL_DIR: "$HOME/zanvil"
+expect:
+  exit_code: 0
+  stdout:
+    # ignore_ansi : le header et les sections sont colores, et la couleur depend du
+    # theme charge. Ce cas parle du texte, pas de la palette.
+    ignore_ansi: true
+    contains:
+      - "Zanvil Sync Export"
+      - "Config exportee"
+      - "sync.json"
+      - "Version"
+      - "Theme"
+      - "minimal"
+      - "Modules"

--- a/tests/cases/sync/sync-export-carries-every-setting.yaml
+++ b/tests/cases/sync/sync-export-carries-every-setting.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Caracterisation du zsh avant migration (chantier 2 du spec zsh-ou-rust). Ce cas est
+# le contrat : il doit passer INCHANGE une fois que `zanvil-sync export` deleguera au
+# CLI. Mesure faite avant d ecrire une ligne de Rust — l implementation actuelle du CLI
+# exporte `"plugins": []` en dur, donc elle ne satisfait pas ce cas, et c est son role
+# de le dire.
+#
+# `exported_at` n est pas asserte : sa valeur change a chaque run. C est la meme raison
+# qui fait que gaveldrop n a pas de cle pour les durees.
+name: sync-export-carries-every-setting
+weight: 7
+setup:
+  exec: ./tests/hooks/prepare-sync-fixture.sh
+  shell: zsh
+  source: ["core/ui.zsh", "core/lifecycle/sync.zsh"]
+  call: ["zanvil-sync", "export"]
+  env:
+    ZANVIL_DIR: "$HOME/zanvil"
+expect:
+  exit_code: 0
+  files:
+    "zanvil/sync.json":
+      contains:
+        - '"version": "v'
+        # Les deux valeurs booleennes : sans un module a false, l export pourrait
+        # ecrire `true` en dur sans qu on le voie.
+        - '"KUBE"'
+        - '"DOCKER"'
+        - '"theme": "minimal"'
+        - '"theme_light": "minimal"'
+        - '"theme_dark": "tokyo-night-pro"'
+        # Le coeur du cas : les plugins. C est le seul reglage que le CLI perd
+        # aujourd hui a l export, et rien ne le signalait.
+        - '"zsh-autosuggestions"'
+        - '"zsh-syntax-highlighting"'
+        - '"frequency": 14'
+        - '"mode": "silent"'
+      # Un export ne doit pas substituer ses defauts a ce que la config porte : `7` et
+      # `prompt` sont les valeurs de repli du code, et les voir ici signifierait que la
+      # lecture de config.zsh a echoue en silence.
+      absent:
+        - '"frequency": 7'
+        - '"mode": "prompt"'

--- a/tests/cases/sync/sync-export-defaults-the-theme-when-absent.yaml
+++ b/tests/cases/sync/sync-export-defaults-the-theme-when-absent.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Un poste qui n a jamais choisi de theme n a pas de .current_theme. L export doit
+# ecrire « default » plutot qu une chaine vide, sinon l import d en face poserait un
+# theme sans nom. Les deux implementations le font aujourd hui ; le cas fige l accord.
+name: sync-export-defaults-the-theme-when-absent
+weight: 3
+setup:
+  exec: ./tests/hooks/prepare-sync-fixture.sh
+  shell: zsh
+  source: ["core/ui.zsh", "core/lifecycle/sync.zsh"]
+  # eval parce qu il faut retirer le fichier avant d appeler la fonction, et qu un
+  # `call:` ne prend qu une commande.
+  call: ["eval", "rm -f \"$ZANVIL_DIR/.current_theme\"; zanvil-sync export"]
+  env:
+    ZANVIL_DIR: "$HOME/zanvil"
+expect:
+  exit_code: 0
+  files:
+    "zanvil/sync.json":
+      contains: ['"theme": "default"']
+      absent: ['"theme": ""']

--- a/tests/cases/sync/sync-import-applies-every-setting.yaml
+++ b/tests/cases/sync/sync-import-applies-every-setting.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Le cas qui compte le plus du chantier 2. Le CLI ignore aujourd hui CINQ des sept
+# reglages a l import — les trois d auto-update et les deux themes clair/sombre — et
+# imprime « Config importee » quand meme. Un utilisateur qui synchronise deux machines
+# croirait sa config alignee.
+#
+# La fixture porte l inverse de ce que le fichier importe demande, sur chaque ligne :
+# sans cela, une ligne inchangee passerait pour une ligne importee.
+name: sync-import-applies-every-setting
+weight: 9
+setup:
+  exec: ./tests/hooks/prepare-sync-fixture.sh
+  shell: zsh
+  source: ["core/ui.zsh", "core/lifecycle/sync.zsh"]
+  call: ["zanvil-sync", "import", "ref.json"]
+  env:
+    ZANVIL_DIR: "$HOME/zanvil"
+expect:
+  exit_code: 0
+  files:
+    "zanvil/config.zsh":
+      contains:
+        - "ZANVIL_MODULE_KUBE=false"
+        - "ZANVIL_MODULE_DOCKER=true"
+        - "ZANVIL_AUTO_UPDATE=true"
+        - "ZANVIL_UPDATE_FREQUENCY=3"
+        - 'ZANVIL_UPDATE_MODE="auto"'
+        - "ZANVIL_THEME_LIGHT=forge"
+        - "ZANVIL_THEME_DARK=forge"
+      # Les valeurs de la fixture ne doivent plus etre la. Sans ces lignes, un import
+      # qui n aurait rien fait passerait pour un import reussi.
+      absent:
+        - "ZANVIL_MODULE_KUBE=true"
+        - "ZANVIL_AUTO_UPDATE=false"
+        - "ZANVIL_UPDATE_FREQUENCY=14"
+        - 'ZANVIL_UPDATE_MODE="silent"'
+        - "ZANVIL_THEME_DARK=tokyo-night-pro"
+    "zanvil/.current_theme":
+      equals: "tokyo-night-pro"
+    # Le filet de securite : un import ecrase config.zsh, donc il en garde une copie.
+    "zanvil/config.zsh.pre-import":
+      contains: ["ZANVIL_MODULE_KUBE=true"]

--- a/tests/cases/sync/sync-import-refuses-a-missing-file.yaml
+++ b/tests/cases/sync/sync-import-refuses-a-missing-file.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Un import sans fichier lisible doit refuser avant de toucher a quoi que ce soit.
+#
+# Ce cas devrait aussi asserter qu AUCUNE sauvegarde n a ete creee — un refus qui
+# laisserait un config.zsh.pre-import derriere lui aurait deja commence a travailler.
+# Le format ne le permet pas : les quatre champs de `expect.files` portent tous sur un
+# contenu (`contains`, `absent`, `equals`, `ignore_ansi`), et aucun ne dit « ce fichier
+# ne doit pas exister ». Demande n 10 dans le document d evolution.
+name: sync-import-refuses-a-missing-file
+weight: 5
+setup:
+  exec: ./tests/hooks/prepare-sync-fixture.sh
+  shell: zsh
+  source: ["core/ui.zsh", "core/lifecycle/sync.zsh"]
+  call: ["zanvil-sync", "import", "ce-fichier-nexiste-pas.json"]
+  env:
+    ZANVIL_DIR: "$HOME/zanvil"
+expect:
+  exit_code: 1
+  stdout:
+    ignore_ansi: true
+    contains: ["Usage: zanvil-sync import"]

--- a/tests/cases/sync/sync-import-then-diff-reports-no-difference.yaml
+++ b/tests/cases/sync/sync-import-then-diff-reports-no-difference.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Le seul cas de la suite a deux echanges, et il est la pour une raison : c est la
+# boucle complete que personne ne verifiait. Un import qui ecrit et un diff qui relit
+# doivent s accorder, sinon la commande ment a l une des deux extremites — et aucune
+# assertion sur un fichier ne peut le prouver, parce que c est le DIFF qui doit lire ce
+# que l IMPORT a ecrit.
+#
+# L etat de la racine isolee persiste entre les echanges : c est ce qui rend ce cas
+# possible, et c est la nouveaute de la 0.1.11 que zanvil attendait.
+name: sync-import-then-diff-reports-no-difference
+weight: 9
+setup:
+  exec: ./tests/hooks/prepare-sync-fixture.sh
+  shell: zsh
+  source: ["core/ui.zsh", "core/lifecycle/sync.zsh"]
+  # Aucun `call:` ici : chaque echange porte le sien. La contrepartie a importer est
+  # deposee par le hook, parce qu un cas a steps n execute pas le run de son setup.
+  env:
+    ZANVIL_DIR: "$HOME/zanvil"
+steps:
+  - name: "le diff annonce des differences avant l import"
+    request:
+      call: ["zanvil-sync", "diff", "ref.json"]
+    expect:
+      exit_code: 0
+      stdout:
+        ignore_ansi: true
+        contains: ["difference(s)"]
+        absent: ["Configurations identiques"]
+  - name: "l import les applique"
+    request:
+      call: ["zanvil-sync", "import", "ref.json"]
+    expect:
+      exit_code: 0
+      stdout:
+        ignore_ansi: true
+        contains: ["Config importee"]
+  - name: "le diff ne trouve plus rien a signaler"
+    request:
+      call: ["zanvil-sync", "diff", "ref.json"]
+    expect:
+      exit_code: 0
+      stdout:
+        ignore_ansi: true
+        contains: ["Configurations identiques"]
+expect: {}

--- a/tests/cases/sync/sync-refuses-an-unknown-action.yaml
+++ b/tests/cases/sync/sync-refuses-an-unknown-action.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Une action inconnue doit sortir en erreur ET montrer l aide. Sortir en 0 ferait
+# passer une faute de frappe pour un succes dans un script.
+name: sync-refuses-an-unknown-action
+weight: 5
+setup:
+  exec: ./tests/hooks/prepare-sync-fixture.sh
+  shell: zsh
+  source: ["core/ui.zsh", "core/lifecycle/sync.zsh"]
+  call: ["zanvil-sync", "exprot"]
+  env:
+    ZANVIL_DIR: "$HOME/zanvil"
+expect:
+  exit_code: 1
+  stdout:
+    ignore_ansi: true
+    contains:
+      - "Action inconnue: exprot"
+      # L aide suit le refus : les trois actions sont nommees.
+      - "export"
+      - "import"
+      - "diff"

--- a/tests/hooks/prepare-sync-fixture.sh
+++ b/tests/hooks/prepare-sync-fixture.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# Construit un ZANVIL_DIR dont la config porte TOUT ce que sync sait exporter.
+#
+# `prepare-zanvil-dir.sh` ne convient pas ici : son config.zsh est volontairement
+# minimal — sept modules, aucun plugin, ni auto-update ni thèmes clair/sombre. Un cas
+# qui caractérise l export contre lui ne pourrait rien dire de ces trois familles de
+# réglages, qui sont précisément celles où le zsh et le Rust divergent.
+#
+# Ce hook ne modifie pas l autre : il copie la même arborescence, puis écrit un
+# config.zsh complet. Les cas existants gardent leur fixture inchangée.
+set -eu
+
+# Drain de la charge setup, envoyée en JSON sur stdin.
+cat >/dev/null
+
+SRC="$GAVELDROP_PROJECT"
+DST="$HOME/zanvil"
+
+mkdir -p "$DST"
+for d in core modules config; do
+    cp -R "$SRC/$d" "$DST/"
+done
+
+# Deux modules seulement, dont un inactif : assez pour que l export porte les deux
+# valeurs booléennes, assez peu pour que le JSON attendu tienne dans une assertion.
+# Les plugins sont deux noms inertes — rien ne les clone, la config est seulement lue.
+{
+    printf 'ZANVIL_PLUGINS=(zsh-autosuggestions zsh-syntax-highlighting)\n'
+    printf 'ZANVIL_MODULE_KUBE=true\n'
+    printf 'ZANVIL_MODULE_DOCKER=false\n'
+    printf 'ZANVIL_AUTO_UPDATE=false\n'
+    printf 'ZANVIL_UPDATE_FREQUENCY=14\n'
+    printf 'ZANVIL_UPDATE_MODE="silent"\n'
+    printf 'ZANVIL_THEME_LIGHT=minimal\n'
+    printf 'ZANVIL_THEME_DARK=tokyo-night-pro\n'
+} >"$DST/config.zsh"
+
+printf 'minimal\n' >"$DST/.current_theme"
+
+# La contrepartie a importer, ecrite ici et non dans un cas, pour deux raisons : les
+# arguments de `call:` sont inertes — gaveldrop les passe entre quotes simples, donc
+# `$HOME/ref.json` resterait litteral — et un cas qui declare des `steps:` n execute
+# PAS le `run` de son setup, qui ne sert que de repli. Le fichier doit donc exister
+# avant le premier echange. Il est ecrit dans la racine isolee, qui est aussi le
+# repertoire courant du sujet : les cas y renvoient par « ref.json » tout court.
+#
+# Chaque valeur est l inverse de celle de la fixture ci-dessus. Sans cela, une ligne
+# laissee intacte passerait pour une ligne importee.
+cat >ref.json <<'JSON'
+{
+  "version": "v4.4.0",
+  "exported_at": "2026-01-01T00:00:00Z",
+  "modules": { "KUBE": false, "DOCKER": true },
+  "theme": "tokyo-night-pro",
+  "theme_light": "forge",
+  "theme_dark": "forge",
+  "plugins": [],
+  "auto_update": { "enabled": true, "frequency": 3, "mode": "auto" }
+}
+JSON

--- a/web/docs/superpowers/2026-08-05-demandes-evolution-gaveldrop-echanges.md
+++ b/web/docs/superpowers/2026-08-05-demandes-evolution-gaveldrop-echanges.md
@@ -3,6 +3,32 @@
 **Pour un agent travaillant dans `~/work/misc/gaveldrop`.** Rien n'a été modifié là-bas ; tout ce qui
 suit est décrit, jamais corrigé sur place.
 
+> **Répondu par la `v0.1.14` — sept demandes sur neuf livrées.** Vérifié contre l'archive publiée, par
+> comportement. Réponse détaillée dans `~/work/misc/gaveldrop/docs/superpowers/maj-zanvil-0-1-14.md`.
+>
+> | # | État | Constaté ici |
+> |---|---|---|
+> | 1. `shell.md` muet sur les échanges | livré | Les deux formes documentées, avec `weight`, `expect: {}` et la persistance de la racine isolée. |
+> | 2. `timeout:` par échange | livré | **8,3 s → 2,0 s.** « the case exits within 2.0s, exchanges included », l'échange tué est nommé, les non tentés le disent chacun sous son chemin. |
+> | 3. `calls` cumulatifs par échange | livré | La sonde qui donnait `2` au second échange donne `1`. Le global additionne toujours. |
+> | 4. Chemin d'un `calls` violé | livré | `steps[1] "le deuxieme se trompe".calls.outil`. |
+> | 5. « The body was empty » | livré | « there is no response document to walk … a process and a shell function answer text on standard output ». |
+> | 6. `time` sur les nœuds JUnit | **refusé** | Sur la condition que j'avais posée : la durée n'est pas mesurée par échange, donc la condition s'applique. Et le motif qui la justifiait est parti avec la nº 2. |
+> | 7. Règle d'agrégation non documentée | livré | Table dans `shell.md` et dans le schéma, sur `exit_code` et sur `steps`. |
+> | 8. `args_include` | livré | Vérifié en sonde : `theme` servi, `themes` refusé. La même sonde en `args_contain` laisse passer les deux — c'était bien le trou. |
+> | 9. Association sur une ligne | livré, **corrigé** | `line_includes`, adopté dans `cli-modules-list-reflects-config-zsh`. |
+>
+> **Sur la nº 9, ma proposition était fausse et ils l'ont corrigée.** Je demandais des fragments cherchés
+> comme sous-chaînes ; écrite ainsi, l'assertion **passe** sur la table inversée, puisque « inactif »
+> contient « actif ». Les valeurs sont donc comparées comme des **mots** — d'où `include` plutôt que
+> `contain`, la même distinction que pour `args_include`. Mes deux trous d'injection étaient le même trou.
+>
+> **Les demandes 10 et 11 sont postérieures à ce document** et restent ouvertes. La nº 11 empêche
+> d'adopter `args_include` dans `theme-delegates-to-the-cli-with-the-right-subcommand` : `fake.bins` étant
+> global, falsifier notre binaire pour ce cas rendrait les huit cas de `tests/cases/sync/` incapables
+> d'atteindre le vrai. `exec: real` ne dénoue pas le nœud — sur un runner il n'y a pas de vrai binaire
+> plus loin dans le `PATH`, donc les cas emprunteraient une délégation vers rien au lieu du repli zsh.
+
 ## Ce qui a produit ces demandes
 
 zanvil est passé de la 0.1.5 à la 0.1.12 d'un coup, sans document de mise à jour dans le canal. **Les 59

--- a/web/docs/superpowers/2026-08-05-demandes-evolution-gaveldrop-echanges.md
+++ b/web/docs/superpowers/2026-08-05-demandes-evolution-gaveldrop-echanges.md
@@ -332,6 +332,77 @@ exactement ce que cette commande doit savoir faire.
 
 ---
 
+# Deux demandes nées de la migration de `sync`
+
+Le chantier 2 du spec zsh/Rust a été mené jusqu'au bout avec gaveldrop comme filet : huit cas
+caractérisent la fonction zsh, le Rust a été complété jusqu'à les satisfaire, puis la délégation a été
+branchée. **Les huit passent inchangés dans les deux configurations** — le Rust quand le binaire est
+installé, le repli zsh quand il ne l'est pas. C'est exactement la non-régression que le format promet, et
+elle a tenu.
+
+Deux choses ont manqué en route.
+
+## 10. Rien ne permet d'asserter qu'un fichier n'a **pas** été écrit
+
+Un import qui refuse un fichier illisible ne doit rien laisser derrière lui — en particulier pas la
+sauvegarde `config.zsh.pre-import`, dont la présence signifierait qu'il avait déjà commencé à travailler.
+
+Le cas ne peut pas le dire. Les quatre champs de `expect.files` portent tous sur un contenu :
+
+```console
+case ...sync-import-refuses-a-missing-file.yaml is invalid:
+  expect.files.zanvil/config.zsh.pre-import: unknown field `absent_file`,
+  expected one of `contains`, `absent`, `equals`, `ignore_ansi`
+```
+
+Le message est bon — il liste les champs valides — mais il n'y en a aucun pour l'absence. Écrire
+`contains: []` ne dit rien, et `equals: ""` teste un fichier vide, ce qui est un autre fait.
+
+**Demandé :** un moyen de déclarer qu'un chemin ne doit pas exister à la fin du cas. L'information est
+déjà côté moteur, puisque `unmentioned files` sait lister ce qui a été écrit sans être asserté ; il
+manque de pouvoir la retourner en exigence.
+
+**Écarté :** un `expect.files` où la clé seule, sans valeur, vaudrait « absent ». Une clé qui change de
+sens selon qu'elle a un corps ou non se lit mal en revue, et le format tire sa valeur de l'inverse.
+
+## 11. `fake.bins` est global, donc falsifier son propre binaire interdit de l'utiliser ailleurs
+
+Le pattern de délégation est central dans zanvil : douze sous-commandes, invoquées depuis le zsh, dont
+`zanvil project` 47 fois. Une fonction fait `command -v zanvil` puis appelle le binaire **par son nom**.
+
+Pour vérifier *avec quels arguments* elle l'appelle, il faut un faux — donc `fake.bins: [zanvil]`. Mais
+`bins` est global à `gaveldrop.yaml`, et le faux prend la tête du `PATH` : les huit cas de
+`tests/cases/sync/` se sont alors mis à parler à un faux muet et à échouer en bloc, alors qu'ils ont
+besoin du vrai pour prouver que la délégation rend le même résultat que le repli.
+
+Les trois portes de sortie sont fermées, et chacune pour une bonne raison :
+
+- **`setup.env` refuse `PATH`** — « isolation defines it, and a case that could point it elsewhere would
+  undo the isolation it is running in ». Le refus est juste, et le message le dit bien.
+- **`setup.hide`** retire des répertoires entiers et ne pose pas de symlink pour l'outil hidé : il donne
+  « aucun zanvil », pas « le vrai zanvil ».
+- **`fake` par cas** n'accepte que `rules` et `render`, pas `bins`.
+
+Le résultat est qu'on doit choisir, pour toute la suite, entre observer les appels à son propre binaire
+et s'en servir. J'ai choisi de m'en servir, et le cas de délégation a perdu son assertion la plus forte —
+le nom exact de la sous-commande, vérifiable partout. Il ne détecte plus un renommage que là où le
+binaire est installé.
+
+**Demandé :** de quoi lever le choix. Deux formes possibles, par ordre de préférence :
+
+1. **`bins` déclarable par cas**, en complément du global — la symétrie de `setup.hide`, qui permet déjà
+   à un cas de se soustraire à une falsification globale. Ici il s'agirait de s'y ajouter.
+2. **Un `setup.expose`** qui ajoute un répertoire du projet devant le `PATH` de l'isolation sans le
+   remplacer. Plus général, mais il entame la propriété que le refus de `env.PATH` protège, donc la
+   première forme me paraît plus sûre.
+
+**Écarté :** qu'un hook dépose lui-même un script `zanvil` journalisant ses arguments dans un répertoire
+du `PATH`. C'est faisable — le `PATH` de l'isolation contient `$HOME/.local/bin` — et c'est
+précisément le contournement qu'il ne faut pas : ce serait réécrire `fake` et son journal à la main, dans
+un hook, sans le verdict `unexpected calls` qui en fait la valeur.
+
+---
+
 ## Ce qui tient, et qu'il ne faut pas retoucher
 
 Éprouvé et solide, consigné pour que personne n'y touche en corrigeant le reste :

--- a/web/docs/superpowers/specs/2026-08-03-zsh-ou-rust-design.md
+++ b/web/docs/superpowers/specs/2026-08-03-zsh-ou-rust-design.md
@@ -117,9 +117,39 @@ Rust et non plus depuis son repli.
 |---|---|---|
 | 1 | **Réparer le binaire** | `zsh-env-cli` au lieu de `zanvil` : trois commandes cassées ou dégradées, 5 359 lignes de Rust inertes. La migration doit renommer, et un cas doit l'attraper. |
 | 2 | **`sync`** | Doublon pur : 274 lignes de zsh et 288 de Rust pour le même export/import/diff, avec **zéro** délégation entre les deux. |
+| | ↳ **fait le 5 août 2026**, et « doublon » était faux — voir ci-dessous. |
 | 3 | **`work/elasticsearch`** | 38 dépendances fragiles, le détecteur `date`, la duplication annotée avec `fetch_es_logs.sh`. |
 | 4 | **`core/commands/commands.zsh`** | 24 appels `jq`/`awk`/`sed` dans `zanvil-list`, `-status`, `-help`, `-doctor-conflicts`. `zanvil-doctor` est hors périmètre : il délègue déjà. |
 | 5 | **`gitlab_logic`** | 20 fragiles, mais 7 effets shell : migration **partielle**, la façade et les `export` restent en zsh. |
+
+### Chantier 2 — ce que la caractérisation a corrigé dans ce spec
+
+Le tableau ci-dessus annonce un « doublon pur ». **C'était faux, et c'est la caractérisation qui l'a
+montré** — avant qu'une ligne de Rust ne soit écrite. Les deux implémentations ne faisaient pas la même
+chose, et le CLI était incomplet en silence :
+
+| Sous-commande | Ce que le CLI perdait |
+|---|---|
+| `export` | les plugins — `plugins: vec![]` en dur, donc un poste qui en déclarait les perdait à la synchronisation |
+| `import` | **cinq réglages sur sept** : les trois d'auto-update et les deux thèmes clair/sombre, avec « Config importee » quand même |
+| `diff` | le thème n'était pas comparé, donc deux différences annoncées là où il y en avait trois |
+| les trois | aucun header, ce que la convention UI du projet exige |
+
+Brancher la délégation sur cet état aurait donc **régressé**, silencieusement, sur la commande dont le
+métier est justement de ne rien perdre entre deux machines. C'est l'argument le plus concret pour l'ordre
+des quatre étapes : ce n'est pas une précaution de principe, c'est ce qui a évité de casser `sync` en
+croyant l'améliorer.
+
+**Le critère « aucune dépendance à `jq` ni à `date` » demande une nuance.** `sync.zsh` en compte toujours
+15 et 2 : ils sont dans le **repli**, que CLAUDE.md exige de garder complet. Sur un poste équipé, plus
+aucun appel n'a lieu — la délégation intervient avant. Le critère se lit donc « plus aucune dépendance
+fragile sur le chemin emprunté », et le repli reste ce qu'il est : un mode dégradé, seul recours quand le
+binaire manque.
+
+**Un défaut trouvé en chemin, hors périmètre mais corrigé.** `cmd::print_header` dessinait une bordure de
+40 caractères pour une ligne de 44 : le cadre était ouvert à droite dans les **sept** commandes qui
+l'appellent. Le zsh compte les quatre espaces intérieurs, le Rust les oubliait. Sans cette correction, la
+délégation aurait dégradé l'affichage — les deux dessinent maintenant la même boîte, au caractère près.
 
 ## La méthode : caractériser avant de migrer
 


### PR DESCRIPTION
Chantier 2 du spec `zsh-ou-rust`, mené selon sa méthode : caractériser, vérifier par mutation, migrer, exiger que les mêmes cas passent.

## Le spec se trompait, et la caractérisation l'a montré

Le spec annonçait un « doublon pur : 274 lignes de zsh et 288 de Rust pour le même export/import/diff ». La mesure, faite **avant** d'écrire une ligne de Rust, a montré autre chose : le CLI était incomplet, et silencieusement.

| Sous-commande | Ce que le CLI perdait |
|---|---|
| `export` | les plugins — `plugins: vec![]` en dur |
| `import` | **cinq réglages sur sept** : auto-update ×3, thèmes clair/sombre ×2, avec « Config importee » quand même |
| `diff` | le thème n'était pas comparé — deux différences annoncées là où il y en avait trois |
| les trois | aucun header, ce que la convention UI exige |

Brancher la délégation sur cet état aurait régressé, en silence, sur la commande dont le métier est de ne rien perdre entre deux machines. C'est l'argument le plus concret pour l'ordre des quatre étapes : pas une précaution de principe, mais ce qui a évité de casser `sync` en croyant l'améliorer.

## La vérification qui compte

**Les huit cas passent inchangés dans les deux configurations** — le Rust quand le binaire est installé, le repli zsh quand il est écarté du PATH. 68 cas, 280/280, deux fois. C'est la non-régression démontrée plutôt qu'espérée, et c'est exactement ce que le spec attendait de cette suite.

Trois mutations du Rust migré font rougir un cas chacune. Huit mutations du zsh, à l'étape de caractérisation, en faisaient rougir un ou deux — jamais zéro, jamais tous.

## Un cas à trois échanges

`sync-import-then-diff-reports-no-difference` est le premier de la suite à utiliser les `steps:` de gaveldrop 0.1.11 : diff, puis import, puis diff à nouveau. C'est la boucle que rien ne vérifiait, et aucune assertion sur un fichier ne peut la prouver — c'est le diff qui doit relire ce que l'import a écrit.

## Hors périmètre mais corrigé

`cmd::print_header` dessinait une bordure de 40 caractères pour une ligne de 44 : le cadre était ouvert à droite dans les **sept** commandes qui l'appellent. Le zsh compte les quatre espaces intérieurs, le Rust les oubliait. Sans cette correction, la délégation aurait dégradé l'affichage.

## Deux demandes pour gaveldrop

Ajoutées au document d'évolution : rien ne permet d'asserter qu'un fichier n'a **pas** été écrit (un refus ne doit rien laisser derrière lui), et `fake.bins` étant global, falsifier son propre binaire pour observer une délégation interdit de l'utiliser dans les autres cas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)