### PR TITLE
perf+fix: falsifier az dans les cas doctor, et ne plus ecraser plugins.yaml

### DIFF
--- a/modules/kube/kube_config.zsh
+++ b/modules/kube/kube_config.zsh
@@ -1206,10 +1206,34 @@ kube_k9s_setup() {
     # Deployer plugins — $ZANVIL_DIR est resolu a la copie : k9s tente de
     # substituer lui-meme les $VAR et n'a pas ZANVIL_DIR dans son environnement
     # (warning "No k9s environment matching key" + chemin vide si la var change).
+    # Depose dans plugins/zanvil.yaml, et NON dans plugins.yaml.
+    #
+    # L ancienne version ecrasait `$k9s_dir/plugins.yaml`, sans sauvegarde ni
+    # avertissement : quiconque avait ses propres plugins k9s les perdait au premier
+    # `kube_k9s_setup`. Le defaut a ete trouve en construisant l installateur autonome
+    # du plugin de logs, qui a du resoudre le meme probleme.
+    #
+    # k9s lit `plugins.yaml` ET `plugins/*.yaml`. Le second format porte ses entrees A LA
+    # RACINE, sans la cle `plugins:` — verifie en deposant une sonde et en lisant le
+    # journal de k9s, qui refusait le fichier avec « Additional property plugins is not
+    # allowed ». D ou le retrait de la premiere ligne utile et la desindentation de deux
+    # espaces.
     local plugins_src="$ZANVIL_DIR/config/k9s/plugins.yaml"
     if [[ -f "$plugins_src" ]]; then
-        sed "s|\$ZANVIL_DIR|$ZANVIL_DIR|g" "$plugins_src" > "$k9s_dir/plugins.yaml"
-        _ui_msg_ok "plugins.yaml deploye"
+        mkdir -p "$k9s_dir/plugins"
+        # Trois passes, dans cet ordre : substituer $ZANVIL_DIR comme avant, retirer la
+        # ligne `plugins:` seule, puis desindenter ce qu elle contenait. Les commentaires
+        # de tete sont conserves — ils expliquent la syntaxe a qui ouvre le fichier.
+        sed -e "s|\$ZANVIL_DIR|$ZANVIL_DIR|g" \
+            -e '/^plugins:[[:space:]]*$/d' \
+            -e 's/^  //' \
+            "$plugins_src" > "$k9s_dir/plugins/zanvil.yaml"
+        _ui_msg_ok "plugins/zanvil.yaml deploye"
+        # Un plugins.yaml deja present n est pas touche, mais il peut revendiquer les
+        # memes raccourcis : k9s charge les deux et l un gagne sans le dire.
+        if [[ -f "$k9s_dir/plugins.yaml" ]]; then
+            _ui_msg_warn "plugins.yaml existe et n a pas ete modifie — verifiez les doublons de raccourcis"
+        fi
     else
         _ui_msg_warn "config/k9s/plugins.yaml absent dans $ZANVIL_DIR"
     fi

--- a/tests/cases/cli/cli-doctor-names-a-setting-left-under-the-old-name.yaml
+++ b/tests/cases/cli/cli-doctor-names-a-setting-left-under-the-old-name.yaml
@@ -29,6 +29,29 @@ setup:
     # Une variable vide ne compte pas : c est ce que fait `${X:-…}`, donc elle n ecrase
     # aucun choix. Celle-ci verifie la regle.
     ZSH_ENV_WORK_TIMEOUT: ""
+fake:
+  # Declare pour ces trois cas seulement, ce que la 0.1.15 de gaveldrop permet. `az` est
+  # le plus lent des trois outils que doctor interroge, et le seul a ecrire : chaque run
+  # deposait DOUZE fichiers sous .azure/ dans la racine isolee, dont la telemetrie
+  # Microsoft et un journal horodate. Un test ne doit pas contacter un service externe
+  # pour verifier que doctor sait lire un numero de version.
+  #
+  # kubectl et helm sont laisses tels quels : ils ne joignent personne pour rendre leur
+  # version, et leur presence ou absence sur un runner est justement ce que les cas
+  # existants observent.
+  bins: [az]
+  rules:
+    # La forme que `az_version` parse : il cherche la ligne contenant « azure-cli » et
+    # prend la valeur entre les quatrieme et cinquieme guillemets.
+    - match: { bin: az, args_include: ["version"] }
+      stdout: |
+        {
+          "azure-cli": "2.9.0",
+          "azure-cli-core": "2.9.0"
+        }
+    - match: {}
+      exit: 127
+      stderr: "the case did not foresee this call"
 expect:
   exit_code: 0
   stdout:

--- a/tests/cases/cli/cli-doctor-reports-its-own-binary.yaml
+++ b/tests/cases/cli/cli-doctor-reports-its-own-binary.yaml
@@ -13,9 +13,36 @@ setup:
   env:
     ZANVIL_DIR: "$HOME/zanvil"
   run: ["$GAVELDROP_PROJECT/cli/target/release/zanvil", "doctor"]
+fake:
+  # Declare pour les cas doctor seulement, ce que la 0.1.15 de gaveldrop permet. `az`
+  # etait le plus lent des trois outils que doctor interroge, et le seul a ecrire : chaque
+  # run deposait DOUZE fichiers sous .azure/ dans la racine isolee, dont la telemetrie
+  # Microsoft et un journal horodate. Les trois cas passaient de 11,4 s a 1,8 s.
+  #
+  # kubectl et helm restent reels : ils ne joignent personne pour rendre leur version, et
+  # leur presence ou absence sur un runner est ce que les cas existants observent.
+  bins: [az]
+  rules:
+    # La forme que `az_version` parse — il prend la valeur entre les 4e et 5e guillemets.
+    # La version tient en cinq caracteres exprès : doctor.rs tronque au-dela, donc un
+    # « 2.99.0 » ressortirait « 2.99. » et l assertion ci-dessous serait fausse pour une
+    # raison qui n a rien a voir avec ce qu elle verifie.
+    - match: { bin: az, args_include: ["version"] }
+      stdout: |
+        {
+          "azure-cli": "2.9.0",
+          "azure-cli-core": "2.9.0"
+        }
+    - match: {}
+      exit: 127
+      stderr: "the case did not foresee this call"
 expect:
   exit_code: 0
   stdout:
     # « Binaire » seul : la valeur qui suit depend de la machine — un poste equipe
     # affiche un chemin, un runner affiche l absence — mais la SECTION existe partout.
-    contains: ["Binaire"]
+    contains:
+      - "Binaire"
+      # La version que le faux annonce. Sans elle, un faux muet passerait aussi bien
+      # qu un faux qui repond : le cas ne prouverait pas que doctor a lu quelque chose.
+      - "2.9.0"

--- a/tests/cases/cli/cli-doctor-runs-on-an-isolated-home.yaml
+++ b/tests/cases/cli/cli-doctor-runs-on-an-isolated-home.yaml
@@ -6,6 +6,29 @@ setup:
   env:
     ZANVIL_DIR: "$HOME/zanvil"
   run: ["$GAVELDROP_PROJECT/cli/target/release/zanvil", "doctor"]
+fake:
+  # Declare pour ces trois cas seulement, ce que la 0.1.15 de gaveldrop permet. `az` est
+  # le plus lent des trois outils que doctor interroge, et le seul a ecrire : chaque run
+  # deposait DOUZE fichiers sous .azure/ dans la racine isolee, dont la telemetrie
+  # Microsoft et un journal horodate. Un test ne doit pas contacter un service externe
+  # pour verifier que doctor sait lire un numero de version.
+  #
+  # kubectl et helm sont laisses tels quels : ils ne joignent personne pour rendre leur
+  # version, et leur presence ou absence sur un runner est justement ce que les cas
+  # existants observent.
+  bins: [az]
+  rules:
+    # La forme que `az_version` parse : il cherche la ligne contenant « azure-cli » et
+    # prend la valeur entre les quatrieme et cinquieme guillemets.
+    - match: { bin: az, args_include: ["version"] }
+      stdout: |
+        {
+          "azure-cli": "2.9.0",
+          "azure-cli-core": "2.9.0"
+        }
+    - match: {}
+      exit: 127
+      stderr: "the case did not foresee this call"
 expect:
   exit_code: 0
   stdout:
@@ -19,4 +42,12 @@ expect:
     # a installe. Le cas passait sur ubuntu, qui a kubectl, et echouait sur macOS
     # qui ne l a pas. GITLAB et SECURITY n ont pas de binaire : leur symbole ne
     # depend que du config.zsh isole, ce que ce cas veut precisement prouver.
-    contains: ["Zanvil Doctor v", "Config", "GITLAB ✓", "SECURITY ○"]
+    contains:
+      - "Zanvil Doctor v"
+      - "Config"
+      - "GITLAB ✓"
+      - "SECURITY ○"
+      # La version que le faux `az` annonce. Sans cette ligne, un faux muet passerait
+      # aussi bien qu un faux qui repond : le cas ne prouverait pas que doctor a lu
+      # quelque chose.
+      - "2.9.0"

--- a/tests/cases/k9s-setup/k9s-setup-leaves-an-existing-plugins-file-alone.yaml
+++ b/tests/cases/k9s-setup/k9s-setup-leaves-an-existing-plugins-file-alone.yaml
@@ -1,0 +1,61 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# `kube_k9s_setup` ECRASAIT le plugins.yaml de l utilisateur, sans sauvegarde ni
+# avertissement : quiconque avait ses propres plugins k9s les perdait au premier appel. Le
+# defaut a ete trouve en construisant l installateur autonome du plugin de logs, qui a du
+# resoudre le meme probleme et l a resolu autrement.
+#
+# k9s lit `plugins.yaml` ET `plugins/*.yaml`. Le second format porte ses entrees A LA
+# RACINE, sans la cle `plugins:` — verifie en deposant une sonde et en lisant le journal de
+# k9s, qui refusait le fichier avec « Additional property plugins is not allowed ». Le
+# deploiement va donc dans plugins/zanvil.yaml, transforme, et ne touche plus a rien.
+#
+# ── Pourquoi la sortie et non `expect.files` ─────────────────────────────────────
+#
+# `_k9s_config_dir` rend « $HOME/Library/Application Support/k9s » sur macOS et
+# « $XDG_CONFIG_HOME/k9s » ailleurs. `expect.files` prend un chemin fixe, donc un cas qui
+# en nommerait un serait vrai sur une plateforme et trivialement vrai sur l autre — le
+# fichier n y existant pas, l assertion ne prouverait rien. La fonction est donc invoquee,
+# puis le cas lit ce qu elle a produit LA OU elle l a produit.
+name: k9s-setup-leaves-an-existing-plugins-file-alone
+weight: 9
+setup:
+  exec: ./tests/hooks/prepare-k9s-with-existing-plugins.sh
+  shell: zsh
+  # theme.zsh d abord : il definit _k9s_config_dir, que kube_config.zsh appelle sans la
+  # declarer — une dependance implicite entre un module et le core, que le loader satisfait
+  # par son ordre de chargement.
+  source: ["core/ui.zsh", "core/commands/theme.zsh", "modules/kube/kube_config.zsh"]
+  call: ["eval", "kube_k9s_setup >/dev/null 2>&1; d=$(_k9s_config_dir); printf 'DEPOSE:%s\\n' \"$(grep -m1 '^log-json-pod:' \"$d/plugins/zanvil.yaml\" 2>/dev/null)\"; printf 'CLE_RACINE:%s\\n' \"$(grep -c '^plugins:' \"$d/plugins/zanvil.yaml\" 2>/dev/null)\"; printf 'INTACT:%s\\n' \"$(grep -c 'mon-plugin-a-moi' \"$d/plugins.yaml\" 2>/dev/null)\"; kube_k9s_setup 2>&1 | grep -i 'plugins.yaml existe'"]
+  env:
+    ZANVIL_DIR: "$GAVELDROP_PROJECT"
+    ZANVIL_MODULE_KUBE: "true"
+fake:
+  # k9s doit exister pour que la fonction s execute, mais elle ne l invoque jamais : elle
+  # ne fait que deployer des fichiers de configuration.
+  bins: [k9s]
+  rules:
+    - match: {}
+      exit: 0
+expect:
+  exit_code: 0
+  stdout:
+    ignore_ansi: true
+    contains:
+      # Le plugin est bien depose, et A LA RACINE — sans indentation, donc au format que
+      # k9s attend dans plugins/*.yaml.
+      - "DEPOSE:log-json-pod:"
+      # Et sans la cle `plugins:`, que k9s refuse dans ce repertoire.
+      - "CLE_RACINE:0"
+      # Le fichier de l utilisateur porte toujours son plugin.
+      - "INTACT:1"
+      # Un plugins.yaml present est signale : k9s chargerait les deux et l un gagnerait
+      # sans le dire.
+      - "plugins.yaml existe"
+  not_written:
+    # Le coeur du correctif, dit sans passer par la sortie. Le hook cree les DEUX
+    # emplacements possibles, donc chacune de ces deux lignes porte sur un fichier qui
+    # existe reellement, sur macOS comme ailleurs — et « pas ecrit » y signifie « laisse
+    # tranquille » et non « jamais cree ».
+    - "$HOME/Library/Application Support/k9s/plugins.yaml"
+    - "$XDG_CONFIG_HOME/k9s/plugins.yaml"

--- a/tests/hooks/prepare-k9s-with-existing-plugins.sh
+++ b/tests/hooks/prepare-k9s-with-existing-plugins.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Depose un plugins.yaml k9s DEJA present, pour que le cas puisse prouver qu il survit.
+#
+# `not_written` ne dit rien de l existence : un fichier jamais cree n est pas ecrit, et un
+# fichier deja la et laisse tranquille non plus. Pour prouver qu une chose SURVIT, il faut
+# donc la creer d abord — c est ce que ce hook fait.
+set -eu
+
+cat >/dev/null   # drain de la charge setup
+
+SRC="$GAVELDROP_PROJECT"
+
+# Les deux emplacements possibles : la fonction rend l un ou l autre selon la plateforme,
+# et le hook ne sait pas lequel tournera. Les deux sont prepares.
+for d in "$HOME/Library/Application Support/k9s" "${XDG_CONFIG_HOME:-$HOME/.config}/k9s"; do
+    mkdir -p "$d"
+    cat >"$d/plugins.yaml" <<'YAML'
+plugins:
+  mon-plugin-a-moi:
+    shortCut: Ctrl-Y
+    description: Un plugin que l utilisateur avait avant zanvil
+    scopes: [po]
+    command: echo
+    args: [bonjour]
+YAML
+done


### PR DESCRIPTION
Les deux étapes suivantes après le merge de #108 et #109.

## 1. Les faux `az` — 11,4 s à 1,8 s

Les trois cas doctor invoquaient `az` pour de vrai. Le coût était double : **onze secondes** sur une suite qui en comptait trente, et **douze fichiers** déposés sous `.azure/` à chaque run — dont la télémétrie Microsoft et un journal horodaté. Un test ne doit pas contacter un service externe pour vérifier que `doctor` sait lire un numéro de version.

Déclaré **par cas** et non globalement, ce que la 0.1.15 de gaveldrop vient de permettre : c'est le deuxième usage de cette nouveauté après le cas de délégation, et il n'aurait pas été possible hier.

`kubectl` et `helm` restent réels — ils ne joignent personne pour rendre leur version, et leur présence sur un runner est ce que les cas existants observent.

**Deux cas assertent la version falsifiée**, sans quoi un faux muet passerait aussi bien qu'un faux qui répond. La version tient en cinq caractères exprès : `doctor.rs` tronque au-delà, donc un `2.99.0` ressortait `2.99.` et l'assertion échouait pour une raison étrangère à ce qu'elle vérifie.

**Mesure** : les trois cas de 11,4 s à 1,8 s, la suite entière de 15,6 s à **11,3 s**, et les cas doctor quittent le podium des plus lents.

## 2. `kube_k9s_setup` n'écrase plus rien

`sed … > "$k9s_dir/plugins.yaml"` : quiconque avait ses propres plugins k9s les perdait au premier appel, sans sauvegarde ni avertissement.

Le déploiement va désormais dans `plugins/zanvil.yaml`. **Le format diffère**, et c'est ce qui rendait le correctif non trivial : k9s lit les deux, mais `plugins/*.yaml` porte ses entrées **à la racine**, sans la clé `plugins:` — vérifié en déposant une sonde et en lisant son journal, qui refusait le fichier avec « Additional property plugins is not allowed ».

Un `plugins.yaml` présent est désormais **signalé**, parce que k9s charge les deux et l'un gagne sans le dire.

### Le cas asserte par la sortie, et pourquoi

`_k9s_config_dir` rend `$HOME/Library/Application Support/k9s` sur macOS et `$XDG_CONFIG_HOME/k9s` ailleurs. Un cas nommant un chemin fixe dans `expect.files` serait vrai sur une plateforme et **trivialement** vrai sur l'autre. Il invoque donc la fonction, puis lit ce qu'elle a produit là où elle l'a produit.

`not_written` porte quand même le cœur du correctif, sur les **deux** chemins possibles : le hook les crée tous les deux, donc chaque ligne porte sur un fichier réel et « pas écrit » y signifie « laissé tranquille » et non « jamais créé ». C'est l'usage que gaveldrop décrivait pour cette clé.

Vérifié par mutation en restaurant l'écrasement : `INTACT:0` — le plugin de l'utilisateur disparaît — et `not_written` dit « **modified, 4875 bytes** », donc modifié et non créé.

## Au passage

`_k9s_config_dir` est définie dans `core/commands/theme.zsh` et appelée depuis `modules/kube/kube_config.zsh` sans y être déclarée. Le loader satisfait cette dépendance par son ordre de chargement, mais elle est implicite — le cas a dû sourcer les deux fichiers pour tourner.

## Vérification

**92 cas, 444/444**, avec le binaire installé comme sans. Deux suites bash vertes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)