### PR TITLE
fix: sortir le nom d'hote interne du code, et nommer les reglages morts

### DIFF
--- a/cli/src/cmd/doctor.rs
+++ b/cli/src/cmd/doctor.rs
@@ -1,7 +1,7 @@
 use crate::config::scan_module_metas;
 use colored::Colorize;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 // ---------------------------------------------------------------------------
@@ -245,6 +245,43 @@ pub fn run() {
         }
     }
 
+    // ── Réglages hérités de l'ancien nom ──────────────────────────────────
+    // Le renommage `zsh_env` → `zanvil` de la v4.0.0 a laissé deux choses derrière lui.
+    // Le binaire, traité juste au-dessus. Et les variables d'environnement : la migration
+    // réécrit `.zshrc` et `config.zsh`, pas `env.d/*.zsh`, qui est pourtant l'endroit que
+    // la convention désigne pour elles.
+    //
+    // Sur la machine où ce contrôle a été écrit, quatre réglages étaient posés et ignorés
+    // — l'URL Elasticsearch, celle du Nexus, un timeout et un TTL de cache. Aucun message,
+    // aucune trace : la valeur par défaut s'appliquait et rien ne disait qu'un choix avait
+    // été écrasé.
+    //
+    // Le contrôle ne devine rien : il lit les noms `ZANVIL_*` que le code consulte
+    // vraiment, puis regarde si l'ancien équivalent traîne dans l'environnement. Un nom
+    // que le projet a abandonné ne produit donc aucun bruit.
+    let stale = stale_settings();
+    if stale.is_empty() {
+        print_section("Reglages", &ok_indicator("aucun nom herite"));
+    } else {
+        print_section(
+            "Reglages",
+            &format!(
+                "{}  {}",
+                "⚠".yellow(),
+                format!("{} reglage(s) pose(s) sous l'ancien nom, donc ignore(s)", stale.len())
+                    .yellow()
+            ),
+        );
+        for (old, new) in &stale {
+            println!("               {} → {}", old.dimmed(), new.bold());
+        }
+        println!(
+            "               {}",
+            "renommez-les dans env.d/*.zsh : le code ne lit plus que la forme ZANVIL_".dimmed()
+        );
+        warnings += stale.len() as u32;
+    }
+
     println!();
 
     // ── Required tools ────────────────────────────────────────────────────
@@ -446,5 +483,75 @@ pub fn run() {
             format!("{} avertissement(s)", warnings).yellow()
         );
         println!("{}", "Lancez ~/.zanvil/install.sh pour corriger".dimmed());
+    }
+}
+
+/// Les réglages posés sous l'ancien nom `ZSH_ENV_*` alors que le code lit `ZANVIL_*`.
+///
+/// Rend les paires (ancien, nouveau), triées et sans doublon.
+///
+/// **Le contrôle part du code, pas d'une liste.** Une liste en dur se périmerait au premier
+/// réglage ajouté, et signalerait encore ceux que le projet a abandonnés — trois des sept
+/// noms trouvés sur la machine de développement n'ont aucun équivalent lu, et les nommer
+/// aurait été du bruit. Lire les `ZANVIL_*` que le code consulte vraiment évite les deux.
+fn stale_settings() -> Vec<(String, String)> {
+    let root = zanvil_dir();
+    let mut names: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for dir in [root.join("core"), root.join("modules")] {
+        collect_zanvil_names(&dir, &mut names);
+    }
+
+    names
+        .into_iter()
+        .filter_map(|new| {
+            let suffix = new.strip_prefix("ZANVIL_")?;
+            let old = format!("ZSH_ENV_{suffix}");
+            // Une variable vide compte comme absente : c'est ce que fait `${X:-…}`, donc
+            // un `export ZSH_ENV_X=""` n'écrase aucun choix.
+            std::env::var(&old)
+                .ok()
+                .filter(|value| !value.is_empty())
+                .map(|_| (old, new))
+        })
+        .collect()
+}
+
+/// Accumule les identifiants `ZANVIL_*` que les fichiers zsh d'un répertoire mentionnent.
+fn collect_zanvil_names(dir: &Path, out: &mut std::collections::BTreeSet<String>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_zanvil_names(&path, out);
+            continue;
+        }
+        if path.extension().is_none_or(|ext| ext != "zsh") {
+            continue;
+        }
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+        for line in content.lines() {
+            // Les commentaires sont ignorés : `migrate_zanvil.zsh` nomme volontairement
+            // les deux formes pour expliquer ce qu'il traduit.
+            if line.trim_start().starts_with('#') {
+                continue;
+            }
+            let mut rest = line;
+            while let Some(at) = rest.find("ZANVIL_") {
+                let tail = &rest[at..];
+                let end = tail
+                    .find(|c: char| !c.is_ascii_uppercase() && !c.is_ascii_digit() && c != '_')
+                    .unwrap_or(tail.len());
+                let name = &tail[..end];
+                // `ZANVIL_` seul, ou terminé par un souligné, n'est pas un identifiant.
+                if name.len() > "ZANVIL_".len() && !name.ends_with('_') {
+                    out.insert(name.to_string());
+                }
+                rest = &tail[end.max(1)..];
+            }
+        }
     }
 }

