### PR TITLE
fix(migration): couvrir env.d/, et clore le chantier des vestiges

### DIFF
--- a/core/lifecycle/migrate_zanvil.zsh
+++ b/core/lifecycle/migrate_zanvil.zsh
@@ -44,6 +44,33 @@ _zanvil_migrate_from_zsh_env() {
             || echo "zanvil: avertissement: reecriture config.zsh echouee"
     fi
 
+    # env.d/*.zsh, qui manquait — et c'est le repertoire que la convention designe pour
+    # les variables d'environnement, donc celui ou les anciens noms sont les plus
+    # probables. Sur la machine de developpement, quatre reglages y etaient poses sous la
+    # forme ZSH_ENV_* et donc ignores : l'URL Elasticsearch, celle du Nexus, un timeout et
+    # un TTL de cache. Aucun message ne le disait.
+    #
+    # Les fichiers *.sops.zsh sont exclus : ils sont chiffres, et un sed dessus les
+    # rendrait indechiffrables. Leur contenu se remigre en clair, puis se rechiffre.
+    local envd="$new/env.d" f
+    if [[ -d "$envd" ]]; then
+        for f in "$envd"/*.zsh(N); do
+            [[ "$f" == *.sops.zsh ]] && continue
+            grep -q 'ZSH_ENV_' "$f" 2>/dev/null || continue
+            cp "$f" "${f}.bak-${ts}"
+            sed 's/ZSH_ENV_/ZANVIL_/g' "$f" > "${f}.tmp" \
+                && mv "${f}.tmp" "$f" \
+                && echo "zanvil: env.d/${f:t} migre" \
+                || echo "zanvil: avertissement: reecriture ${f:t} echouee"
+        done
+        # Un fichier chiffre qui porte l'ancien nom ne peut pas etre migre ici, mais se
+        # taire reviendrait a laisser un reglage mort sans le dire — ce que ce volet
+        # existe pour empecher.
+        for f in "$envd"/*.sops.zsh(N); do
+            echo "zanvil: ${f:t} est chiffre — verifiez ses ZSH_ENV_* a la main"
+        done
+    fi
+
     echo "zanvil: migration terminee (backup: ${bak}). Rechargement..."
     export ZANVIL_DIR="$new"
     [[ -n "$ZANVIL_MIGRATE_NO_EXEC" ]] && return 0

--- a/tests/cases/boot/migration-renames-settings-in-env-d.yaml
+++ b/tests/cases/boot/migration-renames-settings-in-env-d.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# La migration reecrivait .zshrc et config.zsh, mais pas env.d/*.zsh — le repertoire que
+# la convention designe pour les variables d environnement, donc celui ou les anciens noms
+# sont les plus probables. Sur la machine de developpement, quatre reglages y etaient
+# poses sous la forme ZSH_ENV_* et donc ignores.
+#
+# `doctor` sait desormais les nommer (volet 2, livre avant celui-ci parce qu il atteint
+# les postes DEJA migres, que ce volet ne peut plus toucher). Ce volet-ci evite qu un
+# poste qui migre aujourd hui n herite du probleme.
+name: migration-renames-settings-in-env-d
+weight: 9
+setup:
+  exec: ./tests/hooks/prepare-legacy-install.sh
+  shell: zsh
+  source: [".zsh_env/core/lifecycle/migrate_zanvil.zsh"]
+  call: ["true"]
+  env:
+    # Sans cela la migration termine par `exec zsh`, et le cas n observerait rien.
+    ZANVIL_MIGRATE_NO_EXEC: "1"
+expect:
+  exit_code: 0
+  stdout:
+    contains:
+      - "migration depuis ~/.zsh_env"
+      - "env.d/work.zsh migre"
+      # Le fichier chiffre est signale et non touche : se taire laisserait un reglage
+      # mort sans le dire, ce que ce volet existe pour empecher.
+      - "secrets.sops.zsh est chiffre"
+      - "migration terminee"
+  files:
+    # Le reglage en clair est renomme.
+    ".zanvil/env.d/work.zsh":
+      contains:
+        - "ZANVIL_WORK_ES_URL"
+        - "ZANVIL_WORK_TIMEOUT"
+      absent:
+        - "ZSH_ENV_WORK_ES_URL"
+        - "ZSH_ENV_WORK_TIMEOUT"
+    # Une sauvegarde horodatee reste, comme pour config.zsh.
+    ".zanvil/config.zsh":
+      contains: ["ZANVIL_MODULE_KUBE=true"]
+      absent: ["ZSH_ENV_MODULE_KUBE"]
+    # Le fichier chiffre ressort identique : un sed dessus le rendrait indechiffrable.
+    ".zanvil/env.d/secrets.sops.zsh":
+      equals: "ENC[AES256_GCM,data:ZSH_ENV_FAUX_CHIFFRE,type:str]"

--- a/tests/hooks/prepare-legacy-install.sh
+++ b/tests/hooks/prepare-legacy-install.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Construit un ~/.zsh_env herite, pour que la migration ait quelque chose a migrer.
+#
+# La fixture porte les trois cas qui decident du comportement : un config.zsh avec un
+# garde de module sous l ancien nom, un env.d/*.zsh en clair avec un reglage sous
+# l ancien nom, et un env.d/*.sops.zsh qui ne doit PAS etre touche parce qu il est
+# chiffre — un sed dessus le rendrait indechiffrable.
+set -eu
+
+cat >/dev/null   # drain de la charge setup
+
+SRC="$GAVELDROP_PROJECT"
+OLD="$HOME/.zsh_env"
+
+mkdir -p "$OLD/core/lifecycle" "$OLD/env.d"
+cp "$SRC/core/lifecycle/migrate_zanvil.zsh" "$OLD/core/lifecycle/"
+
+printf 'ZSH_ENV_MODULE_KUBE=true\nZSH_ENV_MODULE_DOCKER=false\n' >"$OLD/config.zsh"
+printf 'export ZSH_ENV_WORK_ES_URL="https://es.exemple.invalide"\nexport ZSH_ENV_WORK_TIMEOUT=5\n' >"$OLD/env.d/work.zsh"
+
+# Un faux fichier chiffre : son contenu est du charabia, comme le serait une sortie sops.
+# Ce qui compte est son nom, et qu il ressorte identique.
+printf 'ENC[AES256_GCM,data:ZSH_ENV_FAUX_CHIFFRE,type:str]\n' >"$OLD/env.d/secrets.sops.zsh"
+
+# Un .zshrc herite, que la migration reecrit deja.
+printf 'export ZSH_ENV_DIR="$HOME/.zsh_env"\nsource "$ZSH_ENV_DIR/rc.zsh"\n' >"$HOME/.zshrc"

--- a/web/docs/ROADMAP.md
+++ b/web/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Programme de rebranding (`zsh_env` → **zanvil**) + nouvelles fonctionnalités.
 > Chaque item = une PR (`feature/*`/`feat/*` → minor, `hotfix/*` → patch, `breaking/*` → major) = une release auto via `auto-release.yml`.
-> Version actuelle : voir `core/ui.zsh` (`ZSH_ENV_VERSION`).
+> Version actuelle : voir `core/ui.zsh` (`ZANVIL_VERSION`).
 
 ## Livré
 

--- a/web/docs/superpowers/2026-08-05-chantier-vestiges-de-migration.md
+++ b/web/docs/superpowers/2026-08-05-chantier-vestiges-de-migration.md
@@ -1,13 +1,23 @@
 # Chantier — les vestiges du renommage `zsh_env` → `zanvil`
 
-> **Volet 2 livré le 5 août 2026.** `doctor` porte une section `Reglages` qui nomme les réglages posés
-> sous l'ancien nom, et il trouve exactement les quatre que l'inventaire manuel ci-dessous avait trouvés —
-> ni plus, ni moins. Les trois noms sans équivalent lu ne produisent aucun bruit.
+> **Les trois volets sont livrés, le 5 août 2026.**
 >
-> Restent les volets 1 et 3 : étendre la migration à `env.d/` (qui ne répare pas les postes déjà passés,
-> d'où l'ordre) et corriger `ROADMAP.md:5`, qui renvoie encore à `ZSH_ENV_VERSION`.
+> **Volet 2 d'abord**, parce que c'est le seul qui atteint les postes déjà migrés. `doctor` porte une
+> section `Reglages` qui trouve exactement les quatre réglages de l'inventaire ci-dessous — ni plus, ni
+> moins, les trois noms sans équivalent lu ne produisant aucun bruit.
+>
+> **Volet 1** : la migration couvre `env.d/*.zsh`, et laisse les `*.sops.zsh` intacts — un `sed` sur un
+> fichier chiffré le rendrait indéchiffrable — en signalant qu'ils restent à vérifier à la main.
+>
+> **Volet 3** : `ROADMAP.md` renvoie désormais à `ZANVIL_VERSION`.
+>
+> **Un vestige reste, hors de portée d'ici.** `secrets/work/certificates_unix.sh` lit
+> `ZSH_ENV_WORK_PKI_URL` alors que `examples/env.d/work.zsh` documente `ZANVIL_WORK_PKI_URL` : le script
+> et le modèle ne parlent pas de la même variable. Le fichier en clair n'est pas versionné, mais son
+> `.enc` l'est, donc le corriger demande de déchiffrer et rechiffrer avec la clé age — ce qui appartient
+> à qui la détient.
 
-**À prendre en compte, partiellement fait.** Ce document est le cadrage, écrit pendant le chantier 3 du
+**Fait le 5 août 2026.** Ce document est le cadrage, écrit pendant le chantier 3 du
 spec zsh/Rust parce que c'est là que le problème est apparu deux fois de suite.
 
 ## Ce qui a déclenché ce cadrage


### PR DESCRIPTION
Les volets 1 et 3 du chantier des vestiges, après le volet 2 livré dans #107.

## L'ordre avait une raison

Le volet 2 — `doctor` qui nomme les réglages morts — est passé **d'abord** parce qu'il est le seul à atteindre les postes **déjà migrés** : la migration ne rejoue pas, donc l'étendre ne répare rien chez ceux qui l'ont déjà subie. Ce volet-ci évite qu'un poste qui migre aujourd'hui n'hérite du problème.

## La migration couvre `env.d/`

C'est le répertoire que la convention désigne pour les variables d'environnement, donc celui où les anciens noms sont les plus probables — et le seul que la migration ignorait.

**Les fichiers chiffrés sont exclus et signalés.** Un `sed` sur un `*.sops.zsh` le rendrait indéchiffrable, donc la boucle les saute. Mais se taire laisserait un réglage mort sans le dire, ce que ce chantier existe pour empêcher : chacun est nommé, avec la consigne de le vérifier à la main.

Le cas a sa fixture d'installation héritée et vérifie les trois comportements : le réglage en clair est renommé, `config.zsh` l'est aussi, et le fichier chiffré ressort **identique** — asserté par `equals`, donc au caractère près. Trois mutations, trois rouges.

## `ROADMAP.md` renvoyait à un nom disparu

`ZSH_ENV_VERSION` n'existe plus depuis la v4.0.0. Corrigé.

## Un vestige reste, hors de portée d'ici

`secrets/work/certificates_unix.sh` lit `ZSH_ENV_WORK_PKI_URL` alors que `examples/env.d/work.zsh` documente `ZANVIL_WORK_PKI_URL` — le script et le modèle ne parlent pas de la même variable. Le fichier en clair n'est pas versionné, mais son `.enc` l'est : le corriger demande de déchiffrer et rechiffrer avec la clé age, ce qui appartient à qui la détient. Consigné dans le document du chantier.

## Vérification

**91 cas, 433/433**, avec le binaire installé comme sans, et vérifié dans l'environnement d'un runner (`env -u ES_URL -u ZSH_ENV_WORK_ES_URL`) avant de pousser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)