### PR TITLE
feat(es): porter le calcul temporel du module Elasticsearch — chantier 3, lot A

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -149,6 +149,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +617,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,6 +839,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "smallvec"
@@ -1192,6 +1226,7 @@ name = "zanvil"
 version = "4.4.0"
 dependencies = [
  "chrono",
+ "chrono-tz",
  "clap",
  "clap_complete",
  "colored",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,6 +14,8 @@ colored = "2"
 regex = "1"
 ignore = "0.4"
 chrono = "0.4"
+# Europe/Paris avec son heure d ete : chrono seul ne connait qu UTC et le fuseau local.
+chrono-tz = "0.10"
 ratatui = "0.29"
 crossterm = "0.28"
 

--- a/cli/src/cmd/es.rs
+++ b/cli/src/cmd/es.rs
@@ -1,0 +1,285 @@
+//! Calcul de la fenêtre temporelle des requêtes Elasticsearch.
+//!
+//! Portage du lot A du chantier 3. Les six fonctions zsh remplacées portaient 14 des 38
+//! dépendances fragiles du module, dont un détecteur de variante écrit à la main parce
+//! que `date -d` et `date -j -f` ne coexistent pas :
+//!
+//! ```text
+//! if date --version &>/dev/null; then _WORK_ES_DATE_FLAVOR=gnu; else …=bsd; fi
+//! ```
+//!
+//! Ce que ce détecteur contournait disparaît ici : `chrono` et `chrono-tz` ne dépendent
+//! d'aucun binaire externe, donc il n'y a plus deux chemins à maintenir ni de variante à
+//! deviner.
+//!
+//! **La sortie est lue, pas évaluée.** Trois lignes `clé=valeur` sur la sortie standard,
+//! que le zsh relit avec `read`. Un format évaluable — `_work_es_gte='…'` passé à `eval`,
+//! comme le font `starship init` ou `mise activate` — serait plus court d'une ligne et
+//! exécuterait ce que l'utilisateur a écrit dans `--from`, puisque le libellé le reprend
+//! tel quel.
+
+use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
+use chrono_tz::Europe::Paris;
+use clap::Subcommand;
+
+#[derive(Subcommand)]
+pub enum EsAction {
+    /// Compute the time window of a query from --since, or --from/--to
+    Window {
+        /// Relative duration back from now: 30s, 5m, 2h, 3d
+        #[arg(long)]
+        since: Option<String>,
+        /// Start of the window, in Europe/Paris local time: 2026-03-26T15:30:00
+        #[arg(long)]
+        from: Option<String>,
+        /// End of the window, same format. Defaults to now.
+        #[arg(long)]
+        to: Option<String>,
+    },
+    /// Convert between the two timestamp shapes the module handles.
+    ///
+    /// Caché : ce sont les primitives que les fonctions zsh appellent, pas des commandes
+    /// qu'on tape. Les exposer donnerait à l'aide de `zanvil es` trois entrées qui ne
+    /// répondent à aucune question qu'un utilisateur se pose.
+    #[command(hide = true)]
+    Convert {
+        /// Epoch seconds to render as ISO 8601 UTC
+        #[arg(long, conflicts_with_all = ["from_iso", "from_paris"])]
+        from_epoch: Option<i64>,
+        /// ISO 8601 UTC timestamp to read as epoch seconds
+        #[arg(long, conflicts_with_all = ["from_epoch", "from_paris"])]
+        from_iso: Option<String>,
+        /// Europe/Paris local time to read as epoch seconds
+        #[arg(long, conflicts_with_all = ["from_epoch", "from_iso"])]
+        from_paris: Option<String>,
+    },
+}
+
+pub fn run(action: EsAction) -> i32 {
+    match action {
+        EsAction::Window { since, from, to } => window(since, from, to),
+        EsAction::Convert {
+            from_epoch,
+            from_iso,
+            from_paris,
+        } => convert(from_epoch, from_iso, from_paris),
+    }
+}
+
+/// Une conversion par invocation, imprimée nue pour qu'un `$(…)` la capture.
+///
+/// Rend 1 sans rien écrire quand l'entrée est illisible : les fonctions zsh appelantes
+/// testaient déjà `[[ "$epoch" == <-> ]]`, donc un message ici s'ajouterait à leur
+/// diagnostic au lieu de le remplacer.
+fn convert(from_epoch: Option<i64>, from_iso: Option<String>, from_paris: Option<String>) -> i32 {
+    if let Some(epoch) = from_epoch {
+        println!("{}", epoch_to_iso(epoch));
+        return 0;
+    }
+    if let Some(iso) = from_iso {
+        return match iso_to_epoch(&iso) {
+            Some(epoch) => {
+                println!("{epoch}");
+                0
+            }
+            None => 1,
+        };
+    }
+    if let Some(local) = from_paris {
+        return match paris_to_epoch(&local) {
+            Some(epoch) => {
+                println!("{epoch}");
+                0
+            }
+            None => 1,
+        };
+    }
+    eprintln!("rien a convertir: donnez --from-epoch, --from-iso ou --from-paris");
+    1
+}
+
+/// ISO 8601 UTC en epoch, avec ou sans millisecondes.
+///
+/// Les deux formes arrivent réellement : les requêtes du module portent des `.000Z`, les
+/// réponses d'Elasticsearch pas toujours. Les millisecondes sont lues puis jetées, comme
+/// le zsh le faisait en coupant la chaîne — la précision du module est la seconde.
+fn iso_to_epoch(ts: &str) -> Option<i64> {
+    let trimmed = ts.trim_end_matches('Z');
+    let without_fraction = trimmed.split_once('.').map_or(trimmed, |(head, _)| head);
+    NaiveDateTime::parse_from_str(without_fraction, "%Y-%m-%dT%H:%M:%S")
+        .ok()
+        .map(|naive| Utc.from_utc_datetime(&naive).timestamp())
+}
+
+/// `Xs`/`Xm`/`Xh`/`Xd` en secondes.
+///
+/// Refuse tout le reste, y compris un nombre nu et `1w`. Une durée sans unité serait
+/// interprétée au hasard, et accepter `1w` comme une seconde serait pire qu'un refus.
+fn parse_duration(spec: &str) -> Option<i64> {
+    let (digits, unit) = spec.split_at(spec.len().checked_sub(1)?);
+    if digits.is_empty() || !digits.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let n: i64 = digits.parse().ok()?;
+    match unit {
+        "s" => Some(n),
+        "m" => Some(n * 60),
+        "h" => Some(n * 3600),
+        "d" => Some(n * 86_400),
+        _ => None,
+    }
+}
+
+/// Le format qu'Elasticsearch attend dans une requête de plage : ISO 8601 UTC, avec des
+/// millisecondes toujours à zéro.
+fn epoch_to_iso(epoch: i64) -> String {
+    DateTime::<Utc>::from_timestamp(epoch, 0)
+        .unwrap_or_else(|| DateTime::<Utc>::from_timestamp(0, 0).expect("epoch zero is valid"))
+        .format("%Y-%m-%dT%H:%M:%S.000Z")
+        .to_string()
+}
+
+/// Une heure locale d'Europe/Paris en epoch UTC, heure d'été comprise.
+///
+/// C'est ce que le zsh obtenait de `TZ=Europe/Paris date`, et le seul endroit du lot où
+/// une erreur ne se verrait pas : à heure locale égale, le 28 et le 30 mars 2026 sont à
+/// une heure d'écart, parce que le basculement tombe entre les deux.
+///
+/// Une heure qui n'existe pas — 02:30 la nuit où l'on avance les pendules — est refusée
+/// plutôt que décalée en silence. Une heure qui existe deux fois prend la première, celle
+/// d'avant le recul.
+fn paris_to_epoch(local: &str) -> Option<i64> {
+    let naive = NaiveDateTime::parse_from_str(local, "%Y-%m-%dT%H:%M:%S").ok()?;
+    Paris
+        .from_local_datetime(&naive)
+        .earliest()
+        .map(|dt| dt.timestamp())
+}
+
+fn window(since: Option<String>, from: Option<String>, to: Option<String>) -> i32 {
+    let now = Utc::now().timestamp();
+
+    let (gte, lte, display) = match since.as_deref().filter(|s| !s.is_empty()) {
+        Some(spec) => match parse_duration(spec) {
+            Some(seconds) => (
+                epoch_to_iso(now - seconds),
+                epoch_to_iso(now),
+                format!("depuis {spec} (-> now)"),
+            ),
+            None => {
+                eprintln!("--since invalide: {spec} (attendu: Xs/Xm/Xh/Xd)");
+                return 1;
+            }
+        },
+        None => {
+            let from = from.unwrap_or_default();
+            let Some(from_epoch) = paris_to_epoch(&from) else {
+                eprintln!("--from invalide: {from} (attendu: 2026-03-26T15:30:00)");
+                return 1;
+            };
+            match to.as_deref().filter(|s| !s.is_empty()) {
+                Some(to_str) => {
+                    let Some(to_epoch) = paris_to_epoch(to_str) else {
+                        eprintln!("--to invalide: {to_str} (attendu: 2026-03-26T15:30:00)");
+                        return 1;
+                    };
+                    (
+                        epoch_to_iso(from_epoch),
+                        epoch_to_iso(to_epoch),
+                        format!("{from} -> {to_str} (Europe/Paris)"),
+                    )
+                }
+                None => (
+                    epoch_to_iso(from_epoch),
+                    epoch_to_iso(now),
+                    format!("{from} -> now (Europe/Paris)"),
+                ),
+            }
+        }
+    };
+
+    println!("gte={gte}");
+    println!("lte={lte}");
+    println!("display={display}");
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn duration_units_are_the_four_the_module_documents() {
+        assert_eq!(parse_duration("30s"), Some(30));
+        assert_eq!(parse_duration("5m"), Some(300));
+        assert_eq!(parse_duration("2h"), Some(7200));
+        assert_eq!(parse_duration("3d"), Some(259_200));
+    }
+
+    #[test]
+    fn anything_else_is_refused_rather_than_guessed() {
+        for spec in ["30x", "abc", "30", "1w", "2H", "", "s", "-1s", "1.5h"] {
+            assert_eq!(parse_duration(spec), None, "{spec} should be refused");
+        }
+    }
+
+    /// Les quatre valeurs viennent de `zoneinfo` en Python, pas de ce code : le cas
+    /// gaveldrop et ce test partagent la même source indépendante.
+    #[test]
+    fn paris_time_crosses_the_dst_boundary() {
+        assert_eq!(paris_to_epoch("2026-01-15T12:00:00"), Some(1_768_474_800));
+        assert_eq!(paris_to_epoch("2026-07-15T12:00:00"), Some(1_784_109_600));
+        // Le basculement 2026 tombe le 29 mars : la veille et le lendemain sont à une
+        // heure d'écart pour la même heure locale.
+        assert_eq!(paris_to_epoch("2026-03-28T12:00:00"), Some(1_774_695_600));
+        assert_eq!(paris_to_epoch("2026-03-30T12:00:00"), Some(1_774_864_800));
+        assert_eq!(
+            paris_to_epoch("2026-03-30T12:00:00").unwrap() - paris_to_epoch("2026-03-28T12:00:00").unwrap(),
+            2 * 86_400 - 3600,
+            "deux jours moins l heure perdue au basculement"
+        );
+    }
+
+    #[test]
+    fn an_hour_that_does_not_exist_is_refused() {
+        // 02:30 le 29 mars 2026 : les pendules passent de 02:00 à 03:00.
+        assert_eq!(paris_to_epoch("2026-03-29T02:30:00"), None);
+    }
+
+    #[test]
+    fn iso_carries_milliseconds_at_zero() {
+        assert_eq!(epoch_to_iso(0), "1970-01-01T00:00:00.000Z");
+        assert_eq!(epoch_to_iso(1_780_000_000), "2026-05-28T20:26:40.000Z");
+    }
+
+    #[test]
+    fn iso_is_read_with_or_without_milliseconds() {
+        assert_eq!(iso_to_epoch("2026-05-28T20:26:40.000Z"), Some(1_780_000_000));
+        assert_eq!(iso_to_epoch("2026-05-28T20:26:40Z"), Some(1_780_000_000));
+        // Sans le Z non plus : une réponse Elasticsearch peut l'omettre.
+        assert_eq!(iso_to_epoch("2026-05-28T20:26:40"), Some(1_780_000_000));
+        // Les millisecondes sont jetées, pas arrondies : la précision du module est la
+        // seconde, et le zsh coupait la chaîne au point.
+        assert_eq!(iso_to_epoch("2026-05-28T20:26:40.999Z"), Some(1_780_000_000));
+    }
+
+    #[test]
+    fn a_malformed_iso_is_refused() {
+        for ts in ["pas-une-date", "2026-05-28", "", "20:26:40"] {
+            assert_eq!(iso_to_epoch(ts), None, "{ts} should be refused");
+        }
+    }
+
+    #[test]
+    fn iso_round_trips_through_epoch() {
+        let start = "2026-05-28T20:26:40.000Z";
+        assert_eq!(epoch_to_iso(iso_to_epoch(start).unwrap()), start);
+    }
+
+    #[test]
+    fn a_malformed_local_time_is_refused() {
+        for spec in ["pas-une-date", "2026-03-26", "2026-03-26T15:30", ""] {
+            assert_eq!(paris_to_epoch(spec), None, "{spec} should be refused");
+        }
+    }
+}

--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -2,6 +2,7 @@ pub mod audit;
 pub mod bench;
 pub mod context;
 pub mod doctor;
+pub mod es;
 pub mod modules;
 pub mod mr_fanout;
 pub mod project;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -69,6 +69,11 @@ enum Commands {
         action: ProjectAction,
     },
     /// Fan-out a change as a MR/PR across multiple env branches
+    /// Elasticsearch query helpers
+    Es {
+        #[command(subcommand)]
+        action: cmd::es::EsAction,
+    },
     #[command(name = "mr-fanout")]
     MrFanout(MrFanoutArgs),
     /// Interactive configuration TUI
@@ -90,6 +95,12 @@ fn main() {
         Commands::Bench { runs } => cmd::bench::run(runs),
         Commands::Update { check } => cmd::update::run(check),
         Commands::Project { action } => cmd::project::run(action),
+        Commands::Es { action } => {
+            let code = cmd::es::run(action);
+            if code != 0 {
+                std::process::exit(code);
+            }
+        }
         Commands::MrFanout(args) => cmd::mr_fanout::run(args),
         Commands::Config => cmd::tui_config::run(),
         Commands::Sync { action } => cmd::sync::run(action),

--- a/modules/work/elasticsearch.zsh
+++ b/modules/work/elasticsearch.zsh
@@ -79,6 +79,12 @@ _work_es_json() {
 # reecrit en zsh ($match). Garder les deux versions synchronisees.
 
 typeset -g _WORK_ES_DATE_FLAVOR=""
+# Detecteur de variante `date`, garde pour le seul repli.
+#
+# Il existait parce que `date -d` et `date -j -f` ne coexistent pas, et le spec
+# zsh-ou-rust le cite comme la dette qui justifie son critere de migration. Les trois
+# fonctions ci-dessous ne l appellent plus quand le CLI est la : chrono ne depend
+# d aucun binaire, donc il n y a plus deux chemins a maintenir ni de variante a deviner.
 _work_es_date_flavor() {
     if [[ -z "$_WORK_ES_DATE_FLAVOR" ]]; then
         if date --version &>/dev/null; then
@@ -108,6 +114,9 @@ _work_es_parse_duration() {
 
 _work_es_epoch_to_iso() {
     local epoch=$1
+    if command -v zanvil &>/dev/null; then
+        zanvil es convert --from-epoch "$epoch"; return $?
+    fi
     if [[ $(_work_es_date_flavor) == gnu ]]; then
         date -u -d "@$epoch" +"%Y-%m-%dT%H:%M:%S.000Z"
     else
@@ -118,6 +127,9 @@ _work_es_epoch_to_iso() {
 # ISO UTC ("2026-05-30T14:00:00.000Z" ou sans ms) -> epoch
 _work_es_iso_to_epoch() {
     local ts=$1
+    if command -v zanvil &>/dev/null; then
+        zanvil es convert --from-iso "$ts"; return $?
+    fi
     if [[ $(_work_es_date_flavor) == gnu ]]; then
         date -u -d "$ts" +%s
     else
@@ -130,6 +142,9 @@ _work_es_iso_to_epoch() {
 # Date Europe/Paris "YYYY-mm-ddTHH:MM:SS" -> epoch UTC (DST gere)
 _work_es_paris_to_epoch() {
     local dt=$1
+    if command -v zanvil &>/dev/null; then
+        zanvil es convert --from-paris "$dt"; return $?
+    fi
     if [[ $(_work_es_date_flavor) == gnu ]]; then
         TZ=Europe/Paris date -d "$dt" +%s
     else
@@ -142,6 +157,48 @@ _work_es_paris_to_epoch() {
 _work_es_window() {
     local since="${1:-}" from="${2:-}" to="${3:-}"
     typeset -g _work_es_gte="" _work_es_lte="" _work_es_display=""
+
+    # Le calcul delegue au CLI, l affectation reste ici : remplir trois globales EST un
+    # effet shell, et un binaire ne modifie pas le shell qui l appelle. C est la ligne
+    # de partage du spec, appliquee au milieu d une fonction plutot qu a son entree.
+    #
+    # La sortie est LUE et non evaluee. Un format evaluable — `_work_es_gte='…'` passe a
+    # `eval`, comme le font `starship init` ou `mise activate` — serait plus court d une
+    # ligne et executerait ce que l utilisateur a ecrit dans --from, puisque le libelle
+    # le reprend tel quel.
+    #
+    # Divergence connue et assumee : sur une heure locale qui n existe pas — 02:30 la
+    # nuit ou les pendules avancent — le CLI refuse, ce repli decale silencieusement
+    # d une heure. Le refus est le bon comportement ; le repli garde le sien parce que
+    # le detecter en zsh demanderait deux appels a `date` de plus, dans le code meme
+    # dont ce lot retire la dependance.
+    if command -v zanvil &>/dev/null; then
+        # Un tableau, et non `${since:+--since "$since"}` : en zsh cette forme rend un
+        # mot unique, donc le CLI recevait « --from 2026-03-30T12:00:00 » comme un seul
+        # argument et clap le refusait.
+        local -a _w_args=(es window)
+        [[ -n "$since" ]] && _w_args+=(--since "$since")
+        [[ -n "$from" ]]  && _w_args+=(--from "$from")
+        [[ -n "$to" ]]    && _w_args+=(--to "$to")
+
+        local _w_out _w_rc
+        _w_out=$(zanvil "${_w_args[@]}" 2>&1)
+        _w_rc=$?
+        if (( _w_rc != 0 )); then
+            _ui_msg_fail "$_w_out"
+            return 1
+        fi
+        local _k _v
+        while IFS='=' read -r _k _v; do
+            case "$_k" in
+                gte)     _work_es_gte="$_v" ;;
+                lte)     _work_es_lte="$_v" ;;
+                display) _work_es_display="$_v" ;;
+            esac
+        done <<< "$_w_out"
+        return 0
+    fi
+
     if [[ -n "$since" ]]; then
         local seconds now
         seconds=$(_work_es_parse_duration "$since") || {

--- a/tests/cases/es/es-computes-a-duration-between-two-timestamps.yaml
+++ b/tests/cases/es/es-computes-a-duration-between-two-timestamps.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Trois endroits du module font de l arithmetique sur le resultat d une conversion :
+# _work_es_status_section calcule la duree couverte par des logs, et work_fetch_logs
+# elargit une fenetre d une marge. Aucun cas ne les couvrait, ce qui est precisement la
+# forme de trou que writing-cases.md decrit — un defaut qui se cache dans un nombre que
+# personne n asserte.
+#
+# La delegation les rend plus fragiles qu avant : `$(( $(zanvil es convert …) - … ))`
+# depend de ce que le CLI imprime un entier nu, sans unite ni retour de ligne parasite.
+# Ce cas fige ce contrat.
+name: es-computes-a-duration-between-two-timestamps
+weight: 7
+setup:
+  shell: zsh
+  source: ["core/ui.zsh", "modules/work/elasticsearch.zsh"]
+  env:
+    ZANVIL_DIR: "$GAVELDROP_PROJECT"
+  call: ["eval", "min=2026-05-28T20:00:00.000Z; max=2026-05-28T20:26:40.000Z; printf 'duree=%s\\n' $(( $(_work_es_iso_to_epoch $max) - $(_work_es_iso_to_epoch $min) )); marge=$(_work_es_parse_duration 1m); printf 'elargie=%s\\n' $(_work_es_epoch_to_iso $(( $(_work_es_iso_to_epoch $min) - marge )))"]
+expect:
+  exit_code: 0
+  stdout:
+    contains:
+      # 26 minutes et 40 secondes entre les deux bornes.
+      - "duree=1600"
+      # La borne basse reculee d une minute, rendue au format des requetes.
+      - "elargie=2026-05-28T19:59:00.000Z"

--- a/tests/cases/es/es-converts-paris-time-across-the-dst-boundary.yaml
+++ b/tests/cases/es/es-converts-paris-time-across-the-dst-boundary.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# LE cas du lot. Les quatre attendus sont calcules par une source independante (zoneinfo
+# en Python), pas releves sur la sortie du sujet : c est ce que writing-cases.md demande
+# — ecrire ce qui doit etre vrai, puis verifier que le sujet est d accord.
+#
+# Le basculement d heure d ete 2026 tombe le 29 mars. Le 28 est donc en CET (UTC+1) et
+# le 30 en CEST (UTC+2), a la meme heure locale : un portage qui ignorerait le fuseau
+# leur donnerait le meme epoch, et c est l erreur exacte que ce cas existe pour
+# attraper. Les deux dates de janvier et juillet tiennent la position au milieu de
+# chaque saison.
+name: es-converts-paris-time-across-the-dst-boundary
+weight: 9
+setup:
+  shell: zsh
+  source: ["core/ui.zsh", "modules/work/elasticsearch.zsh"]
+  env:
+    ZANVIL_DIR: "$GAVELDROP_PROJECT"
+  call: ["eval", "for dt in 2026-01-15T12:00:00 2026-07-15T12:00:00 2026-03-28T12:00:00 2026-03-30T12:00:00; do printf '%s=%s\\n' $dt $(_work_es_paris_to_epoch $dt); done"]
+expect:
+  exit_code: 0
+  stdout:
+    contains:
+      # Hiver : UTC+1, donc 12:00 Paris = 11:00 UTC.
+      - "2026-01-15T12:00:00=1768474800"
+      # Ete : UTC+2, donc 12:00 Paris = 10:00 UTC.
+      - "2026-07-15T12:00:00=1784109600"
+      # La veille du basculement, encore en CET.
+      - "2026-03-28T12:00:00=1774695600"
+      # Le lendemain, en CEST : une heure d ecart avec la ligne precedente pour la
+      # meme heure locale, a deux jours d intervalle.
+      - "2026-03-30T12:00:00=1774864800"

--- a/tests/cases/es/es-parses-the-four-duration-units.yaml
+++ b/tests/cases/es/es-parses-the-four-duration-units.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Caracterisation avant migration (chantier 3, lot A). Les six fonctions de calcul
+# temporel portent 14 des 38 dependances fragiles du module, dont le detecteur de
+# variante `date` que le spec cite comme justification du critere. Ces cas doivent
+# passer INCHANGES apres le portage en Rust.
+name: es-parses-the-four-duration-units
+weight: 5
+setup:
+  shell: zsh
+  source: ["core/ui.zsh", "modules/work/elasticsearch.zsh"]
+  env:
+    ZANVIL_DIR: "$GAVELDROP_PROJECT"
+  call: ["eval", "for u in 30s 5m 2h 3d 1d; do printf '%s=%s\\n' $u $(_work_es_parse_duration $u); done"]
+expect:
+  exit_code: 0
+  stdout:
+    contains:
+      - "30s=30"
+      - "5m=300"
+      - "2h=7200"
+      - "3d=259200"
+      - "1d=86400"

--- a/tests/cases/es/es-refuses-a-malformed-duration.yaml
+++ b/tests/cases/es/es-refuses-a-malformed-duration.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Les cinq formes que la fonction doit rejeter. `30` sans unite et `1w` en particulier :
+# le premier parce qu une duree sans unite serait interpretee au hasard, le second parce
+# que la semaine n est pas dans le vocabulaire et qu accepter silencieusement 1 seconde
+# serait pire qu un refus.
+name: es-refuses-a-malformed-duration
+weight: 5
+setup:
+  shell: zsh
+  source: ["core/ui.zsh", "modules/work/elasticsearch.zsh"]
+  env:
+    ZANVIL_DIR: "$GAVELDROP_PROJECT"
+  call: ["eval", "for u in 30x abc 30 1w 2H; do _work_es_parse_duration $u >/dev/null 2>&1 && printf 'ACCEPTE:%s\\n' $u || printf 'refuse:%s\\n' $u; done"]
+expect:
+  exit_code: 0
+  stdout:
+    contains:
+      - "refuse:30x"
+      - "refuse:abc"
+      - "refuse:30"
+      - "refuse:1w"
+      - "refuse:2H"
+    # Aucune de ces formes ne doit passer. Sans cette ligne, un parseur devenu
+    # permissif rendrait le cas vrai en acceptant tout.
+    absent: ["ACCEPTE"]

--- a/tests/cases/es/es-renders-an-epoch-as-utc-with-milliseconds.yaml
+++ b/tests/cases/es/es-renders-an-epoch-as-utc-with-milliseconds.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Le format est celui qu Elasticsearch attend dans une requete de plage : ISO 8601 UTC
+# avec des millisecondes toujours a zero. Les deux bornes sont l epoch zero, qui
+# attrape un decalage de fuseau, et une date de 2026, qui attrape un debordement.
+name: es-renders-an-epoch-as-utc-with-milliseconds
+weight: 5
+setup:
+  shell: zsh
+  source: ["core/ui.zsh", "modules/work/elasticsearch.zsh"]
+  env:
+    ZANVIL_DIR: "$GAVELDROP_PROJECT"
+  call: ["eval", "for e in 0 1780000000; do printf '%s=%s\\n' $e $(_work_es_epoch_to_iso $e); done"]
+expect:
+  exit_code: 0
+  stdout:
+    contains:
+      - "0=1970-01-01T00:00:00.000Z"
+      - "1780000000=2026-05-28T20:26:40.000Z"

--- a/tests/cases/es/es-round-trips-an-iso-timestamp.yaml
+++ b/tests/cases/es/es-round-trips-an-iso-timestamp.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# L aller-retour ISO -> epoch -> ISO doit rendre la valeur de depart. Teste avec et sans
+# millisecondes, parce que le module recoit les deux formes : ses propres requetes
+# portent des `.000Z`, les reponses d Elasticsearch pas toujours.
+name: es-round-trips-an-iso-timestamp
+weight: 5
+setup:
+  shell: zsh
+  source: ["core/ui.zsh", "modules/work/elasticsearch.zsh"]
+  env:
+    ZANVIL_DIR: "$GAVELDROP_PROJECT"
+  call: ["eval", "for ts in 2026-05-28T20:26:40.000Z 2026-05-28T20:26:40Z; do printf '%s=%s\\n' $ts $(_work_es_epoch_to_iso $(_work_es_iso_to_epoch $ts)); done"]
+expect:
+  exit_code: 0
+  stdout:
+    contains:
+      - "2026-05-28T20:26:40.000Z=2026-05-28T20:26:40.000Z"
+      - "2026-05-28T20:26:40Z=2026-05-28T20:26:40.000Z"

--- a/tests/cases/es/es-window-refuses-invalid-bounds.yaml
+++ b/tests/cases/es/es-window-refuses-invalid-bounds.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Les deux refus, avec leur message. Un `--since` mal ecrit et un `--from` mal ecrit ne
+# doivent pas produire une fenetre vide silencieuse : une requete sur une plage vide
+# rendrait zero resultat, ce qui se lit comme « pas de logs » et non comme « mauvaise
+# saisie ».
+name: es-window-refuses-invalid-bounds
+weight: 7
+setup:
+  shell: zsh
+  source: ["core/ui.zsh", "modules/work/elasticsearch.zsh"]
+  env:
+    ZANVIL_DIR: "$GAVELDROP_PROJECT"
+  call: ["eval", "_work_es_window 3jours >/dev/null 2>&1; printf 'since_rc=%s\\n' $?; _work_es_window '' pas-une-date >/dev/null 2>&1; printf 'from_rc=%s\\n' $?; _work_es_window 3jours 2>&1 | head -1"]
+expect:
+  exit_code: 0
+  stdout:
+    ignore_ansi: true
+    contains:
+      - "since_rc=1"
+      - "from_rc=1"
+      - "--since invalide: 3jours"
+      - "attendu: Xs/Xm/Xh/Xd"

--- a/tests/cases/es/es-window-refuses-invalid-bounds.yaml
+++ b/tests/cases/es/es-window-refuses-invalid-bounds.yaml
@@ -11,13 +11,21 @@ setup:
   source: ["core/ui.zsh", "modules/work/elasticsearch.zsh"]
   env:
     ZANVIL_DIR: "$GAVELDROP_PROJECT"
-  call: ["eval", "_work_es_window 3jours >/dev/null 2>&1; printf 'since_rc=%s\\n' $?; _work_es_window '' pas-une-date >/dev/null 2>&1; printf 'from_rc=%s\\n' $?; _work_es_window 3jours 2>&1 | head -1"]
+  # Les cinq formes couvrent deux mecanismes de refus distincts : « 3jours » et
+  # « pas-une-date » echouent sur les chiffres, « 2H », « 30x » et « 30 » sur l unite.
+  # Sans les trois dernieres, un parseur qui accepterait n importe quelle unite avec un
+  # nombre valide passerait inapercu — trouve par mutation.
+  call: ["eval", "for bad in 3jours 2H 30x 30 1w; do _work_es_window $bad >/dev/null 2>&1; printf 'since_%s=%s\\n' $bad $?; done; _work_es_window '' pas-une-date >/dev/null 2>&1; printf 'from_rc=%s\\n' $?; _work_es_window 3jours 2>&1 | head -1"]
 expect:
   exit_code: 0
   stdout:
     ignore_ansi: true
     contains:
-      - "since_rc=1"
+      - "since_3jours=1"
+      - "since_2H=1"
+      - "since_30x=1"
+      - "since_30=1"
+      - "since_1w=1"
       - "from_rc=1"
       - "--since invalide: 3jours"
       - "attendu: Xs/Xm/Xh/Xd"

--- a/tests/cases/es/es-window-since-spans-exactly-the-duration.yaml
+++ b/tests/cases/es/es-window-since-spans-exactly-the-duration.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# La fenetre relative, celle que `--since` produit. Elle se termine a « maintenant »,
+# donc ses deux bornes changent a chaque run : ce qui est deterministe, c est leur ECART,
+# qui doit valoir exactement la duree demandee.
+#
+# Ce cas existe parce que la verification par mutation a trouve son absence. Muter
+# `"h" => Some(n * 3600)` en `* 60` dans le Rust ne faisait rougir aucun cas : le
+# parseur de duree du CLI n est atteint que par `--since`, et les cas de fenetre ne
+# testaient que `--from/--to`. Le cas qui asserte les quatre unites, lui, appelle la
+# fonction zsh, qui n a pas migre — c est une regex, sans dependance a `date`.
+name: es-window-since-spans-exactly-the-duration
+weight: 7
+setup:
+  shell: zsh
+  source: ["core/ui.zsh", "modules/work/elasticsearch.zsh"]
+  env:
+    ZANVIL_DIR: "$GAVELDROP_PROJECT"
+  call: ["eval", "for d in 30s 5m 2h 3d; do _work_es_window $d >/dev/null || { printf 'ECHEC:%s\\n' $d; continue; }; printf '%s=%s|%s\\n' $d $(( $(_work_es_iso_to_epoch $_work_es_lte) - $(_work_es_iso_to_epoch $_work_es_gte) )) $_work_es_display; done"]
+expect:
+  exit_code: 0
+  stdout:
+    ignore_ansi: true
+    contains:
+      - "30s=30|depuis 30s (-> now)"
+      - "5m=300|depuis 5m (-> now)"
+      - "2h=7200|depuis 2h (-> now)"
+      - "3d=259200|depuis 3d (-> now)"
+    absent: ["ECHEC"]

--- a/tests/cases/es/es-window-spans-the-requested-range.yaml
+++ b/tests/cases/es/es-window-spans-the-requested-range.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# La fenetre explicite, celle qui est deterministe. Les deux bornes sont converties
+# depuis Europe/Paris et rendues en UTC, et le libelle nomme le fuseau d entree — sans
+# quoi un lecteur ne saurait pas si « 15:30 » etait local ou UTC.
+name: es-window-spans-the-requested-range
+weight: 7
+setup:
+  shell: zsh
+  source: ["core/ui.zsh", "modules/work/elasticsearch.zsh"]
+  env:
+    ZANVIL_DIR: "$GAVELDROP_PROJECT"
+  call: ["eval", "_work_es_window '' 2026-03-30T12:00:00 2026-03-30T14:00:00 && printf 'gte=%s\\nlte=%s\\ndisplay=%s\\n' $_work_es_gte $_work_es_lte $_work_es_display"]
+expect:
+  exit_code: 0
+  stdout:
+    contains:
+      - "gte=2026-03-30T10:00:00.000Z"
+      - "lte=2026-03-30T12:00:00.000Z"
+      - "display=2026-03-30T12:00:00 -> 2026-03-30T14:00:00 (Europe/Paris)"


### PR DESCRIPTION
Chantier 3 du spec `zsh-ou-rust`, premier lot. Le module `work/elasticsearch` fait 550 lignes et 18 fonctions : trop pour un seul passage. Ce lot prend la famille qui porte la dette citée par le spec — le calcul temporel.

## Le détecteur de variante disparaît

```zsh
if date --version &>/dev/null; then _WORK_ES_DATE_FLAVOR=gnu
else _WORK_ES_DATE_FLAVOR=bsd; fi
```

Il existait parce que `date -d` et `date -j -f` ne coexistent pas. `chrono` et `chrono-tz` ne dépendent d'aucun binaire : il n'y a plus deux chemins à maintenir ni de variante à deviner. Quatre fonctions délèguent — la fenêtre et les trois conversions — et le détecteur ne sert plus qu'au repli.

## Un recomptage qui corrige le spec

Le spec annonce 14 dépendances à `date`. Toutes ne sont pas fragiles : **`date +%s` est POSIX** et se comporte pareil partout. Seuls `date -d` (2) et `date -j -f` (3) divergent, plus le détecteur. Et `_work_es_parse_duration` n'utilise pas `date` du tout — c'est une regex zsh — donc elle reste en place.

Le critère se lit « plus aucune dépendance fragile sur le chemin emprunté », pas « plus aucun `date` ».

## Le cas qui porte le lot

Le basculement d'heure d'été 2026 tombe le 29 mars. À heure locale égale, le 28 (CET) et le 30 (CEST) sont à une heure d'écart — un portage qui ignorerait le fuseau leur donnerait le même epoch.

**Les attendus viennent de `zoneinfo` en Python, pas de la sortie du sujet.** C'est ce que `writing-cases.md` demande : écrire ce qui doit être vrai, puis vérifier que le sujet est d'accord. Les deux sources concordent, donc le contrat était vérifié des deux côtés avant qu'une ligne de Rust ne soit écrite.

## Ce que la vérification par mutation a trouvé

Muter `"h" => Some(n * 3600)` en `* 60` dans le Rust **ne faisait rougir aucun cas** : le parseur de durée du CLI n'est atteint que par `--since`, et les cas de fenêtre ne testaient que `--from/--to`. Comblé par un cas qui mesure l'**écart** entre les deux bornes — la seule chose déterministe quand la fenêtre se termine à « maintenant » — et par cinq formes invalides passées à la fenêtre.

Deux autres usages de conversion, dans une arithmétique (`$(( $(...) - $(...) ))`), n'avaient aucun cas non plus. Ils en ont un.

**Deux mutations écartées plutôt que comblées**, parce qu'équivalentes : retirer la validation des chiffres est rattrapé par `parse()`, et ajouter `.latest()` ne change rien pour un creux horaire où les deux bornes sont absentes.

## Divergence assumée

Sur une heure locale qui n'existe pas — 02:30 la nuit où les pendules avancent — le CLI **refuse**, le repli zsh **décale d'une heure en silence**. Le refus est le bon comportement. Aucun cas gaveldrop ne peut le figer sans rendre un verdict différent selon que le binaire est installé, donc ce sont les tests unitaires qui le tiennent.

## Vérification

**77 cas, 337/337, avec le binaire installé comme sans.** 9 tests unitaires. Les deux suites bash vertes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)