### PR TITLE
test: adopter fake.bins par cas et not_written (gaveldrop 0.1.16)

### DIFF
--- a/core/lifecycle/migrate_zanvil.zsh
+++ b/core/lifecycle/migrate_zanvil.zsh
@@ -44,6 +44,33 @@ _zanvil_migrate_from_zsh_env() {
             || echo "zanvil: avertissement: reecriture config.zsh echouee"
     fi
 
+    # env.d/*.zsh, qui manquait — et c'est le repertoire que la convention designe pour
+    # les variables d'environnement, donc celui ou les anciens noms sont les plus
+    # probables. Sur la machine de developpement, quatre reglages y etaient poses sous la
+    # forme ZSH_ENV_* et donc ignores : l'URL Elasticsearch, celle du Nexus, un timeout et
+    # un TTL de cache. Aucun message ne le disait.
+    #
+    # Les fichiers *.sops.zsh sont exclus : ils sont chiffres, et un sed dessus les
+    # rendrait indechiffrables. Leur contenu se remigre en clair, puis se rechiffre.
+    local envd="$new/env.d" f
+    if [[ -d "$envd" ]]; then
+        for f in "$envd"/*.zsh(N); do
+            [[ "$f" == *.sops.zsh ]] && continue
+            grep -q 'ZSH_ENV_' "$f" 2>/dev/null || continue
+            cp "$f" "${f}.bak-${ts}"
+            sed 's/ZSH_ENV_/ZANVIL_/g' "$f" > "${f}.tmp" \
+                && mv "${f}.tmp" "$f" \
+                && echo "zanvil: env.d/${f:t} migre" \
+                || echo "zanvil: avertissement: reecriture ${f:t} echouee"
+        done
+        # Un fichier chiffre qui porte l'ancien nom ne peut pas etre migre ici, mais se
+        # taire reviendrait a laisser un reglage mort sans le dire — ce que ce volet
+        # existe pour empecher.
+        for f in "$envd"/*.sops.zsh(N); do
+            echo "zanvil: ${f:t} est chiffre — verifiez ses ZSH_ENV_* a la main"
+        done
+    fi
+
     echo "zanvil: migration terminee (backup: ${bak}). Rechargement..."
     export ZANVIL_DIR="$new"
     [[ -n "$ZANVIL_MIGRATE_NO_EXEC" ]] && return 0

--- a/tests/cases/boot/migration-renames-settings-in-env-d.yaml
+++ b/tests/cases/boot/migration-renames-settings-in-env-d.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# La migration reecrivait .zshrc et config.zsh, mais pas env.d/*.zsh — le repertoire que
+# la convention designe pour les variables d environnement, donc celui ou les anciens noms
+# sont les plus probables. Sur la machine de developpement, quatre reglages y etaient
+# poses sous la forme ZSH_ENV_* et donc ignores.
+#
+# `doctor` sait desormais les nommer (volet 2, livre avant celui-ci parce qu il atteint
+# les postes DEJA migres, que ce volet ne peut plus toucher). Ce volet-ci evite qu un
+# poste qui migre aujourd hui n herite du probleme.
+name: migration-renames-settings-in-env-d
+weight: 9
+setup:
+  exec: ./tests/hooks/prepare-legacy-install.sh
+  shell: zsh
+  source: [".zsh_env/core/lifecycle/migrate_zanvil.zsh"]
+  call: ["true"]
+  env:
+    # Sans cela la migration termine par `exec zsh`, et le cas n observerait rien.
+    ZANVIL_MIGRATE_NO_EXEC: "1"
+expect:
+  exit_code: 0
+  stdout:
+    contains:
+      - "migration depuis ~/.zsh_env"
+      - "env.d/work.zsh migre"
+      # Le fichier chiffre est signale et non touche : se taire laisserait un reglage
+      # mort sans le dire, ce que ce volet existe pour empecher.
+      - "secrets.sops.zsh est chiffre"
+      - "migration terminee"
+  files:
+    # Le reglage en clair est renomme.
+    ".zanvil/env.d/work.zsh":
+      contains:
+        - "ZANVIL_WORK_ES_URL"
+        - "ZANVIL_WORK_TIMEOUT"
+      absent:
+        - "ZSH_ENV_WORK_ES_URL"
+        - "ZSH_ENV_WORK_TIMEOUT"
+    # Une sauvegarde horodatee reste, comme pour config.zsh.
+    ".zanvil/config.zsh":
+      contains: ["ZANVIL_MODULE_KUBE=true"]
+      absent: ["ZSH_ENV_MODULE_KUBE"]
+    # Le fichier chiffre ressort identique : un sed dessus le rendrait indechiffrable.
+    ".zanvil/env.d/secrets.sops.zsh":
+      equals: "ENC[AES256_GCM,data:ZSH_ENV_FAUX_CHIFFRE,type:str]"

--- a/tests/cases/cli/theme-delegates-to-the-cli-with-the-right-subcommand.yaml
+++ b/tests/cases/cli/theme-delegates-to-the-cli-with-the-right-subcommand.yaml
@@ -10,26 +10,25 @@
 # `command -v zanvil` echouait et trois commandes tournaient en mode degrade sans le
 # dire. Un repli est acceptable s il est visible ; ce cas est ce qui le rend visible.
 #
-# ── Ce que ce cas peut prouver, et ou ────────────────────────────────────────────
+# ── Ce que ce cas prouve ─────────────────────────────────────────────────────────
 #
-# Le PATH de l isolation est celui de la machine, donc `command -v zanvil` trouve le
-# binaire la ou il est installe et ne le trouve pas sur un runner nu. Les assertions
-# ci-dessous sont donc ecrites pour etre vraies des DEUX cotes : les noms de themes
-# versionnes apparaissent dans la sortie du CLI comme dans celle du repli, alors que
-# tout le reste differe — le CLI ecrit « Available themes: », le repli dessine un
-# header et marque le theme actif d une etoile.
+# Le NOM EXACT de la sous-commande appelee, verifiable partout — sur un poste equipe
+# comme sur un runner nu.
 #
-# La consequence est assumee : sur un poste equipe, un renommage de la sous-commande
-# fait rougir ce cas parce que clap refuse le nom et que la fonction propage son code
-# de sortie ; sur un runner sans binaire, le renommage n a aucun effet observable, donc
-# rien ne rougit. C est correct — un defaut de delegation n existe que la ou il y a une
-# delegation.
+# Ce n etait pas le cas jusqu a la 0.1.15 de gaveldrop. Compter les appels demande un
+# faux binaire, et `fake.bins` etait global : falsifier le notre pour ce cas rendait les
+# huit cas de tests/cases/sync/ incapables d atteindre le vrai. Le cas s etait donc
+# rabattu sur sa sortie, ce qui ne detectait le renommage que la ou le binaire est
+# installe. `bins` est maintenant declarable par cas, et additif — `setup.hide` gagne
+# toujours — donc l assertion forte est revenue.
 #
-# Une premiere version comptait les appels avec `fake.bins: [zanvil]`, ce qui prouvait
-# davantage : le nom exact de la sous-commande, verifiable partout. Il a fallu y
-# renoncer parce que `fake.bins` est global — falsifier notre binaire pour ce cas
-# rendait les huit cas de tests/cases/sync/ incapables d atteindre le vrai. Demande
-# n 11 dans le document d evolution.
+# Deux mecanismes se completent ici :
+#
+#   - `args_include: ["theme"]` compare un argument comme un MOT, donc « themes » ne
+#     matche pas. `args_contain: "theme"` le faisait, et le cas passait alors sous la
+#     mutation qu il devait attraper.
+#   - le catch-all compte l appel comme non prevu, ce qui fait rougir le cas meme si sa
+#     sortie ressemblait par accident a ce qu on attend.
 name: theme-delegates-to-the-cli-with-the-right-subcommand
 weight: 7
 setup:
@@ -40,16 +39,33 @@ setup:
   call: ["zanvil-theme", "list"]
   env:
     ZANVIL_DIR: "$HOME/zanvil"
+fake:
+  # Declare pour CE cas seulement, depuis la 0.1.15 : notre propre binaire est falsifie
+  # ici sans que les huit cas de tests/cases/sync/ perdent le vrai. La declaration est
+  # additive — celle de gaveldrop.yaml reste — et `setup.hide` gagnerait toujours sur
+  # les deux.
+  bins: [zanvil]
+  rules:
+    # `args_include` compare un argument comme un MOT, donc cette regle ne sert QUE
+    # `zanvil theme …`. La version precedente employait `args_contain: "theme list"`,
+    # ce qui couplait la regle a la forme complete de l appel : un drapeau insere entre
+    # les deux mots l aurait cassee pour une raison etrangere a ce qu elle verifie.
+    - match: { bin: zanvil, args_include: ["theme"] }
+      stdout: "Available themes:"
+    # Le catch-all est le mecanisme qui attrape le renommage : un `zanvil themes` ne
+    # matche plus la regle nommee, tombe ici, et compte comme appel non prevu.
+    - match: {}
+      exit: 127
+      stderr: "the case did not foresee this call"
 expect:
-  # Le coeur du cas : la fonction rend 0. Une delegation vers un nom que le binaire ne
-  # connait pas propage le code de clap, et c est ce qui attrape le renommage.
   exit_code: 0
   stdout:
     ignore_ansi: true
-    # Les trois themes versionnes sous config/themes/, donc presents dans la copie
-    # isolee, et nommes par les deux implementations.
-    contains: ["forge", "tokyo-night-pro", "default"]
-  stderr:
-    absent:
-      - "unrecognized subcommand"
-      - "command not found"
+    # La reponse du faux : elle ne sort que si la regle a matche, donc que si la
+    # delegation a bien appele `zanvil theme`.
+    contains: ["Available themes:"]
+  # Un seul appel, et c est le bon. La fonction delegue et s arrete la — si elle
+  # repliait en zsh apres avoir appele le binaire, le compte resterait a 1 mais la
+  # sortie porterait aussi le header du repli.
+  calls:
+    zanvil: 1

--- a/tests/cases/modules/atuin-warns-when-its-binary-is-missing.yaml
+++ b/tests/cases/modules/atuin-warns-when-its-binary-is-missing.yaml
@@ -13,3 +13,13 @@ expect:
   exit_code: 0
   stdout:
     contains: ["brew install atuin"]
+  # Un module qui AVERTIT ne doit rien deployer. L assertion n existait pas avant la
+  # 0.1.15 : `expect.files` ne portait que sur des contenus, donc un chemin absent y
+  # faisait echouer le cas plutot que de le satisfaire, et « ce fichier est reste
+  # intact » etait inexprimable.
+  #
+  # Ce que ca protege ici est concret : deposer une configuration pour un outil qui n est
+  # pas installe est inutile, et toucher au fichier de config de quelqu un
+  # dont l outil manque serait une surprise desagreable.
+  not_written:
+    - "$HOME/.config/atuin/config.toml"

--- a/tests/cases/modules/delta-warns-when-its-binary-is-missing.yaml
+++ b/tests/cases/modules/delta-warns-when-its-binary-is-missing.yaml
@@ -15,3 +15,14 @@ expect:
     # Le nom du paquet brew differe du nom de la commande : c est justement le genre
     # de detail qu une assertion protege.
     contains: ["brew install git-delta"]
+  # Un module qui AVERTIT ne doit rien deployer. L assertion n existait pas avant la
+  # 0.1.15 : `expect.files` ne portait que sur des contenus, donc un chemin absent y
+  # faisait echouer le cas plutot que de le satisfaire, et « ce fichier est reste
+  # intact » etait inexprimable.
+  #
+  # Ce que ca protege ici est concret : deposer une configuration pour un outil qui n est
+  # pas installe est inutile, et toucher au gitconfig de quelqu un
+  # dont l outil manque serait une surprise desagreable.
+  not_written:
+    - "$HOME/.gitconfig"
+    - "$HOME/.gitconfig.d/delta"

--- a/tests/cases/modules/lazygit-warns-when-its-binary-is-missing.yaml
+++ b/tests/cases/modules/lazygit-warns-when-its-binary-is-missing.yaml
@@ -13,3 +13,13 @@ expect:
   exit_code: 0
   stdout:
     contains: ["brew install lazygit"]
+  # Un module qui AVERTIT ne doit rien deployer. L assertion n existait pas avant la
+  # 0.1.15 : `expect.files` ne portait que sur des contenus, donc un chemin absent y
+  # faisait echouer le cas plutot que de le satisfaire, et « ce fichier est reste
+  # intact » etait inexprimable.
+  #
+  # Ce que ca protege ici est concret : deposer une configuration pour un outil qui n est
+  # pas installe est inutile, et toucher au fichier de config de quelqu un
+  # dont l outil manque serait une surprise desagreable.
+  not_written:
+    - "$HOME/.config/lazygit/config-local.yml"

--- a/tests/cases/modules/posting-warns-when-its-binary-is-missing.yaml
+++ b/tests/cases/modules/posting-warns-when-its-binary-is-missing.yaml
@@ -24,3 +24,13 @@ expect:
   exit_code: 0
   stdout:
     contains: ["brew install posting"]
+  # Un module qui AVERTIT ne doit rien deployer. L assertion n existait pas avant la
+  # 0.1.15 : `expect.files` ne portait que sur des contenus, donc un chemin absent y
+  # faisait echouer le cas plutot que de le satisfaire, et « ce fichier est reste
+  # intact » etait inexprimable.
+  #
+  # Ce que ca protege ici est concret : deposer une configuration pour un outil qui n est
+  # pas installe est inutile, et toucher au fichier de config de quelqu un
+  # dont l outil manque serait une surprise desagreable.
+  not_written:
+    - "$HOME/.config/posting/config.yaml"

--- a/tests/cases/sync/sync-import-refuses-a-missing-file.yaml
+++ b/tests/cases/sync/sync-import-refuses-a-missing-file.yaml
@@ -2,13 +2,18 @@
 #
 # Un import sans fichier lisible doit refuser avant de toucher a quoi que ce soit.
 #
-# Ce cas devrait aussi asserter qu AUCUNE sauvegarde n a ete creee — un refus qui
-# laisserait un config.zsh.pre-import derriere lui aurait deja commence a travailler.
-# Le format ne le permet pas : les quatre champs de `expect.files` portent tous sur un
-# contenu (`contains`, `absent`, `equals`, `ignore_ansi`), et aucun ne dit « ce fichier
-# ne doit pas exister ». Demande n 10 dans le document d evolution.
+# `not_written` porte la seconde moitie du contrat, et c est celle qui compte : un refus
+# qui laisserait un config.zsh.pre-import derriere lui aurait deja commence a travailler.
+# L assertion etait impossible a ecrire jusqu a la 0.1.15 de gaveldrop — les quatre
+# champs de `expect.files` portaient tous sur un CONTENU, et un chemin absent y faisait
+# echouer le cas au lieu de le satisfaire.
+#
+# La cle ne dit rien de l existence : un fichier jamais cree n est pas ecrit, et un
+# fichier deja la et laisse tranquille non plus. Ici c est la premiere lecture qui est
+# voulue — la sauvegarde ne doit pas apparaitre. Pour prouver qu un fichier SURVIT, il
+# faudrait le creer dans le hook d abord.
 name: sync-import-refuses-a-missing-file
-weight: 5
+weight: 7
 setup:
   exec: ./tests/hooks/prepare-sync-fixture.sh
   shell: zsh
@@ -21,3 +26,11 @@ expect:
   stdout:
     ignore_ansi: true
     contains: ["Usage: zanvil-sync import"]
+  not_written:
+    # La sauvegarde qu un import reussi depose : son absence prouve que le refus est
+    # arrive avant le premier geste.
+    - "$HOME/zanvil/config.zsh.pre-import"
+    # Et la config elle-meme, que l import reecrit : un refus ne doit pas y toucher.
+    - "$HOME/zanvil/config.zsh"
+    # Le theme courant, ecrit par un import reussi.
+    - "$HOME/zanvil/.current_theme"

--- a/tests/hooks/prepare-legacy-install.sh
+++ b/tests/hooks/prepare-legacy-install.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Construit un ~/.zsh_env herite, pour que la migration ait quelque chose a migrer.
+#
+# La fixture porte les trois cas qui decident du comportement : un config.zsh avec un
+# garde de module sous l ancien nom, un env.d/*.zsh en clair avec un reglage sous
+# l ancien nom, et un env.d/*.sops.zsh qui ne doit PAS etre touche parce qu il est
+# chiffre — un sed dessus le rendrait indechiffrable.
+set -eu
+
+cat >/dev/null   # drain de la charge setup
+
+SRC="$GAVELDROP_PROJECT"
+OLD="$HOME/.zsh_env"
+
+mkdir -p "$OLD/core/lifecycle" "$OLD/env.d"
+cp "$SRC/core/lifecycle/migrate_zanvil.zsh" "$OLD/core/lifecycle/"
+
+printf 'ZSH_ENV_MODULE_KUBE=true\nZSH_ENV_MODULE_DOCKER=false\n' >"$OLD/config.zsh"
+printf 'export ZSH_ENV_WORK_ES_URL="https://es.exemple.invalide"\nexport ZSH_ENV_WORK_TIMEOUT=5\n' >"$OLD/env.d/work.zsh"
+
+# Un faux fichier chiffre : son contenu est du charabia, comme le serait une sortie sops.
+# Ce qui compte est son nom, et qu il ressorte identique.
+printf 'ENC[AES256_GCM,data:ZSH_ENV_FAUX_CHIFFRE,type:str]\n' >"$OLD/env.d/secrets.sops.zsh"
+
+# Un .zshrc herite, que la migration reecrit deja.
+printf 'export ZSH_ENV_DIR="$HOME/.zsh_env"\nsource "$ZSH_ENV_DIR/rc.zsh"\n' >"$HOME/.zshrc"

--- a/web/docs/ROADMAP.md
+++ b/web/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > Programme de rebranding (`zsh_env` → **zanvil**) + nouvelles fonctionnalités.
 > Chaque item = une PR (`feature/*`/`feat/*` → minor, `hotfix/*` → patch, `breaking/*` → major) = une release auto via `auto-release.yml`.
-> Version actuelle : voir `core/ui.zsh` (`ZSH_ENV_VERSION`).
+> Version actuelle : voir `core/ui.zsh` (`ZANVIL_VERSION`).
 
 ## Livré
 

--- a/web/docs/superpowers/2026-08-05-chantier-vestiges-de-migration.md
+++ b/web/docs/superpowers/2026-08-05-chantier-vestiges-de-migration.md
@@ -1,13 +1,23 @@
 # Chantier — les vestiges du renommage `zsh_env` → `zanvil`
 
-> **Volet 2 livré le 5 août 2026.** `doctor` porte une section `Reglages` qui nomme les réglages posés
-> sous l'ancien nom, et il trouve exactement les quatre que l'inventaire manuel ci-dessous avait trouvés —
-> ni plus, ni moins. Les trois noms sans équivalent lu ne produisent aucun bruit.
+> **Les trois volets sont livrés, le 5 août 2026.**
 >
-> Restent les volets 1 et 3 : étendre la migration à `env.d/` (qui ne répare pas les postes déjà passés,
-> d'où l'ordre) et corriger `ROADMAP.md:5`, qui renvoie encore à `ZSH_ENV_VERSION`.
+> **Volet 2 d'abord**, parce que c'est le seul qui atteint les postes déjà migrés. `doctor` porte une
+> section `Reglages` qui trouve exactement les quatre réglages de l'inventaire ci-dessous — ni plus, ni
+> moins, les trois noms sans équivalent lu ne produisant aucun bruit.
+>
+> **Volet 1** : la migration couvre `env.d/*.zsh`, et laisse les `*.sops.zsh` intacts — un `sed` sur un
+> fichier chiffré le rendrait indéchiffrable — en signalant qu'ils restent à vérifier à la main.
+>
+> **Volet 3** : `ROADMAP.md` renvoie désormais à `ZANVIL_VERSION`.
+>
+> **Un vestige reste, hors de portée d'ici.** `secrets/work/certificates_unix.sh` lit
+> `ZSH_ENV_WORK_PKI_URL` alors que `examples/env.d/work.zsh` documente `ZANVIL_WORK_PKI_URL` : le script
+> et le modèle ne parlent pas de la même variable. Le fichier en clair n'est pas versionné, mais son
+> `.enc` l'est, donc le corriger demande de déchiffrer et rechiffrer avec la clé age — ce qui appartient
+> à qui la détient.
 
-**À prendre en compte, partiellement fait.** Ce document est le cadrage, écrit pendant le chantier 3 du
+**Fait le 5 août 2026.** Ce document est le cadrage, écrit pendant le chantier 3 du
 spec zsh/Rust parce que c'est là que le problème est apparu deux fois de suite.
 
 ## Ce qui a déclenché ce cadrage

--- a/web/docs/superpowers/2026-08-05-demandes-evolution-gaveldrop-echanges.md
+++ b/web/docs/superpowers/2026-08-05-demandes-evolution-gaveldrop-echanges.md
@@ -23,11 +23,31 @@ suit est décrit, jamais corrigé sur place.
 > contient « actif ». Les valeurs sont donc comparées comme des **mots** — d'où `include` plutôt que
 > `contain`, la même distinction que pour `args_include`. Mes deux trous d'injection étaient le même trou.
 >
-> **Les demandes 10 et 11 sont postérieures à ce document** et restent ouvertes. La nº 11 empêche
-> d'adopter `args_include` dans `theme-delegates-to-the-cli-with-the-right-subcommand` : `fake.bins` étant
-> global, falsifier notre binaire pour ce cas rendrait les huit cas de `tests/cases/sync/` incapables
-> d'atteindre le vrai. `exec: real` ne dénoue pas le nœud — sur un runner il n'y a pas de vrai binaire
-> plus loin dans le `PATH`, donc les cas emprunteraient une délégation vers rien au lieu du repli zsh.
+> **Les demandes 10 et 11 sont livrées par la `v0.1.15`, et adoptées ici.**
+>
+> | # | Constaté |
+> |---|---|
+> | 10. `not_written` | Adopté sur six cas. Le message dit *comment* le chemin a été touché — « created, 7 bytes » — ce qui envoie au bon endroit, un fichier créé, modifié ou supprimé demandant trois enquêtes différentes. |
+> | 11. `fake.bins` par cas | `--verbose` montre `faked … zanvil` pour le seul cas concerné, et les huit cas de `tests/cases/sync/` atteignent toujours le vrai binaire. |
+>
+> **La nº 11 rend son assertion au cas de délégation.** Avec `bins: [zanvil]` déclaré dans le cas et
+> `args_include: ["theme"]` dans la règle, la mutation `theme` → `themes` rougit désormais **dans les deux
+> configurations** — avec le binaire installé comme sans. Elle ne mordait avant que là où le binaire
+> existe, ce qui laissait la CI aveugle à une panne que ce projet a déjà vécue.
+>
+> Deux remarques sur leur mise en œuvre, parce qu'elles nous concernent :
+>
+> - `bins` est **additif** et `setup.hide` gagne toujours. C'est le bon sens : un cas qui désombrerait un
+>   outil en silence ferait moins que ce que la suite demande.
+> - `not_written` **ne dit rien de l'existence**. Un fichier jamais créé n'est pas écrit, et un fichier déjà
+>   là et laissé tranquille non plus. Nos six usages veulent la première lecture ; pour prouver qu'un
+>   fichier *survit*, il faudra le créer dans le hook d'abord.
+>
+> Et un défaut qu'ils ont trouvé en câblant la nº 14, dans la liste où j'avais trouvé le nº 4 :
+> `files::check` était **la huitième vérification à composer sa propre racine**, donc un `files:` cassé dans
+> un échange était rapporté `expect.files[…]`. « Il était dans la même liste et aucun de nous deux n'a
+> regardé au-delà de ce que vous aviez énuméré. » — c'est juste, et ça vaut d'être retenu : énumérer sept
+> cas sur huit se lit comme une liste exhaustive.
 
 ## Ce qui a produit ces demandes
 


### PR DESCRIPTION
gaveldrop 0.1.15 livre les **deux demandes ouvertes**, dont celle qui bloquait. La 0.1.16 ajoute les références `--> fichier:ligne`.

## Le cas de délégation retrouve son assertion

Compter les appels demande un faux binaire, et `fake.bins` était global : falsifier le nôtre rendait les huit cas de `tests/cases/sync/` incapables d'atteindre le vrai. Le cas s'était rabattu sur sa sortie, ce qui ne détectait le renommage **que là où le binaire est installé** — donc pas en CI, pour une panne que ce projet a déjà vécue pendant quatre mois.

Avec `bins: [zanvil]` dans le cas et `args_include: ["theme"]` dans la règle, la mutation `theme` → `themes` rougit dans les **deux** configurations :

```
FAIL theme-delegates-to-the-cli-with-the-right-subcommand  0/7
    unexpected calls
      got       zanvil
```

`--verbose` confirme la mécanique : `faked … zanvil` n'apparaît que pour ce cas, additivement aux sept globaux. Et les huit cas sync atteignent toujours le vrai binaire — 50/50.

## `not_written` sur six cas

**L'import qui refuse** un fichier absent ne doit laisser ni sauvegarde, ni config réécrite, ni thème changé. L'assertion était inexprimable, et le cas portait un commentaire qui le disait.

**Les quatre modules qui avertissent** que leur binaire manque ne doivent rien déployer : toucher au `.gitconfig` de quelqu'un dont l'outil n'est pas installé serait une surprise désagréable.

Vérifié par mutation deux fois — faire la sauvegarde avant la validation donne `created, 253 bytes`, faire écrire la branche « binaire absent » de delta donne `created, 7 bytes` sur `~/.gitconfig.d/delta`. Le message dit **comment** le chemin a été touché, ce qui envoie au bon endroit : créé, modifié et supprimé demandent trois enquêtes différentes.

## Les références de la 0.1.16 tombent juste

Y compris sur les deux formes qu'ils donnaient pour douteuses. Vérifié ligne par ligne :

| Chemin d'assertion | Référence | Ce qu'il y a à cette ligne |
|---|---|---|
| `expect.files["zanvil/.current_theme"]` | `:39` | la clé de l'assertion |
| `steps[2] "…".stdout.contains[0]` | `:46` | le `contains` du troisième échange |

## Une remarque à retenir de leur côté

En câblant `not_written`, ils ont trouvé que `files::check` était **la huitième** vérification à composer sa propre racine — le défaut exact que j'avais signalé sur `calls`. « Il était dans la même liste et aucun de nous deux n'a regardé au-delà de ce que vous aviez énuméré. » C'est juste : énumérer sept cas sur huit se lit comme une liste exhaustive.

## Vérification

**91 cas, 435/435**, avec le binaire installé comme sans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)