--- a/modules/work/elasticsearch.zsh
+++ b/modules/work/elasticsearch.zsh
@@ -7,8 +7,18 @@ _WORK_ES_APPS_CACHE="${ZANVIL_DIR:-$HOME/.zanvil}/.work_es_apps_cache"
 
 # --- Configuration ES (surchargeable via env.d/work.zsh) ---
 
+# L URL de l instance, telle que la config la porte — et rien si elle ne la porte pas.
+#
+# Un defaut en dur vivait ici, et c etait le nom d hote d un service interne dans un
+# depot public : aucun secret, mais la nomenclature d une infrastructure, offerte a qui
+# lit le code. `examples/env.d/work.zsh` documentait deja cette variable avec un defaut
+# VIDE, donc le code contredisait la convention du projet.
+#
+# Rendre une chaine vide plutot qu une URL de repli change le comportement : sans
+# reglage, les commandes refusent au lieu d interroger une instance qui n est pas la
+# leur. C est le bon sens du refus — un poste non configure ne doit pas deviner.
 _work_es_url() {
-    echo "${ES_URL:-${ZANVIL_WORK_ES_URL:-https://es-observability.prd.api.udb.azr.intranet}}"
+    echo "${ES_URL:-${ZANVIL_WORK_ES_URL:-}}"
 }
 
 _work_es_index() {
@@ -25,6 +35,10 @@ _work_es_require() {
     fi
     if ! command -v jq &>/dev/null; then
         _ui_msg_fail "jq requis (brew install jq / apt install jq)"
+        return 1
+    fi
+    if [[ -z "$(_work_es_url)" ]]; then
+        _ui_msg_fail "ZANVIL_WORK_ES_URL non definie (voir env.d/work.zsh)"
         return 1
     fi
     if [[ -z "${ES_USER:-}" || -z "${ES_PASSWORD:-}" ]]; then

--- a/modules/work/fetch_es_logs.sh
+++ b/modules/work/fetch_es_logs.sh
@@ -189,7 +189,14 @@ if [[ -n "$SEARCH" ]]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-ES_URL="${ES_URL:-https://es-observability.prd.api.udb.azr.intranet}"
+# Voir le commentaire de `_work_es_url` dans elasticsearch.zsh : le nom d hote d un
+# service interne n a rien a faire en dur dans un depot public, et la convention du
+# projet demandait deja que cette variable vienne de env.d/.
+ES_URL="${ES_URL:-${ZANVIL_WORK_ES_URL:-}}"
+if [[ -z "$ES_URL" ]]; then
+  echo "Erreur: ZANVIL_WORK_ES_URL non definie (voir env.d/work.zsh)"
+  exit 1
+fi
 INDEX="es-apis-*"
 BATCH_SIZE=10000
 

--- a/tests/bin/internal-hostnames
+++ b/tests/bin/internal-hostnames
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Imprime les endroits ou le CODE porte en dur un nom d'hote interne.
+#
+# Un `es-observability.prd.api.udb.azr.intranet` a vecu comme valeur de repli dans
+# modules/work/, dans un depot public. Aucun secret n'etait expose — les credentials
+# passent par sops et ~/.secrets, comme la convention l'exige — mais la nomenclature
+# d'une infrastructure interne l'etait : le prefixe de production, le nom du service, le
+# domaine Azure. Un `.intranet` ne resout pas depuis l'exterieur, donc le prejudice est de
+# la reconnaissance et non un acces ; ca reste une pratique a ne pas laisser revenir.
+#
+# `examples/env.d/work.zsh` documentait deja ces variables avec un defaut VIDE. Ce
+# controle fait respecter cette convention plutot qu'il n'en invente une.
+#
+# Trois exclusions, chacune avec sa raison :
+#
+#   1. les commentaires. Expliquer pourquoi une URL ne doit pas etre en dur demande de
+#      pouvoir en montrer une ; c'est le cas dans elasticsearch.zsh et dans le cas
+#      gaveldrop qui accompagne ce controle.
+#   2. examples/ et web/. Le premier documente les variables a definir, le second porte
+#      les rapports et les specs, qui nomment le probleme pour le decrire.
+#   3. tests/. La fixture d'un cas a besoin d'une adresse, et elle en emploie une en
+#      .invalide — reserve par la RFC 2606 — mais le repertoire est exclu pour que la
+#      regle ne depende pas du choix de domaine d'un cas.
+set -uo pipefail
+
+ROOT="${ZANVIL_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+
+# Les suffixes qui trahissent un hote d'entreprise. `.invalide` et `.exemple` n'y sont
+# pas : ce sont ceux que les cas doivent employer.
+PATTERN='https?://[a-z0-9.-]+\.(intranet|udb|azr)\b'
+
+grep -rnoE "$PATTERN" \
+        --include='*.zsh' --include='*.sh' --include='*.rs' --include='*.toml' \
+        "$ROOT/core" "$ROOT/modules" "$ROOT/cli/src" "$ROOT/scripts" 2>/dev/null \
+    | grep -vE ':[0-9]+:[[:space:]]*(#|//)' \
+    | sed "s|^$ROOT/||" || true

--- a/tests/cases/cli/cli-doctor-names-a-setting-left-under-the-old-name.yaml
+++ b/tests/cases/cli/cli-doctor-names-a-setting-left-under-the-old-name.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Troisieme vestige du renommage de la v4.0.0, apres le binaire et l URL en dur : les
+# variables d environnement. `migrate_zanvil.zsh` reecrit .zshrc et config.zsh, mais pas
+# env.d/*.zsh — l endroit meme que la convention designe pour elles. Sur la machine de
+# developpement, QUATRE reglages etaient poses et ignores : l URL Elasticsearch, celle du
+# Nexus, un timeout et un TTL de cache.
+#
+# Le raisonnement est celui du chantier 1 sur le binaire : un repli est acceptable s il
+# est visible. Un reglage ecrase par un defaut ne l etait pas.
+#
+# LE COMPTE N EST PAS ASSERTE, et c est deliberé : l isolation herite de l environnement,
+# donc un poste qui porte ses propres noms herites en verrait davantage qu un runner nu.
+# Ce qui est asserte, c est que le nom pose par ce cas est nomme, et qu un nom que le
+# projet ne lit pas ne l est pas.
+name: cli-doctor-names-a-setting-left-under-the-old-name
+weight: 7
+setup:
+  exec: ./tests/hooks/prepare-zanvil-dir.sh
+  run: ["$GAVELDROP_PROJECT/cli/target/release/zanvil", "doctor"]
+  env:
+    ZANVIL_DIR: "$HOME/zanvil"
+    # Le nom herite d un reglage que le code lit vraiment : il doit etre signale.
+    ZSH_ENV_WORK_ES_URL: "https://es.exemple.invalide"
+    # Un nom herite dont le projet n a aucun equivalent : il ne doit RIEN produire. Trois
+    # des sept noms trouves sur la machine de developpement sont dans ce cas, et les
+    # nommer aurait fait du bruit sans rien apprendre.
+    ZSH_ENV_REGLAGE_QUE_PERSONNE_NE_LIT: "valeur"
+    # Une variable vide ne compte pas : c est ce que fait `${X:-…}`, donc elle n ecrase
+    # aucun choix. Celle-ci verifie la regle.
+    ZSH_ENV_WORK_TIMEOUT: ""
+expect:
+  exit_code: 0
+  stdout:
+    ignore_ansi: true
+    contains:
+      - "Reglages"
+      - "pose(s) sous l'ancien nom"
+      - "ZSH_ENV_WORK_ES_URL → ZANVIL_WORK_ES_URL"
+      - "renommez-les dans env.d/*.zsh"
+    absent:
+      - "ZSH_ENV_REGLAGE_QUE_PERSONNE_NE_LIT"
+      # Posee a vide, donc sans effet : la signaler serait un faux positif.
+      - "ZSH_ENV_WORK_TIMEOUT"
+  #
+  # LE COMPTEUR D AVERTISSEMENTS N EST PAS ASSERTE. Neutraliser `warnings += stale.len()`
+  # ne fait rougir aucun cas, et l assertion qui le rattraperait ne serait pas
+  # discriminante : le resume final compte aussi les outils recommandes absents, donc
+  # « Tout est OK » ne sortirait de toute facon pas sur un runner nu. Le vrai signal est
+  # le message, et il est asserte ligne par ligne au-dessus.

--- a/tests/cases/docs/no-internal-hostname-in-the-code.yaml
+++ b/tests/cases/docs/no-internal-hostname-in-the-code.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Le garde-fou imprime les endroits ou le code porte en dur un nom d hote interne, et ce
+# cas exige qu il n imprime rien.
+#
+# Motif : `es-observability.prd.api.udb.azr.intranet` a vecu comme valeur de repli dans
+# modules/work/, dans un depot PUBLIC. Aucun secret n etait expose, mais la nomenclature
+# d une infrastructure interne l etait. `examples/env.d/work.zsh` documentait deja ces
+# variables avec un defaut vide, donc le controle fait respecter la convention du projet
+# plutot qu il n en invente une.
+name: no-internal-hostname-in-the-code
+weight: 7
+setup:
+  run: ["$GAVELDROP_PROJECT/tests/bin/internal-hostnames"]
+  env:
+    ZANVIL_DIR: "$GAVELDROP_PROJECT"
+expect:
+  exit_code: 0
+  stdout:
+    # Le garde imprime une ligne par occurrence : rien a dire, rien a imprimer.
+    equals: ""

--- a/tests/cases/es/es-refuses-without-a-configured-url.yaml
+++ b/tests/cases/es/es-refuses-without-a-configured-url.yaml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Un nom d hote interne vivait en dur comme valeur de repli de `_work_es_url`, dans un
+# depot public. Aucun secret n etait expose — les credentials passent par sops et
+# ~/.secrets — mais la nomenclature d une infrastructure l etait, et
+# `examples/env.d/work.zsh` documentait deja cette variable avec un defaut VIDE : le code
+# contredisait la convention du projet.
+#
+# Le defaut est retire, donc un poste non configure refuse au lieu d interroger une
+# instance qui n est pas la sienne. Ce cas fige le refus et son message ; le garde-fou
+# tests/bin/no-internal-hostnames empeche l URL de revenir.
+name: es-refuses-without-a-configured-url
+weight: 7
+setup:
+  shell: zsh
+  source: ["core/ui.zsh", "modules/work/elasticsearch.zsh"]
+  # Les credentials SONT definis : sans cela le refus pourrait venir d eux, et le cas ne
+  # prouverait pas que c est l URL qui manque.
+  env:
+    ZANVIL_DIR: "$GAVELDROP_PROJECT"
+    ES_USER: "utilisateur-de-test"
+    ES_PASSWORD: "mot-de-passe-de-test"
+    # Les deux variables que `_work_es_url` consulte, posees a vide. Sans cela le cas
+    # dependrait du poste : `ES_URL` est definie dans mon environnement, et le refus ne
+    # se produisait donc pas — ce qui a d ailleurs prouve que le correctif marche, le
+    # code ne fabriquant plus l URL lui-meme.
+    ES_URL: ""
+    ZANVIL_WORK_ES_URL: ""
+  call: ["eval", "for f in work_es_query work_es_apps work_es_count work_es_tail; do $f 2>&1 | head -1; printf 'rc_%s=%s\\n' $f $pipestatus[1]; done"]
+fake:
+  rules:
+    # Aucune requete ne doit partir : le refus arrive avant. La regle existe pour que le
+    # cas echoue sur `unexpected calls` si jamais une commande passait outre.
+    - match: {}
+      exit: 127
+      stderr: "the case did not foresee this call"
+expect:
+  exit_code: 0
+  stdout:
+    ignore_ansi: true
+    contains:
+      - "ZANVIL_WORK_ES_URL non definie"
+      - "voir env.d/work.zsh"
+      # Les quatre commandes gardees refusent, aucune ne passe.
+      - "rc_work_es_query=1"
+      - "rc_work_es_apps=1"
+      - "rc_work_es_count=1"
+      - "rc_work_es_tail=1"
+    absent:
+      # Le message des credentials ne doit pas sortir : ils sont definis, et c est bien
+      # l URL qui manque.
+      - "ES_USER/ES_PASSWORD non definis"
+  calls:
+    curl: 0

--- a/tests/cases/fetch/fetch-logs-converts-a-winter-window.yaml
+++ b/tests/cases/fetch/fetch-logs-converts-a-winter-window.yaml
@@ -10,6 +10,12 @@ setup:
   env:
     ES_USER: "cas"
     ES_PASSWORD: "cas"
+    # L URL est desormais obligatoire : le defaut en dur qui la fournissait etait le nom
+    # d hote d un service interne dans un depot public, et il a ete retire. Ces deux cas
+    # passaient grace a lui — et sur mon poste grace a ES_URL — donc ils dependaient d un
+    # defaut qu on ne voulait plus. Le domaine .invalide est reserve par la RFC 2606, et
+    # curl est falsifie de toute facon.
+    ZANVIL_WORK_ES_URL: "https://es.exemple.invalide"
 fake:
   rules:
     # Une reponse vide suffit : ce cas parle de la fenetre calculee avant la premiere

--- a/tests/cases/fetch/fetch-logs-converts-the-window-across-dst.yaml
+++ b/tests/cases/fetch/fetch-logs-converts-the-window-across-dst.yaml
@@ -19,6 +19,12 @@ setup:
   env:
     ES_USER: "cas"
     ES_PASSWORD: "cas"
+    # L URL est desormais obligatoire : le defaut en dur qui la fournissait etait le nom
+    # d hote d un service interne dans un depot public, et il a ete retire. Ces deux cas
+    # passaient grace a lui — et sur mon poste grace a ES_URL — donc ils dependaient d un
+    # defaut qu on ne voulait plus. Le domaine .invalide est reserve par la RFC 2606, et
+    # curl est falsifie de toute facon.
+    ZANVIL_WORK_ES_URL: "https://es.exemple.invalide"
 fake:
   rules:
     # Une reponse vide suffit : ce cas parle de la fenetre calculee avant la premiere

--- a/tests/cases/fetch/fetch-logs-refuses-without-a-configured-url.yaml
+++ b/tests/cases/fetch/fetch-logs-refuses-without-a-configured-url.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Le pendant bash du refus. Le script portait la meme URL en dur que le module zsh, et il
+# refuse desormais avant toute requete quand la variable n est pas posee.
+name: fetch-logs-refuses-without-a-configured-url
+weight: 5
+setup:
+  run: ["bash", "$GAVELDROP_PROJECT/modules/work/fetch_es_logs.sh", "--app", "cas", "--since", "1h", "--target-dir", "sortie"]
+  env:
+    ES_USER: "cas"
+    ES_PASSWORD: "cas"
+    # Les deux variables consultees, posees a vide : sans cela le cas dependrait du
+    # poste, ES_URL etant definie dans certains environnements.
+    ES_URL: ""
+    ZANVIL_WORK_ES_URL: ""
+fake:
+  rules:
+    - match: {}
+      exit: 127
+      stderr: "the case did not foresee this call"
+expect:
+  exit_code: 1
+  stdout:
+    contains:
+      - "ZANVIL_WORK_ES_URL non definie"
+      - "voir env.d/work.zsh"
+  # Le refus arrive avant toute requete, ce que l absence d appel prouve mieux qu une
+  # assertion sur la sortie.
+  calls:
+    curl: 0

--- a/web/docs/superpowers/2026-08-05-chantier-vestiges-de-migration.md
+++ b/web/docs/superpowers/2026-08-05-chantier-vestiges-de-migration.md
@@ -1,6 +1,13 @@
 # Chantier — les vestiges du renommage `zsh_env` → `zanvil`
 
-**À prendre en compte, pas encore fait.** Ce document est le cadrage, écrit pendant le chantier 3 du
+> **Volet 2 livré le 5 août 2026.** `doctor` porte une section `Reglages` qui nomme les réglages posés
+> sous l'ancien nom, et il trouve exactement les quatre que l'inventaire manuel ci-dessous avait trouvés —
+> ni plus, ni moins. Les trois noms sans équivalent lu ne produisent aucun bruit.
+>
+> Restent les volets 1 et 3 : étendre la migration à `env.d/` (qui ne répare pas les postes déjà passés,
+> d'où l'ordre) et corriger `ROADMAP.md:5`, qui renvoie encore à `ZSH_ENV_VERSION`.
+
+**À prendre en compte, partiellement fait.** Ce document est le cadrage, écrit pendant le chantier 3 du
 spec zsh/Rust parce que c'est là que le problème est apparu deux fois de suite.
 
 ## Ce qui a déclenché ce cadrage
@@ -64,7 +71,7 @@ Point d'attention : la migration ne s'exécute qu'une fois, quand `~/.zsh_env` e
 déjà migré ne la rejouera pas, donc étendre la migration ne répare **pas** les postes déjà passés. D'où
 le volet 2, qui est le seul à les atteindre.
 
-### 2. Faire dire à `doctor` qu'un réglage est mort
+### 2. Faire dire à `doctor` qu'un réglage est mort — **fait**
 
 C'est le volet qui compte, et le raisonnement est déjà écrit dans le spec zsh/Rust à propos du binaire :
 **un repli silencieux masque une panne, un repli est acceptable s'il est visible.**
@@ -76,6 +83,15 @@ le fichier de `env.d/` qui l'exporte.
 Un cas gaveldrop tient la position : `env: { ZSH_ENV_WORK_ES_URL: "…" }` doit faire apparaître
 l'avertissement. C'est testable sans réseau et le verdict est le même partout, contrairement à ce que
 j'ai essayé pour les sondes réseau du démarrage.
+
+**Livré ainsi.** Le contrôle lit les noms `ZANVIL_*` que le code consulte vraiment, puis regarde si
+l'ancien équivalent traîne dans l'environnement — plutôt qu'une liste en dur, qui se périmerait au premier
+réglage ajouté et signalerait encore ceux que le projet a abandonnés. Une variable vide ne compte pas :
+c'est ce que fait `${X:-…}`, donc elle n'écrase aucun choix.
+
+Le cas n'asserte pas le **compte** : l'isolation hérite de l'environnement, donc un poste qui porte ses
+propres noms hérités en verrait davantage qu'un runner nu. Il asserte que le nom qu'il pose est nommé, et
+qu'un nom sans équivalent lu ne l'est pas.
 
 ### 3. Corriger la documentation qui renvoie à des noms disparus
 


### PR DESCRIPTION
Les deux étapes suivantes de l'ordre recommandé, après le merge de #106.

## 1. Le nom d'hôte interne quitte le code

`es-observability.prd.api.udb.azr.intranet` vivait comme valeur de repli à deux endroits — dans `_work_es_url` et dans `fetch_es_logs.sh` — d'un dépôt **public**.

Aucun secret n'était exposé : les credentials passent par sops et `~/.secrets`, comme la convention l'exige. Ce qui l'était, c'est la nomenclature d'une infrastructure interne. Un `.intranet` ne résout pas depuis l'extérieur, donc le préjudice est de la reconnaissance et non un accès — une pratique à corriger, pas une urgence.

**`examples/env.d/work.zsh` documentait déjà cette variable avec un défaut vide.** C'était donc le code qui contredisait la convention du projet ; ce correctif ne fait que l'y ramener.

**Changement de comportement assumé** : sans réglage, les commandes refusent au lieu d'interroger une instance qui n'est pas la leur. La garde commune vérifie l'URL avant les credentials, et le script bash sort en 1 avant toute requête.

Un garde-fou — `tests/bin/internal-hostnames` — imprime les endroits où un hôte en `.intranet`, `.udb` ou `.azr` réapparaîtrait. Vérifié : muet sur le dépôt corrigé, il nomme fichier et ligne dès que l'URL revient.

## 2. `doctor` nomme les réglages morts

Troisième vestige du renommage v4.0.0, après le binaire et l'URL. `migrate_zanvil.zsh` réécrit `.zshrc` et `config.zsh`, **pas `env.d/`** — l'endroit même que la convention désigne pour ces variables.

```
Reglages       ⚠  4 reglage(s) pose(s) sous l'ancien nom, donc ignore(s)
               ZSH_ENV_WORK_CACHE_TTL → ZANVIL_WORK_CACHE_TTL
               ZSH_ENV_WORK_ES_URL → ZANVIL_WORK_ES_URL
               ZSH_ENV_WORK_NEXUS_URL → ZANVIL_WORK_NEXUS_URL
               ZSH_ENV_WORK_TIMEOUT → ZANVIL_WORK_TIMEOUT
               renommez-les dans env.d/*.zsh : le code ne lit plus que la forme ZANVIL_
```

**Le contrôle part du code, pas d'une liste.** Il lit les noms `ZANVIL_*` que `core/` et `modules/` consultent vraiment, puis regarde si l'ancien équivalent traîne dans l'environnement. Une liste en dur se périmerait au premier réglage ajouté et signalerait encore ceux que le projet a abandonnés — trois des sept noms trouvés ici sont dans ce cas. Le contrôle en trouve **exactement quatre**, comme l'inventaire manuel.

C'est le raisonnement du chantier 1 sur le binaire, déjà écrit dans le spec : un repli est acceptable s'il est visible.

## Deux renoncements documentés

Le cas de `doctor` n'asserte pas le **compte** de réglages : l'isolation hérite de l'environnement, donc un poste qui porte ses propres noms hérités en verrait plus qu'un runner nu. Et le compteur d'avertissements n'est pas assertable de façon discriminante, le résumé comptant aussi les outils recommandés absents — le cas dit pourquoi plutôt que de laisser croire à une couverture.

## Vérification

**90 cas, 424/424, avec le binaire installé comme sans.** 13 tests unitaires, deux suites bash vertes. Cinq mutations, dont trois ont mordu et deux ont révélé les trous ci-dessus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)