### PR TITLE
feat: chantiers 4 et 5 du spec zsh/Rust, et deux chantiers notes

### DIFF
--- a/cli/src/cmd/conflicts.rs
+++ b/cli/src/cmd/conflicts.rs
@@ -97,7 +97,12 @@ fn alias_name(line: &str) -> Option<String> {
 fn function_name(line: &str) -> Option<String> {
     // `split_once` et non `strip_suffix` : le motif du zsh finit par `.*`, donc du code
     // sur la même ligne après l'accolade est accepté.
-    let (name, _) = line.split_once("() {")?;
+    //
+    // Les deux syntaxes de déclaration comptent. `function nom() {` manquait au motif
+    // d'origine, ce qui rendait invisibles les sept fonctions de `modules/gitlab/` —
+    // aucune n'est en double aujourd'hui, mais rien ne l'aurait dit.
+    let declaration = line.strip_prefix("function ").unwrap_or(line);
+    let (name, _) = declaration.split_once("() {")?;
     let first = name.chars().next()?;
     (first.is_ascii_lowercase()
         && name

--- a/cli/src/cmd/conflicts.rs
+++ b/cli/src/cmd/conflicts.rs
@@ -1,0 +1,252 @@
+//! Détection des déclarations en double dans les fichiers zsh du projet.
+//!
+//! Portage de `zanvil-doctor-conflicts` (chantier 4). C'est la seule fonction de
+//! `core/commands/commands.zsh` que le critère du spec désigne : `zanvil-list` ne fait
+//! qu'extraire des numéros de version de dix outils externes — de l'orchestration, que le
+//! spec exclut explicitement — et les cinq appels de `zanvil-doctor` sont dans son repli,
+//! puisqu'il délègue depuis sa première ligne.
+//!
+//! Ce que le shell faisait en quatre filtres chaînés par famille — `grep -r` pour
+//! collecter, `sed` pour extraire le nom, `sort | uniq -d` pour ne garder que les
+//! doublons, puis un second `grep -rl` pour retrouver les fichiers — tient ici en une
+//! passe : on lit chaque fichier une fois et on accumule les noms par fichier.
+//!
+//! **Les trois périmètres sont différents, et c'est voulu.** Les alias et les fonctions
+//! sont cherchés dans `core/` et `modules/`, les exports dans `modules/` seulement, et
+//! les hooks `chpwd` dans tout le répertoire. Le zsh faisait déjà cette distinction ; la
+//! reproduire à l'identique est ce qui permet aux cas de ne pas savoir qui répond.
+
+use crate::config;
+use colored::*;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Un nom déclaré, et les fichiers qui le déclarent.
+type Declarations = BTreeMap<String, Vec<String>>;
+
+pub fn run() {
+    crate::cmd::print_header("Conflicts");
+    let root = config::zanvil_dir();
+    let mut issues = 0u32;
+
+    let core_and_modules = [root.join("core"), root.join("modules")];
+    let modules_only = [root.join("modules")];
+
+    issues += report(
+        "Aliases",
+        "alias",
+        &collect(&core_and_modules, &root, alias_name),
+    );
+    println!();
+    issues += report(
+        "Fonctions",
+        "fonction",
+        &collect(&core_and_modules, &root, function_name),
+    );
+    println!();
+    issues += report_hooks(&root);
+    println!();
+    issues += report(
+        "Exports",
+        "export",
+        &collect(&modules_only, &root, export_name),
+    );
+
+    summary(issues);
+}
+
+/// Parcourt les répertoires donnés et accumule ce que `extract` reconnaît.
+fn collect(dirs: &[PathBuf], root: &Path, extract: fn(&str) -> Option<String>) -> Declarations {
+    let mut found: Declarations = BTreeMap::new();
+    for dir in dirs {
+        for file in zsh_files(dir) {
+            let Ok(content) = fs::read_to_string(&file) else {
+                continue;
+            };
+            let shown = relative(&file, root);
+            for line in content.lines() {
+                if let Some(name) = extract(line) {
+                    let entry = found.entry(name).or_default();
+                    // Un nom déclaré deux fois dans le même fichier ne nomme ce fichier
+                    // qu'une fois : le conflit est entre déclarations, et la liste sert à
+                    // savoir où aller regarder.
+                    if !entry.contains(&shown) {
+                        entry.push(shown.clone());
+                    }
+                }
+            }
+        }
+    }
+    found
+}
+
+/// `alias nom=…` en tête de ligne, nom en minuscules — le motif du zsh.
+fn alias_name(line: &str) -> Option<String> {
+    let rest = line.strip_prefix("alias ")?;
+    let name = rest.split('=').next()?.trim();
+    let first = name.chars().next()?;
+    (first.is_ascii_lowercase() || first == '_').then(|| name.to_string())
+}
+
+/// `nom() {` en tête de ligne, nom en minuscules.
+///
+/// Le motif du zsh exige l'accolade ouvrante sur la même ligne, donc une fonction écrite
+/// `nom()\n{` n'est pas vue — ici comme là-bas. Le projet n'en contient pas, et élargir
+/// la détection ferait diverger les deux implémentations sur un cas que personne n'écrit.
+fn function_name(line: &str) -> Option<String> {
+    // `split_once` et non `strip_suffix` : le motif du zsh finit par `.*`, donc du code
+    // sur la même ligne après l'accolade est accepté.
+    let (name, _) = line.split_once("() {")?;
+    let first = name.chars().next()?;
+    (first.is_ascii_lowercase()
+        && name
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-'))
+    .then(|| name.to_string())
+}
+
+/// `export NOM=…` en tête de ligne, nom en majuscules.
+fn export_name(line: &str) -> Option<String> {
+    let rest = line.strip_prefix("export ")?;
+    let (name, _) = rest.split_once('=')?;
+    let first = name.chars().next()?;
+    ((first.is_ascii_uppercase() || first == '_')
+        && name
+            .chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_'))
+    .then(|| name.to_string())
+}
+
+fn report(label: &str, kind: &str, found: &Declarations) -> u32 {
+    crate::cmd::print_section(label, "");
+    let dups: Vec<_> = found.iter().filter(|(_, files)| files.len() > 1).collect();
+    if dups.is_empty() {
+        let none = match kind {
+            "alias" => "Aucun alias en double",
+            "fonction" => "Aucune fonction en double",
+            _ => "Aucun export en double",
+        };
+        println!("{} {}", "✓".green(), none);
+        return 0;
+    }
+    for (name, files) in &dups {
+        println!("{} '{}' → {}  ", "⚠".yellow(), name, files.join("  "));
+    }
+    dups.len() as u32
+}
+
+/// Les hooks `chpwd`, comptés et listés par le **même** critère.
+///
+/// Le zsh employait deux filtres divergents — `grep -cv "^#"` pour compter, qui n'écarte
+/// que les lignes commençant par un dièse, et `grep -v "^.*#"` pour lister, qui écarte
+/// toute ligne en contenant un. Il annonçait donc quatre hooks sur ce dépôt et n'en
+/// affichait que deux : les deux de trop étaient ses propres lignes, celles qui cherchent
+/// la chaîne, et elles n'apparaissaient pas parce qu'elles portent un dièse dans leur
+/// motif. Le bon résultat sortait pour la mauvaise raison.
+///
+/// Exiger l'appel en tête de ligne écarte d'un coup les commentaires, les mentions dans
+/// une chaîne, et le code qui cherche la chaîne sans rien enregistrer.
+fn report_hooks(root: &Path) -> u32 {
+    crate::cmd::print_section("Hooks", "");
+    let mut hooks: Vec<(String, usize, String)> = Vec::new();
+    for file in zsh_files(root) {
+        let Ok(content) = fs::read_to_string(&file) else {
+            continue;
+        };
+        let shown = relative(&file, root);
+        for (index, line) in content.lines().enumerate() {
+            if line.trim_start().starts_with("add-zsh-hook chpwd") {
+                hooks.push((shown.clone(), index + 1, line.to_string()));
+            }
+        }
+    }
+    if hooks.len() > 1 {
+        println!(
+            "{} {} hooks chpwd enregistrés (attention aux interactions)",
+            "⚠".yellow(),
+            hooks.len()
+        );
+        for (file, line, text) in &hooks {
+            println!("{file}:{line}:{text}");
+        }
+        1
+    } else {
+        println!("{} {} hook chpwd", "✓".green(), hooks.len());
+        0
+    }
+}
+
+fn summary(issues: u32) {
+    println!("{}", "─".repeat(44).dimmed());
+    if issues == 0 {
+        println!("{}", "✓ Tout est OK".green());
+    } else {
+        println!(
+            "{}, {}",
+            format!("✗ {} erreur(s)", issues).red(),
+            "0 avertissement(s)".yellow()
+        );
+    }
+}
+
+/// Tous les `*.zsh` sous `dir`, récursivement. Un répertoire illisible est ignoré, comme
+/// `grep -r` le fait avec son `2>/dev/null`.
+fn zsh_files(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let Ok(entries) = fs::read_dir(dir) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            out.extend(zsh_files(&path));
+        } else if path.extension().is_some_and(|ext| ext == "zsh") {
+            out.push(path);
+        }
+    }
+    out.sort();
+    out
+}
+
+fn relative(file: &Path, root: &Path) -> String {
+    file.strip_prefix(root)
+        .unwrap_or(file)
+        .display()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_alias_declaration_is_recognised_by_its_name() {
+        assert_eq!(alias_name("alias dupliq=\"echo x\""), Some("dupliq".into()));
+        assert_eq!(alias_name("alias _prive='x'"), Some("_prive".into()));
+        // Pas en tête de ligne, majuscule, ou sans nom : le zsh ne les voyait pas non plus.
+        assert_eq!(alias_name("  alias indente=x"), None);
+        assert_eq!(alias_name("alias MAJUSCULE=x"), None);
+        assert_eq!(alias_name("# alias commente=x"), None);
+    }
+
+    #[test]
+    fn a_function_declaration_is_recognised_by_its_name() {
+        assert_eq!(function_name("fonction_x() {"), Some("fonction_x".into()));
+        assert_eq!(function_name("kube-switch() {"), Some("kube-switch".into()));
+        // Une fonction privée commence par un souligné, que le motif du zsh écarte.
+        assert_eq!(function_name("_prive() {"), None);
+        assert_eq!(function_name("  indentee() {"), None);
+        assert_eq!(function_name("appel()"), None);
+    }
+
+    #[test]
+    fn an_export_declaration_is_recognised_by_its_name() {
+        assert_eq!(export_name("export MON_VAR=1"), Some("MON_VAR".into()));
+        assert_eq!(export_name("export _INTERNE=x"), Some("_INTERNE".into()));
+        assert_eq!(export_name("export minuscule=1"), None);
+        assert_eq!(export_name("  export INDENTE=1"), None);
+        // Sans affectation, ce n'est pas une déclaration.
+        assert_eq!(export_name("export SANS_VALEUR"), None);
+    }
+}

--- a/cli/src/cmd/convert.rs
+++ b/cli/src/cmd/convert.rs
@@ -1,0 +1,60 @@
+//! Conversions de dates, appelées par les fonctions shell qui en avaient chacune leur copie.
+//!
+//! Cachée de l'aide : ce sont les primitives que le shell invoque, pas des commandes qu'on
+//! tape. Les exposer donnerait à `zanvil --help` une entrée qui ne répond à aucune question
+//! qu'un utilisateur se pose.
+//!
+//! **Pourquoi hors de `es`.** Ces conversions y ont vécu le temps du chantier 3, où seul le
+//! module Elasticsearch les appelait. Le chantier 5 a trouvé le même calcul dans
+//! `modules/gitlab/gitlab_logic.zsh` — l'expiration d'un jeton personnel, écrite deux fois
+//! avec son propre embranchement GNU/BSD — et une primitive partagée par deux modules n'a
+//! pas à porter le nom de l'un d'eux.
+//!
+//! Les fonctions de calcul restent dans `es.rs`, où `window` les utilise aussi.
+
+use clap::Args;
+
+#[derive(Args)]
+pub struct ConvertArgs {
+    /// Epoch seconds to render as ISO 8601 UTC
+    #[arg(long, conflicts_with_all = ["from_iso", "from_paris"])]
+    from_epoch: Option<i64>,
+    /// ISO 8601 UTC timestamp, or a bare day, to read as epoch seconds
+    #[arg(long, conflicts_with_all = ["from_epoch", "from_paris"])]
+    from_iso: Option<String>,
+    /// Europe/Paris local time to read as epoch seconds
+    #[arg(long, conflicts_with_all = ["from_epoch", "from_iso"])]
+    from_paris: Option<String>,
+}
+
+/// Une conversion par invocation, imprimée nue pour qu'un `$(…)` la capture.
+///
+/// Rend 1 sans rien écrire quand l'entrée est illisible : les fonctions shell appelantes
+/// testent déjà la forme du résultat — `[[ "$epoch" == <-> ]]` en zsh, `[[ -n … ]]` en bash
+/// — donc un message ici s'ajouterait à leur diagnostic au lieu de le remplacer.
+pub fn run(args: ConvertArgs) -> i32 {
+    if let Some(epoch) = args.from_epoch {
+        println!("{}", super::es::epoch_to_iso(epoch));
+        return 0;
+    }
+    if let Some(iso) = args.from_iso {
+        return match super::es::iso_to_epoch(&iso) {
+            Some(epoch) => {
+                println!("{epoch}");
+                0
+            }
+            None => 1,
+        };
+    }
+    if let Some(local) = args.from_paris {
+        return match super::es::paris_to_epoch(&local) {
+            Some(epoch) => {
+                println!("{epoch}");
+                0
+            }
+            None => 1,
+        };
+    }
+    eprintln!("rien a convertir: donnez --from-epoch, --from-iso ou --from-paris");
+    1
+}

--- a/cli/src/cmd/es.rs
+++ b/cli/src/cmd/es.rs
@@ -18,7 +18,7 @@
 //! exécuterait ce que l'utilisateur a écrit dans `--from`, puisque le libellé le reprend
 //! tel quel.
 
-use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
+use chrono::{DateTime, NaiveDate, NaiveDateTime, TimeZone, Utc};
 use chrono_tz::Europe::Paris;
 use clap::Subcommand;
 
@@ -36,66 +36,12 @@ pub enum EsAction {
         #[arg(long)]
         to: Option<String>,
     },
-    /// Convert between the two timestamp shapes the module handles.
-    ///
-    /// Caché : ce sont les primitives que les fonctions zsh appellent, pas des commandes
-    /// qu'on tape. Les exposer donnerait à l'aide de `zanvil es` trois entrées qui ne
-    /// répondent à aucune question qu'un utilisateur se pose.
-    #[command(hide = true)]
-    Convert {
-        /// Epoch seconds to render as ISO 8601 UTC
-        #[arg(long, conflicts_with_all = ["from_iso", "from_paris"])]
-        from_epoch: Option<i64>,
-        /// ISO 8601 UTC timestamp to read as epoch seconds
-        #[arg(long, conflicts_with_all = ["from_epoch", "from_paris"])]
-        from_iso: Option<String>,
-        /// Europe/Paris local time to read as epoch seconds
-        #[arg(long, conflicts_with_all = ["from_epoch", "from_iso"])]
-        from_paris: Option<String>,
-    },
 }
 
 pub fn run(action: EsAction) -> i32 {
     match action {
         EsAction::Window { since, from, to } => window(since, from, to),
-        EsAction::Convert {
-            from_epoch,
-            from_iso,
-            from_paris,
-        } => convert(from_epoch, from_iso, from_paris),
     }
-}
-
-/// Une conversion par invocation, imprimée nue pour qu'un `$(…)` la capture.
-///
-/// Rend 1 sans rien écrire quand l'entrée est illisible : les fonctions zsh appelantes
-/// testaient déjà `[[ "$epoch" == <-> ]]`, donc un message ici s'ajouterait à leur
-/// diagnostic au lieu de le remplacer.
-fn convert(from_epoch: Option<i64>, from_iso: Option<String>, from_paris: Option<String>) -> i32 {
-    if let Some(epoch) = from_epoch {
-        println!("{}", epoch_to_iso(epoch));
-        return 0;
-    }
-    if let Some(iso) = from_iso {
-        return match iso_to_epoch(&iso) {
-            Some(epoch) => {
-                println!("{epoch}");
-                0
-            }
-            None => 1,
-        };
-    }
-    if let Some(local) = from_paris {
-        return match paris_to_epoch(&local) {
-            Some(epoch) => {
-                println!("{epoch}");
-                0
-            }
-            None => 1,
-        };
-    }
-    eprintln!("rien a convertir: donnez --from-epoch, --from-iso ou --from-paris");
-    1
 }
 
 /// ISO 8601 UTC en epoch, avec ou sans millisecondes.
@@ -103,12 +49,18 @@ fn convert(from_epoch: Option<i64>, from_iso: Option<String>, from_paris: Option
 /// Les deux formes arrivent réellement : les requêtes du module portent des `.000Z`, les
 /// réponses d'Elasticsearch pas toujours. Les millisecondes sont lues puis jetées, comme
 /// le zsh le faisait en coupant la chaîne — la précision du module est la seconde.
-fn iso_to_epoch(ts: &str) -> Option<i64> {
+pub(crate) fn iso_to_epoch(ts: &str) -> Option<i64> {
     let trimmed = ts.trim_end_matches('Z');
     let without_fraction = trimmed.split_once('.').map_or(trimmed, |(head, _)| head);
-    NaiveDateTime::parse_from_str(without_fraction, "%Y-%m-%dT%H:%M:%S")
-        .ok()
-        .map(|naive| Utc.from_utc_datetime(&naive).timestamp())
+    if let Ok(naive) = NaiveDateTime::parse_from_str(without_fraction, "%Y-%m-%dT%H:%M:%S") {
+        return Some(Utc.from_utc_datetime(&naive).timestamp());
+    }
+    // Une date seule vaut son minuit UTC. Le format vient de l API GitLab, dont le champ
+    // `expires_at` d un jeton personnel est un jour sans heure — et le calcul
+    // d expiration de modules/gitlab/gitlab_logic.zsh en avait deux copies, chacune avec
+    // son embranchement GNU/BSD.
+    let day = NaiveDate::parse_from_str(without_fraction, "%Y-%m-%d").ok()?;
+    Some(Utc.from_utc_datetime(&day.and_hms_opt(0, 0, 0)?).timestamp())
 }
 
 /// `Xs`/`Xm`/`Xh`/`Xd` en secondes.
@@ -132,7 +84,7 @@ fn parse_duration(spec: &str) -> Option<i64> {
 
 /// Le format qu'Elasticsearch attend dans une requête de plage : ISO 8601 UTC, avec des
 /// millisecondes toujours à zéro.
-fn epoch_to_iso(epoch: i64) -> String {
+pub(crate) fn epoch_to_iso(epoch: i64) -> String {
     DateTime::<Utc>::from_timestamp(epoch, 0)
         .unwrap_or_else(|| DateTime::<Utc>::from_timestamp(0, 0).expect("epoch zero is valid"))
         .format("%Y-%m-%dT%H:%M:%S.000Z")
@@ -148,7 +100,7 @@ fn epoch_to_iso(epoch: i64) -> String {
 /// Une heure qui n'existe pas — 02:30 la nuit où l'on avance les pendules — est refusée
 /// plutôt que décalée en silence. Une heure qui existe deux fois prend la première, celle
 /// d'avant le recul.
-fn paris_to_epoch(local: &str) -> Option<i64> {
+pub(crate) fn paris_to_epoch(local: &str) -> Option<i64> {
     let naive = NaiveDateTime::parse_from_str(local, "%Y-%m-%dT%H:%M:%S").ok()?;
     Paris
         .from_local_datetime(&naive)
@@ -265,9 +217,16 @@ mod tests {
 
     #[test]
     fn a_malformed_iso_is_refused() {
-        for ts in ["pas-une-date", "2026-05-28", "", "20:26:40"] {
+        for ts in ["pas-une-date", "", "20:26:40", "2026-13-45"] {
             assert_eq!(iso_to_epoch(ts), None, "{ts} should be refused");
         }
+    }
+
+    #[test]
+    fn a_day_without_a_time_is_its_utc_midnight() {
+        // Le format du champ `expires_at` d un jeton GitLab.
+        assert_eq!(iso_to_epoch("2026-05-28"), Some(1_779_926_400));
+        assert_eq!(epoch_to_iso(iso_to_epoch("2026-05-28").unwrap()), "2026-05-28T00:00:00.000Z");
     }
 
     #[test]

--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -1,5 +1,6 @@
 pub mod audit;
 pub mod bench;
+pub mod conflicts;
 pub mod context;
 pub mod doctor;
 pub mod es;

--- a/cli/src/cmd/mod.rs
+++ b/cli/src/cmd/mod.rs
@@ -1,6 +1,7 @@
 pub mod audit;
 pub mod bench;
 pub mod conflicts;
+pub mod convert;
 pub mod context;
 pub mod doctor;
 pub mod es;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -69,6 +69,8 @@ enum Commands {
         action: ProjectAction,
     },
     /// Fan-out a change as a MR/PR across multiple env branches
+    /// Report duplicate declarations across the project's zsh files
+    Conflicts,
     /// Elasticsearch query helpers
     Es {
         #[command(subcommand)]
@@ -95,6 +97,7 @@ fn main() {
         Commands::Bench { runs } => cmd::bench::run(runs),
         Commands::Update { check } => cmd::update::run(check),
         Commands::Project { action } => cmd::project::run(action),
+        Commands::Conflicts => cmd::conflicts::run(),
         Commands::Es { action } => {
             let code = cmd::es::run(action);
             if code != 0 {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -71,6 +71,9 @@ enum Commands {
     /// Fan-out a change as a MR/PR across multiple env branches
     /// Report duplicate declarations across the project's zsh files
     Conflicts,
+    /// Date conversions the shell functions call. Cachee : primitive, pas commande.
+    #[command(hide = true)]
+    Convert(cmd::convert::ConvertArgs),
     /// Elasticsearch query helpers
     Es {
         #[command(subcommand)]
@@ -98,6 +101,12 @@ fn main() {
         Commands::Update { check } => cmd::update::run(check),
         Commands::Project { action } => cmd::project::run(action),
         Commands::Conflicts => cmd::conflicts::run(),
+        Commands::Convert(args) => {
+            let code = cmd::convert::run(args);
+            if code != 0 {
+                std::process::exit(code);
+            }
+        }
         Commands::Es { action } => {
             let code = cmd::es::run(action);
             if code != 0 {

--- a/core/commands/commands.zsh
+++ b/core/commands/commands.zsh
@@ -370,12 +370,15 @@ zanvil-doctor-conflicts() {
     # --- Fonctions publiques en double ---
     _ui_section "Fonctions" ""
     local fn_dups
-    fn_dups="$(grep -rh "^[a-z][a-z0-9_-]*() {" "$ZANVIL_DIR/modules" "$ZANVIL_DIR/core" --include="*.zsh" 2>/dev/null \
-        | sed "s/\([^(]*\)() {.*/\1/" | sort | uniq -d)"
+    # Les deux syntaxes : `nom() {` et `function nom() {`. La seconde manquait, donc les
+    # sept fonctions de modules/gitlab/ etaient invisibles a cette detection — aucune
+    # n est en double aujourd hui, mais rien ne l aurait dit.
+    fn_dups="$(grep -rhE "^(function )?[a-z][a-z0-9_-]*\(\) \{" "$ZANVIL_DIR/modules" "$ZANVIL_DIR/core" --include="*.zsh" 2>/dev/null \
+        | sed -e "s/^function //" -e "s/\([^(]*\)() {.*/\1/" | sort | uniq -d)"
     if [[ -n "$fn_dups" ]]; then
         while IFS= read -r f; do
             local files
-            files="$(grep -rl "^${f}() {" "$ZANVIL_DIR/modules" "$ZANVIL_DIR/core" --include="*.zsh" 2>/dev/null | sed "s|$ZANVIL_DIR/||" | tr '\n' '  ')"
+            files="$(grep -rlE "^(function )?${f}\(\) \{" "$ZANVIL_DIR/modules" "$ZANVIL_DIR/core" --include="*.zsh" 2>/dev/null | sed "s|$ZANVIL_DIR/||" | tr '\n' '  ')"
             _ui_msg_warn "'${f}' → ${files}"
             ((issues++))
         done <<< "$fn_dups"

--- a/core/commands/commands.zsh
+++ b/core/commands/commands.zsh
@@ -343,6 +343,10 @@ zanvil-help() {
 # zanvil-doctor-conflicts : Détection des conflits entre modules
 # ==============================================================================
 zanvil-doctor-conflicts() {
+    if command -v zanvil &>/dev/null; then
+        zanvil conflicts; return $?
+    fi
+
     _ui_header "Conflicts"
     local issues=0
 
@@ -382,11 +386,22 @@ zanvil-doctor-conflicts() {
 
     # --- Hooks chpwd concurrents ---
     _ui_section "Hooks" ""
+    # Un seul motif pour le compte et pour la liste, et il exige que la ligne COMMENCE
+    # par l appel. Les deux precedents divergeaient — `grep -cv "^#"` n excluait que les
+    # lignes commencant par un diese, `grep -v "^.*#"` excluait toute ligne en contenant
+    # un — donc la commande annoncait 4 hooks sur ce depot et n en affichait que 2. Les
+    # deux de trop etaient ses propres lignes, qui cherchent la chaine ; elles ne
+    # s affichaient pas parce qu elles portent un diese dans leur motif, ce qui donnait
+    # le bon resultat pour la mauvaise raison.
+    #
+    # Exiger l appel en tete de ligne ecarte d un coup les commentaires, les mentions
+    # dans une chaine, et le code qui cherche la chaine sans rien enregistrer.
+    local _chpwd_pattern="^[[:space:]]*add-zsh-hook chpwd"
     local chpwd_count
-    chpwd_count="$(grep -rh "add-zsh-hook chpwd" "$ZANVIL_DIR" --include="*.zsh" 2>/dev/null | grep -cv "^#")"
+    chpwd_count="$(grep -rhE "$_chpwd_pattern" "$ZANVIL_DIR" --include="*.zsh" 2>/dev/null | grep -c .)"
     if [[ $chpwd_count -gt 1 ]]; then
         _ui_msg_warn "$chpwd_count hooks chpwd enregistrés (attention aux interactions)"
-        grep -rn "add-zsh-hook chpwd" "$ZANVIL_DIR" --include="*.zsh" 2>/dev/null | grep -v "^.*#" | sed "s|$ZANVIL_DIR/||"
+        grep -rnE "$_chpwd_pattern" "$ZANVIL_DIR" --include="*.zsh" 2>/dev/null | sed "s|$ZANVIL_DIR/||"
         ((issues++))
     else
         _ui_msg_ok "${chpwd_count} hook chpwd"

--- a/modules/gitlab/gitlab_logic.zsh
+++ b/modules/gitlab/gitlab_logic.zsh
@@ -186,6 +186,36 @@ alias help-clone="list-gitlab-cmds"
 ### GITLAB STATUS & BROWSE ###
 
 # Vérifie le statut du Personal Access Token GitLab
+# Jours restants avant l expiration d une date `YYYY-MM-DD`, telle que l API GitLab la
+# rend dans le champ `expires_at` d un jeton personnel. Rien si la date est illisible.
+#
+# Ce calcul existait DEUX FOIS dans ce fichier, chacune avec son propre embranchement
+# `date -j -f` pour BSD et `date -d` pour GNU — le meme motif que le chantier 3 a paye
+# dans le module Elasticsearch. Il delegue desormais a la primitive partagee.
+#
+# Divergence assumee, sous la journee : `date` rendait minuit LOCAL, le CLI rend minuit
+# UTC. Sur un calcul en jours entiers l ecart ne se voit qu a moins de deux heures de
+# minuit, et minuit UTC a l avantage d etre le meme partout — c est une date que GitLab
+# donne, pas un instant.
+_gitlab_days_until() {
+    local when="$1"
+    [[ -z "$when" || "$when" == "null" ]] && return 1
+
+    local expire_epoch
+    if command -v zanvil &>/dev/null; then
+        expire_epoch=$(zanvil convert --from-iso "$when") || return 1
+    elif [[ "$OSTYPE" == darwin* ]]; then
+        expire_epoch=$(date -j -f "%Y-%m-%d" "$when" +%s 2>/dev/null)
+    else
+        expire_epoch=$(date -d "$when" +%s 2>/dev/null)
+    fi
+    # Le repli n a pas de code de sortie fiable : `date` rend 1 mais imprime aussi une
+    # ligne vide, donc c est le contenu qui decide.
+    [[ -n "$expire_epoch" ]] || return 1
+
+    print -r -- $(( (expire_epoch - $(date +%s)) / 86400 ))
+}
+
 function zanvil-gitlab-status() {
     [[ -z "${GITLAB_BASE_DOMAIN:-}" ]] && { _ui_msg_fail "GITLAB_BASE_DOMAIN non defini (voir env.d/gitlab.zsh)"; return 1; }
     local gitlab_url="https://${GITLAB_BASE_DOMAIN}/api/v4"
@@ -237,16 +267,8 @@ function zanvil-gitlab-status() {
     _ui_section "Expiration" "$expires_at"
 
     if [[ "$expires_at" != "null" && -n "$expires_at" ]]; then
-        local now_epoch expire_epoch days_left
-        now_epoch=$(date +%s)
-        if [[ "$OSTYPE" == darwin* ]]; then
-            expire_epoch=$(date -j -f "%Y-%m-%d" "$expires_at" +%s 2>/dev/null)
-        else
-            expire_epoch=$(date -d "$expires_at" +%s 2>/dev/null)
-        fi
-
-        if [[ -n "$expire_epoch" ]]; then
-            days_left=$(( (expire_epoch - now_epoch) / 86400 ))
+        local days_left
+        if days_left=$(_gitlab_days_until "$expires_at"); then
             if (( days_left < 0 )); then
                 _ui_msg_fail "Token EXPIRÉ depuis $(( -days_left )) jour(s) !"
             elif (( days_left <= 30 )); then
@@ -338,15 +360,8 @@ if [[ -n "$GITLAB_TOKEN" ]] && command -v jq &>/dev/null; then
         expires_at=$(echo "$response" | jq -r '.expires_at // empty' 2>/dev/null)
 
         if [[ -n "$expires_at" ]]; then
-            local now_epoch expire_epoch days_left
-            now_epoch=$(date +%s)
-            if [[ "$OSTYPE" == darwin* ]]; then
-                expire_epoch=$(date -j -f "%Y-%m-%d" "$expires_at" +%s 2>/dev/null)
-            else
-                expire_epoch=$(date -d "$expires_at" +%s 2>/dev/null)
-            fi
-            if [[ -n "$expire_epoch" ]]; then
-                days_left=$(( (expire_epoch - now_epoch) / 86400 ))
+            local days_left
+            if days_left=$(_gitlab_days_until "$expires_at"); then
                 if (( days_left < 0 )); then
                     echo -e "${_ui_red}[GitLab]${_ui_nc} Token PAT ${_ui_bold}EXPIRE${_ui_nc} depuis $(( -days_left )) jour(s) !"
                 elif (( days_left <= 14 )); then

--- a/modules/work/elasticsearch.zsh
+++ b/modules/work/elasticsearch.zsh
@@ -77,7 +77,7 @@ _work_es_json() {
 # --- Dates et durees ---
 #
 # Il n y a plus deux versions a synchroniser. Ce bloc et son homologue de
-# modules/work/fetch_es_logs.sh deleguent au meme code — `zanvil es convert` et
+# modules/work/fetch_es_logs.sh deleguent au meme code — `zanvil convert` et
 # `zanvil es window` — donc le calcul n existe qu une fois, en Rust, avec deux appelants.
 #
 # Ce qui restait a maintenir en double : trois conversions ecrites chacune deux fois, une
@@ -125,7 +125,7 @@ _work_es_parse_duration() {
 _work_es_epoch_to_iso() {
     local epoch=$1
     if command -v zanvil &>/dev/null; then
-        zanvil es convert --from-epoch "$epoch"; return $?
+        zanvil convert --from-epoch "$epoch"; return $?
     fi
     if [[ $(_work_es_date_flavor) == gnu ]]; then
         date -u -d "@$epoch" +"%Y-%m-%dT%H:%M:%S.000Z"
@@ -138,7 +138,7 @@ _work_es_epoch_to_iso() {
 _work_es_iso_to_epoch() {
     local ts=$1
     if command -v zanvil &>/dev/null; then
-        zanvil es convert --from-iso "$ts"; return $?
+        zanvil convert --from-iso "$ts"; return $?
     fi
     if [[ $(_work_es_date_flavor) == gnu ]]; then
         date -u -d "$ts" +%s
@@ -153,7 +153,7 @@ _work_es_iso_to_epoch() {
 _work_es_paris_to_epoch() {
     local dt=$1
     if command -v zanvil &>/dev/null; then
-        zanvil es convert --from-paris "$dt"; return $?
+        zanvil convert --from-paris "$dt"; return $?
     fi
     if [[ $(_work_es_date_flavor) == gnu ]]; then
         TZ=Europe/Paris date -d "$dt" +%s

--- a/modules/work/fetch_es_logs.sh
+++ b/modules/work/fetch_es_logs.sh
@@ -114,7 +114,7 @@ parse_duration_to_seconds() {
 epoch_to_iso() {
   local epoch="$1"
   if _es_cli; then
-    zanvil es convert --from-epoch "$epoch"
+    zanvil convert --from-epoch "$epoch"
     return $?
   fi
   if [[ "$DATE_FLAVOR" == gnu ]]; then
@@ -128,7 +128,7 @@ epoch_to_iso() {
 iso_to_epoch() {
   local ts="$1"
   if _es_cli; then
-    zanvil es convert --from-iso "$ts"
+    zanvil convert --from-iso "$ts"
     return $?
   fi
   if [[ "$DATE_FLAVOR" == gnu ]]; then
@@ -144,7 +144,7 @@ iso_to_epoch() {
 parse_paris_to_epoch() {
   local dt="$1"
   if _es_cli; then
-    zanvil es convert --from-paris "$dt"
+    zanvil convert --from-paris "$dt"
     return $?
   fi
   if [[ "$DATE_FLAVOR" == gnu ]]; then

--- a/tests/cases/cli/cli-lists-its-commands.yaml
+++ b/tests/cases/cli/cli-lists-its-commands.yaml
@@ -30,3 +30,5 @@ expect:
       - "project"
       - "mr-fanout"
       - "config"
+      # Ajoutee par le chantier 4 : zanvil-doctor-conflicts la delegue.
+      - "conflicts"

--- a/tests/cases/conflicts/conflicts-names-every-duplicate.yaml
+++ b/tests/cases/conflicts/conflicts-names-every-duplicate.yaml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Caracterisation de zanvil-doctor-conflicts (chantier 4). La fixture porte un
+# exemplaire de chaque famille detectee, donc le verdict est exact et non « ce que le
+# depot contient aujourd hui ».
+#
+# CE CAS FIGE LE COMPORTEMENT CORRECT, PAS L ACTUEL. L implementation zsh annonce
+# « 4 hooks chpwd » sur le depot reel et n en affiche que 2, parce que le compte et la
+# liste emploient deux filtres differents :
+#
+#   compte : grep -cv "^#"    n exclut que les lignes COMMENCANT par #
+#   liste  : grep -v "^.*#"   exclut toute ligne CONTENANT un #
+#
+# Les deux lignes de commands.zsh qui cherchent la chaine sont donc comptees mais pas
+# affichees — et elles ne sont pas affichees par accident, parce qu elles portent un `#`
+# dans leur propre motif. Le bon resultat sortait pour une mauvaise raison.
+name: conflicts-names-every-duplicate
+weight: 9
+setup:
+  exec: ./tests/hooks/prepare-conflicts-fixture.sh
+  shell: zsh
+  source: ["core/ui.zsh", "core/commands/commands.zsh"]
+  call: ["zanvil-doctor-conflicts"]
+  env:
+    ZANVIL_DIR: "$HOME/zanvil"
+expect:
+  exit_code: 0
+  stdout:
+    ignore_ansi: true
+    contains:
+      - "Conflicts"
+      # Chaque doublon est nomme, et les deux fichiers qui le portent avec lui.
+      - "'dupliq'"
+      - "'fonction_dupliquee'"
+      - "'EXPORT_DUPLIQUE'"
+      - "modules/premier/init.zsh"
+      - "modules/second/init.zsh"
+      # Deux hooks reels : ni la ligne commentee ni celle qui mentionne la chaine sans
+      # rien enregistrer ne doivent etre comptees.
+      - "2 hooks chpwd"
+      - "_premier_chpwd"
+      - "_second_chpwd"
+    absent:
+      # Ce qui n est declare qu une fois n est pas un conflit.
+      - "'unique_premier'"
+      - "'unique_second'"
+      # Le compte fautif de l implementation actuelle.
+      - "4 hooks chpwd"
+      - "3 hooks chpwd"
+      # Le perimetre des exports est modules/ seulement : le meme nom exporte dans
+      # core/ et dans modules/ ne fait donc qu une declaration, pas un doublon.
+      - "'EXPORT_HORS_PERIMETRE'"
+      # La ligne commentee et la mention ne doivent apparaitre nulle part.
+      - "_commente_donc_inactif"
+      - "sans en poser un"

--- a/tests/cases/conflicts/conflicts-names-every-duplicate.yaml
+++ b/tests/cases/conflicts/conflicts-names-every-duplicate.yaml
@@ -32,6 +32,8 @@ expect:
       # Chaque doublon est nomme, et les deux fichiers qui le portent avec lui.
       - "'dupliq'"
       - "'fonction_dupliquee'"
+      # Le meme nom declare avec les deux syntaxes reste un doublon.
+      - "'melange_de_syntaxe'"
       - "'EXPORT_DUPLIQUE'"
       - "modules/premier/init.zsh"
       - "modules/second/init.zsh"

--- a/tests/cases/gitlab/gitlab-status-counts-the-days-before-expiry.yaml
+++ b/tests/cases/gitlab/gitlab-status-counts-the-days-before-expiry.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Caracterisation avant migration (chantier 5). Le calcul de jours restants existait DEUX
+# FOIS dans gitlab_logic.zsh, chacune avec son embranchement `date -j -f` pour BSD et
+# `date -d` pour GNU — le meme motif que le chantier 3 a paye dans le module
+# Elasticsearch.
+#
+# La date exacte n est pas assertee : le nombre de jours depend de « maintenant », donc
+# seule la CATEGORIE l est. Avec une echeance lointaine, l ecart de deux heures entre
+# minuit local et minuit UTC ne peut pas changer le verdict.
+name: gitlab-status-counts-the-days-before-expiry
+weight: 7
+setup:
+  shell: zsh
+  source: ["core/ui.zsh", "modules/gitlab/gitlab_logic.zsh"]
+  call: ["zanvil-gitlab-status"]
+  env:
+    ZANVIL_DIR: "$GAVELDROP_PROJECT"
+    GITLAB_TOKEN: "jeton-de-test-sans-valeur"
+    GITLAB_BASE_DOMAIN: "gitlab.exemple.invalide"
+    # Le module rend la main d entree si son garde n est pas pose.
+    ZANVIL_MODULE_GITLAB: "true"
+fake:
+  rules:
+    # La reponse de l API GitLab pour un jeton personnel, reduite aux champs lus.
+    - match: { bin: curl }
+      stdout: '{"id":1,"name":"jeton-de-test","active":true,"revoked":false,"scopes":["api"],"expires_at":"2099-12-31","created_at":"2026-01-01T00:00:00Z","last_used_at":"2026-08-01T00:00:00Z"}'
+    - match: {}
+      exit: 127
+      stderr: "the case did not foresee this call"
+expect:
+  exit_code: 0
+  stdout:
+    ignore_ansi: true
+    contains:
+      - "jeton-de-test"
+      - "2099-12-31"
+      - "jours restants"
+    absent:
+      - "EXPIRÉ"
+      - "Expire dans"

--- a/tests/cases/gitlab/gitlab-status-says-a-token-has-expired.yaml
+++ b/tests/cases/gitlab/gitlab-status-says-a-token-has-expired.yaml
@@ -1,0 +1,35 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# L autre extremite : une echeance passee doit produire un refus explicite et non un
+# nombre negatif de jours restants. Le module affiche « EXPIRÉ depuis N jour(s) », N
+# etant l oppose du calcul.
+name: gitlab-status-says-a-token-has-expired
+weight: 7
+setup:
+  shell: zsh
+  source: ["core/ui.zsh", "modules/gitlab/gitlab_logic.zsh"]
+  call: ["zanvil-gitlab-status"]
+  env:
+    ZANVIL_DIR: "$GAVELDROP_PROJECT"
+    GITLAB_TOKEN: "jeton-de-test-sans-valeur"
+    GITLAB_BASE_DOMAIN: "gitlab.exemple.invalide"
+    # Le module rend la main d entree si son garde n est pas pose.
+    ZANVIL_MODULE_GITLAB: "true"
+fake:
+  rules:
+    # La reponse de l API GitLab pour un jeton personnel, reduite aux champs lus.
+    - match: { bin: curl }
+      stdout: '{"id":1,"name":"jeton-de-test","active":true,"revoked":false,"scopes":["api"],"expires_at":"2020-01-01","created_at":"2026-01-01T00:00:00Z","last_used_at":"2026-08-01T00:00:00Z"}'
+    - match: {}
+      exit: 127
+      stderr: "the case did not foresee this call"
+expect:
+  exit_code: 0
+  stdout:
+    ignore_ansi: true
+    contains:
+      - "2020-01-01"
+      - "EXPIRÉ depuis"
+      - "jour(s)"
+    absent:
+      - "jours restants"

--- a/tests/cases/gitlab/gitlab-status-stays-silent-on-an-unreadable-date.yaml
+++ b/tests/cases/gitlab/gitlab-status-stays-silent-on-an-unreadable-date.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Une echeance que ni le CLI ni `date` ne savent lire ne doit produire AUCUNE alerte —
+# ni « expire », ni « jours restants ». La date brute reste affichee, parce qu elle vient
+# de l API et que la montrer telle quelle est plus utile que la taire.
+#
+# Ce cas existe parce que la verification par mutation a trouve son absence : retirer le
+# garde `[[ -n "$expire_epoch" ]] || return 1` du helper ne faisait rougir aucun cas.
+name: gitlab-status-stays-silent-on-an-unreadable-date
+weight: 7
+setup:
+  shell: zsh
+  source: ["core/ui.zsh", "modules/gitlab/gitlab_logic.zsh"]
+  call: ["zanvil-gitlab-status"]
+  env:
+    ZANVIL_DIR: "$GAVELDROP_PROJECT"
+    GITLAB_TOKEN: "jeton-de-test-sans-valeur"
+    GITLAB_BASE_DOMAIN: "gitlab.exemple.invalide"
+    # Le module rend la main d entree si son garde n est pas pose.
+    ZANVIL_MODULE_GITLAB: "true"
+fake:
+  rules:
+    # La reponse de l API GitLab pour un jeton personnel, reduite aux champs lus.
+    - match: { bin: curl }
+      stdout: '{"id":1,"name":"jeton-de-test","active":true,"revoked":false,"scopes":["api"],"expires_at":"pas-une-date","created_at":"2026-01-01T00:00:00Z","last_used_at":"2026-08-01T00:00:00Z"}'
+    - match: {}
+      exit: 127
+      stderr: "the case did not foresee this call"
+expect:
+  exit_code: 0
+  stdout:
+    ignore_ansi: true
+    contains:
+      - "jeton-de-test"
+      # La date brute est affichee telle que l API la rend.
+      - "pas-une-date"
+    absent:
+      # Aucune alerte ne doit sortir d une date illisible : un calcul sur une valeur vide
+      # rendrait un nombre de jours arbitraire, et le zsh l afficherait sans hesiter.
+      - "EXPIRÉ"
+      - "jours restants"
+      - "Expire dans"

--- a/tests/hooks/prepare-conflicts-fixture.sh
+++ b/tests/hooks/prepare-conflicts-fixture.sh
@@ -30,6 +30,12 @@ cp "$SRC/core/commands/commands.zsh" "$DST/core/commands/"
 printf 'fonction_dupliquee() {\n    :\n}\n' >>"$DST/modules/premier/init.zsh"
 printf 'fonction_dupliquee() {\n    :\n}\n' >>"$DST/modules/second/init.zsh"
 
+# La même fonction, déclarée une fois avec chaque syntaxe : `nom() {` d'un côté,
+# `function nom() {` de l'autre. C'est un doublon réel, et le motif d'origine ne voyait
+# que la première forme — donc ne le signalait pas.
+printf 'melange_de_syntaxe() {\n    :\n}\n' >>"$DST/modules/premier/init.zsh"
+printf 'function melange_de_syntaxe() {\n    :\n}\n' >>"$DST/modules/second/init.zsh"
+
 # Un export déclaré deux fois. La detection ne regarde que modules/, pas core/.
 printf 'export EXPORT_DUPLIQUE="a"\n' >>"$DST/modules/premier/init.zsh"
 printf 'export EXPORT_DUPLIQUE="b"\n' >>"$DST/modules/second/init.zsh"

--- a/tests/hooks/prepare-conflicts-fixture.sh
+++ b/tests/hooks/prepare-conflicts-fixture.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+# Construit un ZANVIL_DIR dont les conflits sont connus, pour que le verdict de
+# `zanvil-doctor-conflicts` soit exact et non « ce que le dépôt contient aujourd'hui ».
+#
+# La fixture porte un exemplaire de chaque famille détectée, plus les deux pièges qui
+# ont révélé un défaut dans l'implémentation zsh : une ligne commentée, et une ligne de
+# code qui *mentionne* la chaîne cherchée sans rien enregistrer.
+set -eu
+
+cat >/dev/null   # drain de la charge setup
+
+SRC="$GAVELDROP_PROJECT"
+DST="$HOME/zanvil"
+
+mkdir -p "$DST/core/commands" "$DST/modules/premier" "$DST/modules/second"
+cp "$SRC/core/ui.zsh" "$DST/core/"
+cp "$SRC/core/commands/commands.zsh" "$DST/core/commands/"
+
+# Un alias déclaré deux fois, et un déclaré une seule.
+{
+    printf 'alias dupliq="echo premier"\n'
+    printf 'alias unique_premier="echo un"\n'
+} >"$DST/modules/premier/init.zsh"
+{
+    printf 'alias dupliq="echo second"\n'
+    printf 'alias unique_second="echo deux"\n'
+} >"$DST/modules/second/init.zsh"
+
+# Une fonction publique déclarée deux fois.
+printf 'fonction_dupliquee() {\n    :\n}\n' >>"$DST/modules/premier/init.zsh"
+printf 'fonction_dupliquee() {\n    :\n}\n' >>"$DST/modules/second/init.zsh"
+
+# Un export déclaré deux fois. La detection ne regarde que modules/, pas core/.
+printf 'export EXPORT_DUPLIQUE="a"\n' >>"$DST/modules/premier/init.zsh"
+printf 'export EXPORT_DUPLIQUE="b"\n' >>"$DST/modules/second/init.zsh"
+
+# Deux hooks chpwd réels, plus les deux pièges.
+#
+# Le premier piège est une ligne commentée : elle ne doit pas être comptée, ce que le
+# filtre du compte faisait déjà.
+#
+# Le second est une ligne de code qui contient la chaîne sans rien enregistrer — le cas
+# de `commands.zsh` lui-même, dont les deux `grep` mentionnent « add-zsh-hook chpwd ».
+# L implémentation zsh la comptait mais ne l affichait pas, et n'affichait juste que
+# parce que ces lignes portent un `#` dans leur propre motif.
+{
+    printf 'add-zsh-hook chpwd _premier_chpwd\n'
+    printf '# add-zsh-hook chpwd _commente_donc_inactif\n'
+} >>"$DST/modules/premier/init.zsh"
+{
+    printf '    add-zsh-hook chpwd _second_chpwd\n'
+    printf 'echo "cette ligne parle de add-zsh-hook chpwd sans en poser un"\n'
+} >>"$DST/modules/second/init.zsh"
+
+# Un export porte le meme nom dans core/ et dans modules/. Il ne doit PAS etre signale :
+# la detection des exports ne regarde que modules/, contrairement a celle des alias et des
+# fonctions qui couvre les deux. Sans ce piege, elargir le perimetre par erreur ne faisait
+# rougir aucun cas.
+printf 'export EXPORT_HORS_PERIMETRE="cote core"\n' >"$DST/core/hors-perimetre.zsh"
+printf 'export EXPORT_HORS_PERIMETRE="cote modules"\n' >>"$DST/modules/premier/init.zsh"
+
+printf 'ZANVIL_MODULE_PREMIER=true\nZANVIL_MODULE_SECOND=true\n' >"$DST/config.zsh"
+printf 'minimal\n' >"$DST/.current_theme"

--- a/web/docs/superpowers/2026-08-05-cadrage-depot-prive-work.md
+++ b/web/docs/superpowers/2026-08-05-cadrage-depot-prive-work.md
@@ -1,0 +1,109 @@
+# Cadrage — extraire `modules/work/` dans un dépôt privé
+
+**À décider, pas encore fait.** Ce document cadre l'idée pour qu'elle soit arbitrable, pas pour la
+mettre en œuvre.
+
+## Le fait qui rend ce cadrage urgent
+
+`gh repo view` dit **`zanvil: PUBLIC`**. Et :
+
+```
+modules/work/elasticsearch.zsh:11   https://es-observability.prd.api.udb.azr.intranet
+modules/work/fetch_es_logs.sh:192   https://es-observability.prd.api.udb.azr.intranet
+```
+
+Ce nom d'hôte est en dur, comme valeur par défaut, à deux endroits d'un dépôt public. Il n'y a **aucun
+secret** dans le dépôt — pas de jeton, pas de mot de passe, les credentials passent par `env.d/*.sops.zsh`
+et `~/.secrets` comme la convention l'exige. Ce qui est exposé est de la nomenclature d'infrastructure :
+le préfixe de production, le nom du service d'observabilité, le domaine Azure interne.
+
+**Il faut être juste sur la portée.** Un `.intranet` ne résout pas depuis l'extérieur, donc personne ne
+peut s'y connecter avec cette information. Le préjudice est de la reconnaissance : quelqu'un qui
+préparerait une intrusion contre l'entreprise apprend gratuitement comment ses services sont nommés. C'est
+une pratique à corriger, pas une urgence à traiter cette nuit.
+
+Le correctif minimal ne demande pas de dépôt séparé — il suffit de remplacer le défaut par une chaîne
+vide et de refuser proprement quand la variable n'est pas réglée. Le dépôt séparé répond à une question
+plus large, qui est celle que tu poses.
+
+## Ce que l'extraction résoudrait vraiment
+
+Trois choses, dont une seule est la sécurité :
+
+**Les valeurs internes vivent au bon endroit.** Aujourd'hui il n'y a que deux niveaux : le code versionné
+public, et `env.d/` gitignoré donc non partageable. Un dépôt privé en offre un troisième : versionné,
+partagé avec les collègues qui en ont besoin, invisible au public. C'est exactement ce qui manque pour
+« avoir les valeurs qui m'intéressent » sans les mettre en dur ni les recopier sur chaque poste.
+
+**Le module devient partageable.** `work_es_apps`, `work_es_tail`, `work_fetch_logs` sont utiles à
+quiconque interroge le même Elasticsearch. Aujourd'hui ils ne peuvent pas être partagés autrement qu'en
+partageant tout zanvil, avec sa configuration personnelle.
+
+**Le dépôt public redevient homogène.** `modules/work/` est le seul module dont l'utilité dépend d'un
+employeur. Les onze autres marchent pour n'importe qui.
+
+## Ce qui partirait, mesuré
+
+| Fichier | Lignes | Contenu |
+|---|---|---|
+| `modules/work/elasticsearch.zsh` | 550 | Requêtes ES, fenêtres, comptage, tail |
+| `modules/work/fetch_es_logs.sh` | 339 | Export paginé par scroll |
+| `modules/work/work_context.zsh` | 215 | Détection de contexte via sonde Nexus |
+| `modules/work/completions.zsh` | 69 | Complétions |
+| `modules/work/init.zsh` | 2 | Chargeur |
+
+Plus les **12 cas gaveldrop** écrits pendant le chantier 3 (`tests/cases/es/` et `tests/cases/fetch/`), le
+hook `tests/hooks/prepare-sync-fixture.sh` ne concernant pas ce module.
+
+## Ce qui resterait, et c'est le point délicat
+
+**`cli/src/cmd/es.rs` doit rester dans zanvil.** Le calcul temporel qu'il porte — conversions,
+Europe/Paris, fenêtres — n'a rien de spécifique à un employeur : c'est du `chrono` sur des dates. Le
+sortir signifierait publier un second binaire, ou faire dépendre le dépôt privé d'un crate du dépôt
+public. Le laisser signifie que le module privé appelle `zanvil es convert`, donc que **le dépôt privé
+dépend du public** — ce qui est le bon sens de la dépendance.
+
+Rien d'autre du code de zanvil ne connaît `work`. Vérifié : les seules références sont
+`modules/work/init.zsh` et le loader générique, qui découvre les modules par leur dossier.
+
+## Trois formes possibles, par ordre de préférence
+
+**1. Un dépôt privé cloné dans `modules/`, découvert par le loader existant.**
+
+Le loader parcourt `modules/*/init.zsh` : un dossier cloné là est chargé sans une ligne de code en plus.
+Le guard `ZANVIL_MODULE_WORK` fonctionne déjà par dérivation du nom du dossier. `config.zsh` déclare le
+dépôt à cloner, `install.sh` le clone s'il y a accès et passe sinon.
+
+C'est la forme qui demande le moins de mécanique nouvelle. Son défaut : un dossier de `modules/` doit être
+gitignoré, ce qui se lit mal — quelqu'un qui inspecte le dépôt voit un module absent sans savoir pourquoi.
+
+**2. Un plugin, via le mécanisme `ZANVIL_PLUGINS` qui existe.**
+
+`plugins.zsh` clone déjà des dépôts déclarés dans `config.zsh`. Un plugin privé n'est qu'une URL de plus,
+et la nature « externe » est explicite. Défaut : les plugins sont chargés après les modules, donc l'ordre
+change, et le guard de module ne s'appliquerait plus de la même façon.
+
+**3. Un dépôt sœur, source par `.zanvil.local` ou `env.d/`.**
+
+Le plus découplé, et le plus manuel. À écarter sauf si les deux premiers butent : ça revient à ce que
+`env.d/` fait déjà, sans le versionnement qui est le motif de l'opération.
+
+## Ce qu'il faut décider avant de commencer
+
+1. **Le correctif minimal d'abord ?** Retirer le nom d'hôte en dur des deux fichiers coûte dix minutes et
+   règle le point de sécurité indépendamment de l'extraction. Je le recommande dans tous les cas — le
+   cadrage d'une extraction ne doit pas retarder une correction de trois lignes.
+2. **Qui d'autre en a besoin ?** Si personne, `env.d/` suffit peut-être et l'extraction est du travail
+   pour rien. Si des collègues, la forme 1 ou 2 se décide sur la façon dont ils y accéderont.
+3. **Les cas gaveldrop partent-ils avec le module ?** Ils devraient — un test vit avec son sujet — mais
+   alors le dépôt privé a besoin de sa propre CI et de son propre `gaveldrop.yaml`. C'est le même travail
+   que pour le dépôt autonome du plugin k9s, et les deux gagneraient à être faits ensemble.
+4. **Que devient `fetch_es_logs.sh` ?** Il duplique le zsh depuis toujours ; la duplication de calcul est
+   payée, mais deux implémentations de l'export subsistent. L'extraction est le bon moment pour choisir
+   laquelle survit.
+
+## Ce que ce cadrage ne tranche pas
+
+La forme de la dépendance, parce qu'elle dépend de la réponse à la question 2. Et le calendrier : les deux
+chantiers du spec zsh/Rust encore ouverts — `commands.zsh` et `gitlab_logic` — ne touchent pas à `work`,
+donc rien n'oblige à décider maintenant.

--- a/web/docs/superpowers/2026-08-05-chantier-vestiges-de-migration.md
+++ b/web/docs/superpowers/2026-08-05-chantier-vestiges-de-migration.md
@@ -1,0 +1,107 @@
+# Chantier — les vestiges du renommage `zsh_env` → `zanvil`
+
+**À prendre en compte, pas encore fait.** Ce document est le cadrage, écrit pendant le chantier 3 du
+spec zsh/Rust parce que c'est là que le problème est apparu deux fois de suite.
+
+## Ce qui a déclenché ce cadrage
+
+Deux pannes du même type, à trois jours d'écart :
+
+**Le 3 août, le binaire.** `~/.local/bin/` portait `zsh-env-cli` v3.0.0 et pas `zanvil`. Quatre mois
+sans que rien ne le signale, précisément parce que le repli fonctionnait. Corrigé : `install.sh` retire
+l'ancien binaire, `doctor` porte une section `Binaire` qui compte son absence comme une erreur, et un cas
+gaveldrop tient la position.
+
+**Le 5 août, les variables d'environnement.** En cherchant pourquoi un cas rendait un verdict différent
+sur ma machine et sur un runner, j'ai trouvé que mon `env.d/work.zsh` exporte encore
+`ZSH_ENV_WORK_NEXUS_URL`. Le code lit `ZANVIL_WORK_NEXUS_URL` depuis la v4.0.0.
+
+Le même mécanisme, la même durée, la même absence de signal.
+
+## L'inventaire, mesuré
+
+Sept variables `ZSH_ENV_*` sont encore exportées sur ce poste, depuis deux fichiers de `env.d/`. Ce qui
+décide de la gravité n'est pas leur nombre mais si le code attend leur équivalent :
+
+| Ancien nom exporté | Le code lit-il l'équivalent `ZANVIL_*` ? | Conséquence |
+|---|---|---|
+| `ZSH_ENV_WORK_ES_URL` | **oui** — `elasticsearch.zsh:11` | L'URL Elasticsearch réglée est ignorée : le défaut en dur s'applique |
+| `ZSH_ENV_WORK_NEXUS_URL` | **oui** — `work_context.zsh:10` | La détection du contexte Work est inerte |
+| `ZSH_ENV_WORK_TIMEOUT` | **oui** — `work_context.zsh:13` | Le timeout réglé est ignoré, le défaut de 2 s s'applique |
+| `ZSH_ENV_WORK_CACHE_TTL` | **oui** — `work_context.zsh` | Le TTL du cache réglé est ignoré |
+| `ZSH_ENV_DOCKER_ADDRESS_POOL` | non | Vestige sans effet, ou réglage abandonné |
+| `ZSH_ENV_WORK_PKI_URL` | non | Idem |
+| `ZSH_ENV_ENTERPRISE_CA_ISSUERS` | non | Idem |
+
+**Quatre réglages sur sept sont donc silencieusement inertes.** Aucun message, aucune trace : la valeur
+par défaut s'applique et rien ne dit qu'un choix a été écrasé.
+
+## La cause : la migration ne couvre pas `env.d/`
+
+`core/lifecycle/migrate_zanvil.zsh` réécrit deux fichiers :
+
+```zsh
+sed -e 's/ZSH_ENV_DIR/ZANVIL_DIR/g' -e 's#\.zsh_env#.zanvil#g' "$zshrc"   # .zshrc
+sed 's/ZSH_ENV_/ZANVIL_/g' "$cfg"                                          # config.zsh
+```
+
+`grep -c 'env.d' core/lifecycle/migrate_zanvil.zsh` rend **0**. Or `env.d/*.zsh` est l'endroit que
+`CLAUDE.md` et `examples/env.d/` désignent pour les variables d'environnement — donc le lieu le plus
+probable où trouver des `ZSH_ENV_*`, et le seul que la migration ignore. `secrets/` non plus n'est pas
+couvert (`grep -c 'secrets'` rend 0), ce qui reste à vérifier.
+
+Les fichiers de `env.d/` sont gitignorés : **le dépôt n'est pas fautif, la migration l'est.**
+
+## Les trois volets
+
+### 1. Étendre la migration à `env.d/` et vérifier `secrets/`
+
+Le même `sed` que pour `config.zsh`, avec la même prudence — sauvegarde horodatée, fichier temporaire
+plutôt que `sed -i` dont la syntaxe du suffixe diffère entre BSD et GNU. Le code existant est le modèle,
+il n'y a rien à inventer.
+
+Point d'attention : la migration ne s'exécute qu'une fois, quand `~/.zsh_env` existe encore. Un poste
+déjà migré ne la rejouera pas, donc étendre la migration ne répare **pas** les postes déjà passés. D'où
+le volet 2, qui est le seul à les atteindre.
+
+### 2. Faire dire à `doctor` qu'un réglage est mort
+
+C'est le volet qui compte, et le raisonnement est déjà écrit dans le spec zsh/Rust à propos du binaire :
+**un repli silencieux masque une panne, un repli est acceptable s'il est visible.**
+
+Ce que `doctor` peut voir sans rien deviner : une variable `ZSH_ENV_<X>` exportée alors que le code lit
+`ZANVIL_<X>`. Le test est mécanique — la liste des noms lus est dans le code — et le message peut nommer
+le fichier de `env.d/` qui l'exporte.
+
+Un cas gaveldrop tient la position : `env: { ZSH_ENV_WORK_ES_URL: "…" }` doit faire apparaître
+l'avertissement. C'est testable sans réseau et le verdict est le même partout, contrairement à ce que
+j'ai essayé pour les sondes réseau du démarrage.
+
+### 3. Corriger la documentation qui renvoie à des noms disparus
+
+`web/docs/ROADMAP.md:5` dit « Version actuelle : voir `core/ui.zsh` (`ZSH_ENV_VERSION`) ». Cette variable
+n'existe plus : `grep -c 'ZSH_ENV_VERSION' core/ui.zsh` rend 0.
+
+Le reste des occurrences est légitime et ne doit pas être touché : `migrate_zanvil.zsh` porte les anciens
+noms parce que c'est son métier, la ligne 69 du ROADMAP les cite comme historique livré, et les plans
+sous `superpowers/plans/` sont des archives datées.
+
+Le garde-fou `tests/bin/stale-binary-references` fait déjà ce travail pour l'ancien nom du binaire, en
+restreignant son scan aux invocations et en excluant `install.sh`. Le même patron s'applique ici : scanner
+les **lectures** de variables, pas les mentions.
+
+## Ce que ce chantier n'est pas
+
+**Ce n'est pas un renommage de plus.** Le renommage est fait et livré ; ce chantier traite ce que le
+renommage a laissé derrière lui sur les postes, et l'absence de mécanisme pour le voir.
+
+**Ce n'est pas un audit de sécurité.** Aucune de ces variables ne porte de secret. Le préjudice est
+qu'un réglage explicite est ignoré sans le dire — sur `WORK_ES_URL`, cela signifie interroger l'instance
+par défaut au lieu de celle qu'on a choisie.
+
+## Lien avec l'autre chantier ouvert
+
+Trois des quatre réglages perdus appartiennent au module `work`, dont l'extraction vers un dépôt privé
+est cadrée dans [le document voisin](2026-08-05-cadrage-depot-prive-work.md). Si cette extraction se
+fait, elle emporte une partie du problème avec elle — mais pas le mécanisme de détection, qui vaut pour
+toutes les variables du projet.

--- a/web/docs/superpowers/specs/2026-08-03-zsh-ou-rust-design.md
+++ b/web/docs/superpowers/specs/2026-08-03-zsh-ou-rust-design.md
@@ -120,7 +120,9 @@ Rust et non plus depuis son repli.
 | | ↳ **fait le 5 août 2026**, et « doublon » était faux — voir ci-dessous. |
 | 3 | **`work/elasticsearch`** | 38 dépendances fragiles, le détecteur `date`, la duplication annotée avec `fetch_es_logs.sh`. |
 | 4 | **`core/commands/commands.zsh`** | 24 appels `jq`/`awk`/`sed` dans `zanvil-list`, `-status`, `-help`, `-doctor-conflicts`. `zanvil-doctor` est hors périmètre : il délègue déjà. |
+| | ↳ **fait le 5 août 2026** — 7 appels sur 22, pas 24 : voir ci-dessous. |
 | 5 | **`gitlab_logic`** | 20 fragiles, mais 7 effets shell : migration **partielle**, la façade et les `export` restent en zsh. |
+| | ↳ **fait le 5 août 2026** — les 6 `date`, pas les 14 `jq` : voir ci-dessous. |
 
 ### Chantier 2 — ce que la caractérisation a corrigé dans ce spec
 
@@ -150,6 +152,31 @@ binaire manque.
 40 caractères pour une ligne de 44 : le cadre était ouvert à droite dans les **sept** commandes qui
 l'appellent. Le zsh compte les quatre espaces intérieurs, le Rust les oubliait. Sans cette correction, la
 délégation aurait dégradé l'affichage — les deux dessinent maintenant la même boîte, au caractère près.
+
+### Chantiers 4 et 5 — les comptes du tableau sont trop larges
+
+Le tableau annonce 24 appels fragiles pour `commands.zsh` et 20 pour `gitlab_logic`. Le critère du spec
+lui-même n'en retient qu'une fraction, et il faut le dire plutôt que de laisser croire à une dette non
+payée :
+
+| Fonction | Appels | Verdict du critère |
+|---|---|---|
+| `zanvil-list` | 10 | **Orchestration** — extraire un numéro de version de dix outils externes. « On ne migre pas un `for` autour d'un `kubectl` ». |
+| `zanvil-doctor` | 5 | **Dans son repli** — il délègue depuis sa première ligne. |
+| `zanvil-doctor-conflicts` | 7 | **Migré.** Analyse statique de fichiers, zéro effet shell. |
+| `gitlab_logic` — les `jq` | 14 | **Restent.** Ils parsent des réponses de l'API GitLab ; les migrer demanderait de porter le client HTTP, ce qui est un chantier distinct — `mr_fanout.rs` en est le précédent. |
+| `gitlab_logic` — les `date` | 6 | **Migrés.** Le calcul d'expiration d'un jeton, écrit **deux fois** avec son propre embranchement GNU/BSD. |
+
+**Deux défauts trouvés en caractérisant, et corrigés.** `zanvil-doctor-conflicts` annonçait « 4 hooks
+chpwd » et n'en affichait que 2, parce que le compte et la liste employaient des filtres différents — les
+deux de trop étaient ses propres lignes, et elles n'apparaissaient pas parce qu'elles portent un dièse
+dans leur motif. Et sa détection de fonctions ignorait la syntaxe `function nom() {`, donc les neuf
+fonctions de `modules/gitlab/` lui étaient invisibles.
+
+**Une primitive a changé de place.** `zanvil es convert` est devenue `zanvil convert` : le chantier 5 a
+trouvé le même calcul de date dans GitLab, et une primitive partagée par deux modules n'a pas à porter le
+nom de l'un d'eux. Les 86 cas sont passés inchangés à travers ce déplacement, ce qui est la meilleure
+démonstration qu'ils ignorent la mécanique interne.
 
 ## La méthode : caractériser avant de migrer
 


### PR DESCRIPTION
Les deux derniers chantiers du spec `zsh-ou-rust`, plus le cadrage des deux que ce travail a fait apparaître.

## Les comptes du spec sont trop larges, et son propre critère le dit

Le spec annonce 24 appels fragiles pour `commands.zsh` et 20 pour `gitlab_logic`. Mesuré :

| Fonction | Appels | Verdict du critère |
|---|---|---|
| `zanvil-list` | 10 | **Orchestration** — extraire un numéro de version de dix outils. « On ne migre pas un `for` autour d'un `kubectl` » |
| `zanvil-doctor` | 5 | **Dans son repli** — il délègue depuis sa première ligne |
| `zanvil-doctor-conflicts` | 7 | **Migré** — analyse statique, zéro effet shell |
| `gitlab_logic`, les `jq` | 14 | **Restent** — ils parsent l'API GitLab, les migrer voudrait dire porter le client HTTP |
| `gitlab_logic`, les `date` | 6 | **Migrés** — le calcul d'expiration, écrit **deux fois** |

## Deux défauts trouvés en caractérisant

**`doctor-conflicts` annonçait « 4 hooks chpwd » et n'en affichait que 2.** Le compte utilisait `grep -cv "^#"`, la liste `grep -v "^.*#"` — deux filtres différents. Les deux de trop étaient ses propres lignes, celles qui cherchent la chaîne, et elles n'apparaissaient pas parce qu'elles portent un dièse dans leur motif. Le bon résultat sortait pour la mauvaise raison.

**Sa détection de fonctions ignorait `function nom() {}`**, donc les neuf fonctions de `modules/gitlab/` lui étaient invisibles. Aucun doublon n'était masqué — vérifié en confondant les deux syntaxes — mais rien ne l'aurait dit.

## Une primitive a changé de place

`zanvil es convert` devient `zanvil convert`. Ces conversions ont vécu dans `es` le temps du chantier 3 ; le chantier 5 a trouvé le même calcul dans GitLab, et une primitive partagée par deux modules n'a pas à porter le nom de l'un d'eux.

**Les 86 cas sont passés inchangés à travers ce déplacement** — la meilleure démonstration qu'ils ignorent la mécanique interne.

## Ce que la mutation a réclamé

Trois trous fermés parce qu'une mutation ne mordait pas : le périmètre des exports (`modules/` seulement) n'était pas vérifié, le mélange des deux syntaxes de fonction non plus, et surtout le garde sur une date illisible — sans lui, le module annonce « Token EXPIRÉ depuis **20670 jour(s)** », un calcul sur une chaîne vide.

## Deux chantiers notés

**Les vestiges du renommage.** Sept variables `ZSH_ENV_*` sont encore exportées sur ce poste, et pour **quatre** d'entre elles le code lit l'équivalent `ZANVIL_*` : l'URL Elasticsearch, l'URL du Nexus, le timeout et le TTL du cache sont réglés et ignorés, sans un mot. `migrate_zanvil.zsh` réécrit `.zshrc` et `config.zsh` mais pas `env.d/`, qui est justement l'endroit désigné pour ces variables.

**Le dépôt privé pour la partie work.** Le dépôt est **public** et porte l'URL d'un service interne en dur, à deux endroits. Aucun secret n'est exposé, mais la nomenclature d'une infrastructure interne l'est. Le correctif minimal ne demande aucun dépôt et prend dix minutes ; le dépôt répond à une autre question — où vivent des valeurs qu'on veut versionner et partager sans les rendre publiques.

## Vérification

**86 cas, 398/398, avec le binaire installé comme sans.** 13 tests unitaires, deux suites bash vertes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)