### PR TITLE
feat(work): work_config_repo — audit et mise aux normes des repos de config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ web/docs/superpowers
 # Faux HOME des tests de chargement (test_load.sh)
 .fakehome/
 modules/work/logs/
+
+# Espace de travail SDD (scratch, jamais versionne)
+.superpowers/

--- a/modules/work/.lazy
+++ b/modules/work/.lazy
@@ -7,3 +7,4 @@ work_es_query
 work_es_apps
 work_es_count
 work_es_tail
+work_config_repo

--- a/modules/work/completions.zsh
+++ b/modules/work/completions.zsh
@@ -67,3 +67,15 @@ _work_es_tail() {
         '--interval[Intervalle de poll en secondes (defaut 5, min 2)]:secondes:(2 5 10 30)'
 }
 compdef _work_es_tail work_es_tail
+
+_work_config_repo() {
+    _arguments \
+        '--bu[Business unit]:bu:(blg edt udb tsc shared)' \
+        '--app[Application]:app:' \
+        '--envs[Sous-ensemble d envs, separes par des virgules]:envs:(dev dev,qlf dev,qlf,pprd dev,qlf,pprd,prd)' \
+        '--readme[Autorise la reecriture des README preexistants]' \
+        '--fix[Applique les corrections au lieu d auditer]' \
+        '(-h --help)'{-h,--help}'[Afficher l aide]' \
+        '1:repo de configuration:'
+}
+compdef _work_config_repo work_config_repo

--- a/modules/work/config_repos.zsh
+++ b/modules/work/config_repos.zsh
@@ -1,0 +1,988 @@
+# ==============================================================================
+# Work Config Repos — creation et mise aux normes des repos de configuration
+# ==============================================================================
+# Spec : web/docs/superpowers/specs/2026-08-07-work-config-repos-design.md
+#
+# Le coeur de ce fichier est `_work_cfg_build_plan` : une fonction pure qui recoit
+# l etat d un repo et rend une liste d actions. Tout le reste — collecte, rendu,
+# application — est mince autour d elle, et c est delibere : la norme est la seule
+# chose qui merite d etre testee, et elle ne doit pas dependre du reseau pour l etre.
+
+# --- Norme, en dur (surchargeable au runtime par --envs, jamais persistee) ---
+
+typeset -ga _WORK_CFG_ENVS_ALL=(dev qlf pprd prd)
+typeset -ga _WORK_CFG_ENVS_PROTECTED=(pprd prd)
+typeset -ga _WORK_CFG_BU_ALL=(blg edt udb tsc shared)
+typeset -g  _WORK_CFG_PUSH_LEVEL=40      # Maintainers
+typeset -g  _WORK_CFG_MERGE_LEVEL=40     # Maintainers
+
+# --- Chemin canonique ---
+
+# Decompose un chemin absolu en bu/app/repo.
+# Usage : _work_cfg_parse_path <chemin>
+# Sortie : "<bu>\t<app>\t<repo>". Return 1 si le chemin ne suit pas la forme
+#          $WORK_DIR/<bu>/applications/<app>/configurations/<repo>.
+#
+# L arite stricte a cinq segments ecarte d elle-meme les chemins sous companion/,
+# qui en comptent six. Le message dedie est rendu par _work_cfg_guard_target.
+_work_cfg_parse_path() {
+    local p="${1:-}"
+    local root="${WORK_DIR:-$HOME/work}"
+    [[ -n "$p" && "$p" == "$root"/* ]] || return 1
+
+    local rel="${p#$root/}"
+    local -a parts
+    parts=(${(s:/:)rel})
+
+    (( ${#parts} == 5 )) || return 1
+    [[ "$parts[2]" == applications ]] || return 1
+    [[ "$parts[4]" == configurations ]] || return 1
+    (( ${_WORK_CFG_BU_ALL[(Ie)$parts[1]]} )) || return 1
+
+    print -r -- "$parts[1]	$parts[3]	$parts[5]"
+    return 0
+}
+
+# --- Refus durs ---
+
+# Refuse une cible hors perimetre. Aucun appel reseau, jamais.
+# Usage : _work_cfg_guard_target <bu> <app> <repo>
+_work_cfg_guard_target() {
+    local bu="${1:-}" app="${2:-}" repo="${3:-}"
+
+    if ! (( ${_WORK_CFG_BU_ALL[(Ie)$bu]} )); then
+        _ui_msg_fail "BU inconnue : « ${bu:-<vide>} » (attendu : ${_WORK_CFG_BU_ALL})"
+        return 1
+    fi
+    if [[ -z "$app" ]]; then
+        _ui_msg_fail "application non determinee — passer --app, ou se placer dans le chemin canonique"
+        return 1
+    fi
+    if [[ -z "$repo" ]]; then
+        _ui_msg_fail "repo non determine — le passer en argument, ou se placer dans le chemin canonique"
+        return 1
+    fi
+    # technical-assets appartient a une autre chaine de responsabilite et n a pas la
+    # topologie de la norme : l auditer produirait des ecarts qu il ne faut pas corriger.
+    if [[ "$repo" == technical-assets ]]; then
+        _ui_msg_fail "technical-assets est hors perimetre — ni ecriture, ni audit"
+        return 1
+    fi
+    if [[ "$repo" == companion || "$repo" == companion/* ]]; then
+        _ui_msg_fail "le sous-groupe companion est hors perimetre"
+        return 1
+    fi
+    return 0
+}
+
+# --- Envs et norme derivee ---
+
+# Normalise une liste d envs : espaces retires, doublons ecartes, ordre canonique
+# retabli (dev < qlf < pprd < prd). L ordre de frappe n a donc aucune importance.
+# Usage : _work_cfg_normalize_envs "prd,dev"  ->  "dev,prd"
+# Return 1 si la liste est vide ou contient un env hors norme.
+_work_cfg_normalize_envs() {
+    local csv="${1:-}"
+    local -a wanted out e
+    wanted=(${(s:,:)csv})
+    wanted=(${wanted//[[:space:]]/})
+    wanted=(${wanted:#})
+
+    (( ${#wanted} )) || { _ui_msg_fail "liste d envs vide"; return 1 }
+
+    for e in $wanted; do
+        if ! (( ${_WORK_CFG_ENVS_ALL[(Ie)$e]} )); then
+            _ui_msg_fail "env inconnu : « $e » (attendu : ${_WORK_CFG_ENVS_ALL})"
+            return 1
+        fi
+    done
+
+    # On itere sur la norme, pas sur la saisie : l ordre canonique en decoule.
+    for e in $_WORK_CFG_ENVS_ALL; do
+        (( ${wanted[(Ie)$e]} )) && out+=($e)
+    done
+
+    print -r -- "${(j:,:)out}"
+    return 0
+}
+
+# La branche par defaut attendue est la premiere env de la liste normalisee.
+# Sur la norme complete c est dev ; sur --envs qlf,prd c est qlf.
+_work_cfg_expected_default() {
+    local -a envs
+    envs=(${(s:,:)${1:-}})
+    print -r -- "${envs[1]:-}"
+}
+
+# La protection se decide par NOM de branche, pas par rang dans la liste.
+_work_cfg_env_is_protected() {
+    (( ${_WORK_CFG_ENVS_PROTECTED[(Ie)${1:-}]} ))
+}
+
+# Contenu attendu du README d une branche d env : un titre H1, une ligne, rien d autre.
+_work_cfg_readme_content() {
+    print -r -- "# ${1} ${2}"
+}
+
+# --- Planificateur ---
+
+# Construit la liste des actions a partir d un etat, sans aucun appel reseau.
+#
+# Usage : _work_cfg_build_plan <repo> <envs_csv> <readme_optin> <default_branch> \
+#                              <branches> <rules> <readmes>
+#   branches : une branche par ligne
+#   rules    : nom<TAB>push<TAB>merge<TAB>force
+#   readmes  : branche<TAB>ok|absent|divergent
+#
+# Sortie : une action par ligne, champs separes par TAB. L ordre d emission est
+# stable — les tests comparent des sorties entieres, et l ordre d application en
+# depend (cf. _work_cfg_apply).
+_work_cfg_build_plan() {
+    local repo="$1" envs_csv="$2" readme_optin="$3" default_branch="$4"
+    local branches_raw="$5" rules_raw="$6" readmes_raw="$7"
+
+    local -a envs branches created
+    envs=(${(s:,:)envs_csv})
+    branches=(${(f)branches_raw})
+    branches=(${branches:#})
+
+    local -A rule_push rule_merge rule_force has_rule readme_state
+    local line nom f2 f3 f4
+    for line in ${(f)rules_raw}; do
+        [[ -z "$line" ]] && continue
+        IFS=$'\t' read -r nom f2 f3 f4 <<< "$line"
+        has_rule[$nom]=1; rule_push[$nom]="$f2"; rule_merge[$nom]="$f3"; rule_force[$nom]="$f4"
+    done
+    for line in ${(f)readmes_raw}; do
+        [[ -z "$line" ]] && continue
+        IFS=$'\t' read -r nom f2 <<< "$line"
+        readme_state[$nom]="$f2"
+    done
+
+    local expected_default e b
+    expected_default=$(_work_cfg_expected_default "$envs_csv")
+    local source_branch="${default_branch:-$expected_default}"
+
+    # 1. branches d env manquantes, derivees du defaut courant
+    for e in $envs; do
+        if ! (( ${branches[(Ie)$e]} )); then
+            print -r -- "branch_create	$e	$source_branch"
+            created+=($e)
+        fi
+    done
+
+    # 2. branche par defaut
+    [[ "$default_branch" != "$expected_default" ]] && print -r -- "default_set	$expected_default"
+
+    # 3-4. protections, par nom de branche
+    for e in $envs; do
+        if _work_cfg_env_is_protected "$e"; then
+            if (( ! ${+has_rule[$e]} )); then
+                print -r -- "protect_create	$e"
+            elif [[ "$rule_push[$e]" != "$_WORK_CFG_PUSH_LEVEL" || \
+                    "$rule_merge[$e]" != "$_WORK_CFG_MERGE_LEVEL" ]]; then
+                # GitLab CE ne sait pas modifier un niveau d acces par PATCH :
+                # DELETE puis POST, donc une breve fenetre de non-protection.
+                print -r -- "protect_replace	$e"
+            elif [[ "$rule_force[$e]" != false ]]; then
+                print -r -- "protect_patch	$e"
+            fi
+        else
+            (( ${+has_rule[$e]} )) && print -r -- "unprotect	$e"
+        fi
+    done
+
+    # 5. regles orphelines. Une regle dont la branche va etre creee par ce plan
+    #    n est PAS orpheline : elle deviendra une protection legitime.
+    for nom in ${(ok)has_rule}; do
+        (( ${branches[(Ie)$nom]} )) && continue
+        (( ${created[(Ie)$nom]} )) && continue
+        print -r -- "rule_delete_orphan	$nom"
+    done
+
+    # 6. README. D office sur ce que ce run vient de creer — la branche derive de
+    #    dev et porte donc le README de dev, il n y a rien a ecraser. Sur une
+    #    branche preexistante, un README ABSENT n ecrase rien non plus : il est
+    #    ecrit sans --readme. Seul un contenu qui existe deja et DIVERGE reste
+    #    opt-in — c est lui, et lui seul, que --readme protege de l ecrasement.
+    #    Sans cette distinction, --fix seul ne peut jamais amener aux normes un
+    #    depot depourvu de README, ce qui est le cas de tous les depots existants.
+    for e in $envs; do
+        if (( ${created[(Ie)$e]} )); then
+            print -r -- "readme_write	$e"
+        elif [[ "${readme_state[$e]:-ok}" == absent ]]; then
+            print -r -- "readme_write	$e"
+        elif [[ "${readme_state[$e]:-ok}" == divergent ]]; then
+            if [[ "$readme_optin" == 1 ]]; then
+                print -r -- "readme_write	$e"
+            else
+                print -r -- "ecart	README de $e ${readme_state[$e]} — relancer avec --readme"
+            fi
+        fi
+    done
+
+    # 7. branches hors norme. master/main sont candidates a la suppression ;
+    #    tout le reste est conserve. demo-borne porte des config/* vivantes et
+    #    demo-bff une feature/* : une regle « supprimer le hors-norme » les tuerait.
+    for b in $branches; do
+        (( ${envs[(Ie)$b]} )) && continue
+        if [[ "$b" == master || "$b" == main ]]; then
+            print -r -- "master_delete	$b"
+        else
+            print -r -- "warn	branche hors norme conservee : $b"
+        fi
+    done
+}
+
+# --- Couche reseau ---
+#
+# Calquee sur _work_es_curl / _work_es_json. Une difference assumee avec
+# modules/gitlab/gitlab_logic.zsh : pas de -k. Verifie le 2026-08-07, la forge
+# repond 200 sans desactiver la verification TLS — desactiver par precaution
+# reviendrait a accepter n importe quel certificat pour rien.
+
+_work_cfg_api() {
+    print -r -- "https://${GITLAB_BASE_DOMAIN}/api/v4"
+}
+
+# Encode un chemin de projet ou de groupe pour l API (les / deviennent %2F).
+_work_cfg_enc() {
+    print -r -- "${1//\//%2F}"
+}
+
+_work_cfg_require() {
+    if ! command -v curl &>/dev/null; then
+        _ui_msg_fail "curl requis"; return 1
+    fi
+    if ! command -v jq &>/dev/null; then
+        _ui_msg_fail "jq requis (brew install jq / apt install jq)"; return 1
+    fi
+    if [[ -z "${GITLAB_TOKEN:-}" && -f "$HOME/.gitlab_secrets" ]]; then
+        source "$HOME/.gitlab_secrets"
+    fi
+    if [[ -z "${GITLAB_BASE_DOMAIN:-}" ]]; then
+        _ui_msg_fail "GITLAB_BASE_DOMAIN non definie (voir ~/.gitlab_secrets)"; return 1
+    fi
+    if [[ -z "${GITLAB_TOKEN:-}" ]]; then
+        _ui_msg_fail "GITLAB_TOKEN non defini (voir ~/.gitlab_secrets)"; return 1
+    fi
+    return 0
+}
+
+# Usage : _work_cfg_curl METHOD PATH [BODY]
+# Sortie : 1re ligne = code HTTP, reste = corps. Return = code de sortie curl.
+_work_cfg_curl() {
+    local method=$1 api_path=$2 body="${3:-}"
+    local -a opts
+    opts=(-s --connect-timeout 5 --max-time 30 -X "$method")
+    [[ -n "${SSL_CERT_FILE:-}" ]] && opts+=(--cacert "$SSL_CERT_FILE")
+    opts+=(-H "PRIVATE-TOKEN: $GITLAB_TOKEN" -H 'Content-Type: application/json')
+    [[ -n "$body" ]] && opts+=(-d "$body")
+
+    local out ret
+    out=$(command curl "${opts[@]}" -w $'\n%{http_code}' "$(_work_cfg_api)/$api_path" 2>/dev/null)
+    ret=$?
+    (( ret != 0 )) && return $ret
+    print -r -- "${out##*$'\n'}"
+    local resp="${out%$'\n'*}"
+    [[ "$resp" != "$out" && -n "$resp" ]] && print -r -- "$resp"
+    return 0
+}
+
+# Usage : _work_cfg_json METHOD PATH [BODY]
+# Sortie : rien sur stdout. Return 1 en cas d echec, avec la cause dans
+# _work_cfg_last_error — un « echec » nu ne dit pas si c est le VPN, le token
+# ou le chemin qui est en cause, et les trois envoient a des endroits opposes.
+#
+# Le corps de la reponse va dans la globale _work_cfg_body, PAS sur stdout.
+# Une substitution de commande $( ) est un sous-shell : un `typeset -g` qui y
+# est pose est jete au retour, donc _work_cfg_last_error ne survivait jamais
+# a un appel captant le corps (`x=$(_work_cfg_json ...)`). En sortant le corps
+# par une globale, les deux appelants — celui qui veut le corps et celui qui
+# ne veut que le code de retour — lisent la meme fonction sans sous-shell.
+_work_cfg_json() {
+    typeset -g _work_cfg_last_error="" _work_cfg_body=""
+    local out code rc
+    out=$(_work_cfg_curl "$@"); rc=$?
+    if (( rc != 0 )); then
+        case $rc in
+            6)  _work_cfg_last_error="hote introuvable (DNS) — VPN actif ?" ;;
+            7)  _work_cfg_last_error="connexion refusee" ;;
+            28) _work_cfg_last_error="delai depasse" ;;
+            35|60) _work_cfg_last_error="echec TLS — SSL_CERT_FILE pointe-t-il le bundle d entreprise ?" ;;
+            *)  _work_cfg_last_error="curl a rendu $rc" ;;
+        esac
+        return 1
+    fi
+    code="${out%%$'\n'*}"
+    if [[ "$code" != <-> ]]; then
+        _work_cfg_last_error="reponse sans code HTTP — un proxy s est interpose ?"
+        return 1
+    fi
+    if (( code >= 400 )); then
+        case $code in
+            401) _work_cfg_last_error="HTTP 401 — GITLAB_TOKEN refuse" ;;
+            403) _work_cfg_last_error="HTTP 403 — droits insuffisants (Maintainer requis sur les branches protegees)" ;;
+            404) _work_cfg_last_error="HTTP 404 — ressource introuvable" ;;
+            *)   _work_cfg_last_error="HTTP $code" ;;
+        esac
+        # Le corps de la reponse peut refleter les en-tetes de la requete — un portail
+        # d entreprise interpose le fait parfois, et ce module anticipe deja ce genre
+        # d interposition. Le token n a rien a faire dans un message qu un appelant
+        # affichera ou journalisera.
+        if [[ "$out" == *$'\n'* ]]; then
+            local _snippet; _snippet=$(print -r -- "${out#*$'\n'}" | head -c 300)
+            [[ -n "${GITLAB_TOKEN:-}" ]] && _snippet="${_snippet//$GITLAB_TOKEN/<token masque>}"
+            _work_cfg_last_error+=" : $_snippet"
+        fi
+        return 1
+    fi
+    [[ "$out" == *$'\n'* ]] && _work_cfg_body="${out#*$'\n'}"
+    return 0
+}
+
+# --- Collecte de l etat distant ---
+
+# Remplit les globales decrivant l etat du repo. Return 2 si le projet n existe pas.
+_work_cfg_collect() {
+    local bu="$1" app="$2" repo="$3" envs_csv="$4"
+    typeset -g _work_cfg_pid="" _work_cfg_default="" \
+               _work_cfg_branches="" _work_cfg_rules="" _work_cfg_readmes=""
+
+    local full="$bu/applications/$app/configurations/$repo"
+    local enc; enc=$(_work_cfg_enc "$full")
+
+    local proj
+    if ! _work_cfg_json GET "projects/$enc"; then
+        [[ "$_work_cfg_last_error" == HTTP\ 404* ]] && return 2
+        _ui_msg_fail "lecture du projet : $_work_cfg_last_error"
+        return 1
+    fi
+    proj="$_work_cfg_body"
+    _work_cfg_pid=$(print -r -- "$proj" | jq -r '.id')
+    _work_cfg_default=$(print -r -- "$proj" | jq -r '.default_branch // ""')
+
+    local br rules
+    _work_cfg_json GET "projects/$_work_cfg_pid/repository/branches?per_page=100" || {
+        _ui_msg_fail "lecture des branches : $_work_cfg_last_error"; return 1
+    }
+    br="$_work_cfg_body"
+    _work_cfg_branches=$(print -r -- "$br" | jq -r '.[].name')
+
+    _work_cfg_json GET "projects/$_work_cfg_pid/protected_branches?per_page=100" || {
+        _ui_msg_fail "lecture des protections : $_work_cfg_last_error"; return 1
+    }
+    rules="$_work_cfg_body"
+    _work_cfg_rules=$(print -r -- "$rules" | jq -r '
+        .[] | [ .name,
+                (.push_access_levels[0].access_level  // "0" | tostring),
+                (.merge_access_levels[0].access_level // "0" | tostring),
+                (.allow_force_push | tostring) ] | @tsv')
+
+    # Etat des README, une lecture par branche d env existante.
+    local -a envs; envs=(${(s:,:)envs_csv})
+    local e want got code raw
+    for e in $envs; do
+        print -r -- "$_work_cfg_branches" | grep -qx -- "$e" || continue
+        want=$(_work_cfg_readme_content "$repo" "$e")
+        raw=$(_work_cfg_curl GET "projects/$_work_cfg_pid/repository/files/README%2Emd/raw?ref=$e")
+        if (( $? != 0 )); then
+            _ui_msg_fail "lecture du README de $e : appel reseau en echec"
+            return 1
+        fi
+        code="${raw%%$'\n'*}"
+        case "$code" in
+            404) _work_cfg_readmes+="$e	absent"$'\n' ;;
+            200)
+                got="${raw#*$'\n'}"
+                if [[ "${got%$'\n'}" == "$want" ]]; then
+                    _work_cfg_readmes+="$e	ok"$'\n'
+                else
+                    _work_cfg_readmes+="$e	divergent"$'\n'
+                fi ;;
+            *)
+                # Ne jamais traduire un echec reseau ou un refus en « divergent ».
+                # Sous --fix --readme, un incident VPN ou un 403 ferait alors ecraser
+                # un README qui n avait rien de divergent : un diagnostic errone
+                # deviendrait une ecriture.
+                _ui_msg_fail "lecture du README de $e : HTTP ${code:-<aucun code>}"
+                return 1 ;;
+        esac
+    done
+    return 0
+}
+
+# --- Rendu ---
+
+# Compte les actions reelles d un plan : ni `warn` ni `ecart` n en sont.
+_work_cfg_count_actions() {
+    local line n=0
+    for line in ${(f)${1:-}}; do
+        [[ -z "$line" ]] && continue
+        case "${line%%	*}" in warn|ecart) continue ;; esac
+        (( n++ ))
+    done
+    print -r -- "$n"
+}
+
+# Compte les ecarts que ce run ne corrige pas. Ils ne produisent aucune action, mais
+# ils interdisent d annoncer la conformite : un README absent EST un ecart au sens du
+# controle 6 de la spec, seule sa CORRECTION est conditionnee a --readme. Sans cette
+# distinction, un depot sans aucun README rendait 0 en affichant « conforme » juste
+# sous la liste de ses propres ecarts.
+_work_cfg_count_ecarts() {
+    local line n=0
+    for line in ${(f)${1:-}}; do
+        [[ "${line%%	*}" == ecart ]] && (( n++ ))
+    done
+    print -r -- "$n"
+}
+
+# Rend un plan en texte lisible. Fonction pure : aucune lecture distante.
+_work_cfg_render() {
+    local repo="$1" plan="$2"
+    local line kind a b n n_ec
+    n=$(_work_cfg_count_actions "$plan")
+    n_ec=$(_work_cfg_count_ecarts "$plan")
+
+    if (( n == 0 )); then
+        for line in ${(f)plan}; do
+            [[ -z "$line" ]] && continue
+            IFS=$'\t' read -r kind a b <<< "$line"
+            case "$kind" in
+                ecart) print -r -- "  ${_ui_yellow}!${_ui_nc} $a" ;;
+                warn)  print -r -- "  ${_ui_yellow}!${_ui_nc} $a" ;;
+            esac
+        done
+        if (( n_ec > 0 )); then
+            print -r -- "  Aucune action applicable — $n_ec ecart(s) exigent --readme."
+        else
+            print -r -- "  Rien a faire — le repo est conforme."
+        fi
+        return 0
+    fi
+
+    print -r -- "${_ui_bold}Plan ($n actions)${_ui_nc}"
+    for line in ${(f)plan}; do
+        [[ -z "$line" ]] && continue
+        IFS=$'\t' read -r kind a b <<< "$line"
+        case "$kind" in
+            branch_create) print -r -- "  + creer branche $a depuis $b" ;;
+            default_set)   print -r -- "  ~ basculer la branche par defaut sur $a" ;;
+            protect_create) print -r -- "  + proteger $a (Maintainers/Maintainers, force=off)" ;;
+            protect_replace) print -r -- "  ~ remplacer la protection de $a — breve fenetre de non-protection (GitLab CE)" ;;
+            protect_patch) print -r -- "  ~ desactiver allow_force_push sur $a" ;;
+            unprotect)     print -r -- "  - deproteger $a" ;;
+            rule_delete_orphan) print -r -- "  - supprimer la regle orpheline « $a »" ;;
+            readme_write)  print -r -- "  ~ README de $a → « $(_work_cfg_readme_content "$repo" "$a") »" ;;
+            master_delete) print -r -- "  - supprimer $a (sa protection sera retiree), sous reserve du merge-base" ;;
+            ecart)         print -r -- "  ${_ui_yellow}!${_ui_nc} $a" ;;
+            warn)          print -r -- "  ${_ui_yellow}!${_ui_nc} $a" ;;
+        esac
+    done
+    return 0
+}
+
+# --- Point d entree ---
+
+_work_cfg_usage() {
+    print -r -- "Usage: work_config_repo [<repo>] [options]"
+    print -r -- ""
+    print -r -- "  Audite un repo de configuration, ou le met aux normes avec --fix."
+    print -r -- "  Sans argument, la cible est deduite du repertoire courant."
+    print -r -- ""
+    print -r -- "  --bu <${(j:|:)_WORK_CFG_BU_ALL}>"
+    print -r -- "  --app <nom>              application"
+    print -r -- "  --envs <csv>             sous-ensemble d envs (defaut: ${(j:,:)_WORK_CFG_ENVS_ALL})"
+    print -r -- "  --readme                 autorise la reecriture des README preexistants"
+    print -r -- "  --fix                    applique ; sans lui, audit en lecture seule"
+    print -r -- "  -h, --help               cette aide"
+    print -r -- ""
+    print -r -- "  Codes de sortie : 0 conforme ou corrige, 1 erreur, 2 ecarts detectes."
+}
+
+work_config_repo() {
+    local bu="" app="" repo="" envs_csv="" readme_optin=0 do_fix=0 envs_given=0
+
+    while (( $# )); do
+        case "$1" in
+            --bu)
+                (( $# >= 2 )) || { _ui_msg_fail "--bu attend une valeur"; return 1 }
+                bu="$2"; shift 2 ;;
+            --app)
+                (( $# >= 2 )) || { _ui_msg_fail "--app attend une valeur"; return 1 }
+                app="$2"; shift 2 ;;
+            --envs)
+                (( $# >= 2 )) || { _ui_msg_fail "--envs attend une valeur"; return 1 }
+                envs_csv="$2"; envs_given=1; shift 2 ;;
+            --readme) readme_optin=1; shift ;;
+            --fix)    do_fix=1; shift ;;
+            -h|--help) _work_cfg_usage; return 0 ;;
+            -*) _ui_msg_fail "option inconnue : $1"; _work_cfg_usage; return 1 ;;
+            *)  repo="$1"; shift ;;
+        esac
+    done
+
+    # Deduction depuis le repertoire courant pour ce qui n a pas ete passe.
+    if [[ -z "$bu" || -z "$app" || -z "$repo" ]]; then
+        local parsed p_bu p_app p_repo
+        if parsed=$(_work_cfg_parse_path "$PWD"); then
+            IFS=$'\t' read -r p_bu p_app p_repo <<< "$parsed"
+            [[ -z "$bu" ]]   && bu="$p_bu"
+            [[ -z "$app" ]]  && app="$p_app"
+            [[ -z "$repo" ]] && repo="$p_repo"
+        fi
+    fi
+
+    _work_cfg_guard_target "$bu" "$app" "$repo" || return 1
+
+    # Absence de --envs vaut la norme complete ; une valeur explicitement vide est une
+    # erreur. ${x:-y} confondrait les deux et ferait passer `--envs ""` pour un defaut.
+    (( envs_given )) || envs_csv="${(j:,:)_WORK_CFG_ENVS_ALL}"
+
+    # _ui_msg_fail ecrit sur stdout (core/ui.zsh), donc capturer la sortie de
+    # _work_cfg_normalize_envs avale aussi son message d erreur. On le reemet avant
+    # de rendre la main : sans cela, `--envs uat` echoue sans rien dire.
+    local _envs_norm
+    _envs_norm=$(_work_cfg_normalize_envs "$envs_csv") || { print -r -- "$_envs_norm"; return 1 }
+    envs_csv="$_envs_norm"
+
+    _work_cfg_run "$bu" "$app" "$repo" "$envs_csv" "$readme_optin" "$do_fix"
+}
+
+# --- Orchestration ---
+
+_work_cfg_run() {
+    local bu="$1" app="$2" repo="$3" envs_csv="$4" readme_optin="$5" do_fix="$6"
+
+    # master_delete lit cette globale pour connaitre sa cible de merge-base. La
+    # renseigner ici, avant tout chemin qui pourrait mener a _work_cfg_apply,
+    # garantit qu elle n est jamais vide au moment ou la garde en a besoin.
+    typeset -g _work_cfg_envs_current="$envs_csv"
+
+    _work_cfg_require || return 1
+
+    _ui_header "Repo de configuration"
+    _ui_section "Cible" "$bu/applications/$app/configurations/$repo"
+    _ui_section "Envs" "$envs_csv"
+
+    local rc; _work_cfg_collect "$bu" "$app" "$repo" "$envs_csv"; rc=$?
+    (( rc == 1 )) && return 1
+    if (( rc == 2 )); then
+        _ui_msg_warn "le projet n existe pas encore sur la forge"
+        (( do_fix )) || { _ui_msg_info "relancer avec --fix pour le creer"; return 2 }
+        _work_cfg_create "$bu" "$app" "$repo" "$envs_csv"
+        return $?
+    fi
+
+    local plan
+    plan=$(_work_cfg_build_plan "$repo" "$envs_csv" "$readme_optin" "$_work_cfg_default" \
+            "$_work_cfg_branches" "$_work_cfg_rules" "$_work_cfg_readmes")
+
+    echo ""
+    _work_cfg_render "$repo" "$plan"
+
+    # Un ecart sans action possible interdit le code 0 : la spec reserve 0 a
+    # « conforme ou corrige ». Un depot dont tous les README manquent n est pas
+    # conforme, meme si le corriger exige --readme.
+    local n n_ec
+    n=$(_work_cfg_count_actions "$plan")
+    n_ec=$(_work_cfg_count_ecarts "$plan")
+    (( n == 0 && n_ec == 0 )) && return 0
+    (( n == 0 )) && return 2
+    (( do_fix )) || return 2
+
+    _work_cfg_confirm_and_apply "$repo" "$envs_csv" "$readme_optin" "$plan"
+}
+
+# --- Dialogue de confirmation ---
+
+# Lit la reponse au prompt. Tout ce qui n est pas y ou u vaut non — y compris
+# une entree vide et un stdin ferme. Une execution non interactive ne doit jamais
+# appliquer quoi que ce soit par defaut.
+_work_cfg_read_answer() {
+    local ans
+    if ! read -r ans; then
+        print -r -- "n"; return 0
+    fi
+    case "${(L)ans}" in
+        y|yes|o|oui) print -r -- "y" ;;
+        u|update)    print -r -- "u" ;;
+        *)           print -r -- "n" ;;
+    esac
+}
+
+# Boucle de confirmation. `u` recalcule le plan avec une nouvelle liste d envs et
+# repropose : le sous-ensemble n est jamais persiste nulle part.
+_work_cfg_confirm_and_apply() {
+    local repo="$1" envs_csv="$2" readme_optin="$3" plan="$4"
+
+    while true; do
+        echo ""
+        print -n -- "Appliquer ? [y/N/u] "
+        local ans; ans=$(_work_cfg_read_answer)
+
+        case "$ans" in
+            y) _work_cfg_apply "$repo" "$plan"; return $? ;;
+            n) _ui_msg_info "rien n a ete ecrit"; return 2 ;;
+            u)
+                print -n -- "Quels envs ? (${(j:,:)_WORK_CFG_ENVS_ALL}) "
+                local raw; read -r raw || raw=""
+                local new_envs
+                # _ui_msg_fail ecrit sur stdout, donc la capture avale la plainte.
+                # Sans ce reemis, une saisie fautive fait juste reapparaitre le
+                # prompt, muet : l utilisateur ne sait pas ce qu on lui reproche.
+                new_envs=$(_work_cfg_normalize_envs "$raw") || { print -r -- "$new_envs"; continue }
+                envs_csv="$new_envs"
+                # Le sous-ensemble recalcule ici doit rester la cible vue par
+                # master_delete : sans cette remise a jour, une restriction
+                # d envs via `u` laisserait la garde viser l ancien defaut.
+                typeset -g _work_cfg_envs_current="$envs_csv"
+                _ui_section "Envs" "$envs_csv"
+                plan=$(_work_cfg_build_plan "$repo" "$envs_csv" "$readme_optin" \
+                        "$_work_cfg_default" "$_work_cfg_branches" "$_work_cfg_rules" \
+                        "$_work_cfg_readmes")
+                echo ""
+                _work_cfg_render "$repo" "$plan"
+                (( $(_work_cfg_count_actions "$plan") == 0 )) && \
+                    { (( $(_work_cfg_count_ecarts "$plan") == 0 )) && return 0 || return 2 }
+                ;;
+        esac
+    done
+}
+
+# --- Application ---
+
+# Une branche n est supprimable que si son sommet est deja contenu dans la cible.
+# Fonction pure, isolee pour etre testable : c est la seule garde entre un
+# `master` reprenant des commits absents de `dev` et leur perte.
+_work_cfg_sha_contained() {
+    [[ -n "${1:-}" && -n "${2:-}" && "$1" == "$2" ]]
+}
+
+# Return 0 si <branche> est deja contenue dans <cible>.
+# Return 1 si elle porte des commits absents de la cible.
+# Return 2 si la question n a pas pu etre posee (reseau, droits, reponse inattendue).
+#
+# La distinction 1/2 n est pas cosmetique. Rendre 1 sur un VPN coupe reviendrait a
+# annoncer « master porte des commits absents de dev » — factuellement faux — et a
+# jeter le code HTTP que _work_cfg_last_error contient. C est la seule etape du plan
+# qui decide d une suppression : elle doit dire quand elle ne sait pas.
+_work_cfg_is_merged() {
+    local pid="$1" src="$2" dst="$3" sha base
+    local esrc edst
+    esrc=$(_work_cfg_enc "$src"); edst=$(_work_cfg_enc "$dst")
+
+    _work_cfg_json GET "projects/$pid/repository/branches/$esrc" || return 2
+    sha=$(print -r -- "$_work_cfg_body" | jq -r '.commit.id // ""')
+    # `|| return 2` sur le jq qui precede ne peut jamais se declencher : jq rend 0
+    # grace au `// ""`, meme sur une reponse sans .commit.id. sha resterait vide et
+    # la suite lirait ca comme des SHA differents — un return 1 (« porte des commits
+    # absents ») quand la verite est « je n ai pas pu savoir ». Le test explicite
+    # distingue les deux.
+    [[ -n "$sha" && "$sha" != null ]] || return 2
+    _work_cfg_json GET "projects/$pid/repository/merge_base?refs%5B%5D=$esrc&refs%5B%5D=$edst" || return 2
+    base=$(print -r -- "$_work_cfg_body" | jq -r '.id // ""')
+    [[ -n "$base" && "$base" != null ]] || return 2
+
+    _work_cfg_sha_contained "$sha" "$base"
+}
+
+# Remet le plan dans l ordre d application. L API impose deux contraintes qui se
+# croisent — on ne supprime pas la branche par defaut, on ne supprime pas une
+# branche protegee — et les README doivent etre ecrits avant que les protections
+# ne soient posees, sinon un repo neuf bute sur ses propres regles.
+_work_cfg_sort_plan() {
+    local -a order
+    order=(branch_create default_set unprotect readme_write protect_create
+           protect_replace protect_patch rule_delete_orphan master_delete ecart warn)
+    local kind line
+    for kind in $order; do
+        for line in ${(f)${1:-}}; do
+            [[ -z "$line" ]] && continue
+            [[ "${line%%	*}" == "$kind" ]] && print -r -- "$line"
+        done
+    done
+}
+
+# Execute le plan. S arrete a la premiere erreur : appliquer la suite d un plan
+# dont une etape a echoue laisserait le repo dans un etat qu aucun des deux
+# rapports ne decrit.
+_work_cfg_apply() {
+    local repo="$1" plan="$2"
+    local pid="$_work_cfg_pid"
+    local line kind a b ea
+    local survivants=0
+
+    # Les guillemets autour de la substitution ne sont pas decoratifs. Sans eux,
+    # ${(f)$(...)} decoupe D ABORD sur IFS : tabulations et retours ligne deviennent
+    # des espaces avant que (f) ne s applique. La boucle tourne alors une seule fois
+    # sur le plan entier aplati, aucun case ne matche, et la fonction rend 0 sans
+    # avoir rien applique — un « corrige » mensonger sur la seule etape qui ecrit.
+    for line in ${(f)"$(_work_cfg_sort_plan "$plan")"}; do
+        [[ -z "$line" ]] && continue
+        IFS=$'\t' read -r kind a b <<< "$line"
+        # Un nom de branche ou de regle peut porter un / — et une regle de protection
+        # GitLab peut etre un joker (release/*). Non encode, il ajoute un segment de
+        # chemin et la route ne s apparie plus.
+        ea=$(_work_cfg_enc "$a")
+        case "$kind" in
+            branch_create)
+                _work_cfg_json POST "projects/$pid/repository/branches?branch=$a&ref=$b" \
+                    || { _ui_msg_fail "creation de $a : $_work_cfg_last_error"; return 1 }
+                _ui_msg_ok "branche $a creee depuis $b" ;;
+            default_set)
+                # Corps construit par jq, comme les autres : $a est un nom de branche
+                # normalise par ce module, mais rien ne justifie que ce corps reste le
+                # seul construit par interpolation brute.
+                local _body_defset
+                _body_defset=$(jq -n --arg br "$a" '{default_branch:$br}') \
+                    || { _ui_msg_fail "construction du corps de bascule sur $a"; return 1 }
+                _work_cfg_json PUT "projects/$pid" "$_body_defset" \
+                    || { _ui_msg_fail "bascule du defaut sur $a : $_work_cfg_last_error"; return 1 }
+                _ui_msg_ok "branche par defaut : $a" ;;
+            unprotect)
+                _work_cfg_json DELETE "projects/$pid/protected_branches/$ea" \
+                    || { _ui_msg_fail "deprotection de $a : $_work_cfg_last_error"; return 1 }
+                _ui_msg_ok "$a deprotegee" ;;
+            readme_write)
+                _work_cfg_write_readme "$pid" "$repo" "$a" || return 1 ;;
+            protect_create)
+                _work_cfg_protect "$pid" "$a" || return 1 ;;
+            protect_replace)
+                # L avertissement annonce une fenetre BREVE, pas une deprotection
+                # definitive : si le POST qui suit echoue, il faut le dire aussi
+                # explicitement que master_delete le dit plus bas, sinon $a reste
+                # deprotegee en silence et l avertissement se lit comme une
+                # reassurance fausse.
+                _ui_msg_warn "$a : fenetre de non-protection le temps du remplacement"
+                _work_cfg_json DELETE "projects/$pid/protected_branches/$ea" \
+                    || { _ui_msg_fail "retrait de la protection de $a : $_work_cfg_last_error"; return 1 }
+                _work_cfg_protect "$pid" "$a" || {
+                    _ui_msg_fail "$a est restee DEPROTEGEE — la reproteger a la main"
+                    return 1
+                } ;;
+            protect_patch)
+                _work_cfg_json PATCH "projects/$pid/protected_branches/$ea" \
+                    '{"allow_force_push":false}' \
+                    || { _ui_msg_fail "allow_force_push sur $a : $_work_cfg_last_error"; return 1 }
+                _ui_msg_ok "$a : allow_force_push desactive" ;;
+            rule_delete_orphan)
+                _work_cfg_json DELETE "projects/$pid/protected_branches/$ea" \
+                    || { _ui_msg_fail "suppression de la regle « $a » : $_work_cfg_last_error"; return 1 }
+                _ui_msg_ok "regle orpheline « $a » supprimee" ;;
+            master_delete)
+                local target merged deprotegee=0
+                target=$(_work_cfg_expected_default "$_work_cfg_envs_current")
+                _work_cfg_is_merged "$pid" "$a" "$target"; merged=$?
+
+                if (( merged == 2 )); then
+                    _ui_msg_fail "$a : merge-base inverifiable — $_work_cfg_last_error"
+                    _ui_msg_info "aucune suppression tentee"
+                    return 1
+                fi
+                if (( merged != 0 )); then
+                    _ui_msg_warn "$a NON supprimee : elle porte des commits absents de $target"
+                    survivants=1
+                    continue
+                fi
+
+                # Retirer la protection fait partie de la suppression : l API refuse
+                # de supprimer une branche protegee. On l annonce, au lieu de le faire
+                # en silence — si la suppression echoue ensuite, master resterait
+                # exposee et personne ne le saurait.
+                if _work_cfg_json DELETE "projects/$pid/protected_branches/$ea"; then
+                    deprotegee=1
+                    _ui_msg_warn "$a : protection retiree pour permettre la suppression"
+                fi
+                if ! _work_cfg_json DELETE "projects/$pid/repository/branches/$ea"; then
+                    _ui_msg_fail "suppression de $a : $_work_cfg_last_error"
+                    (( deprotegee )) && _ui_msg_fail "$a est restee DEPROTEGEE — la reproteger a la main"
+                    return 1
+                fi
+                _ui_msg_ok "$a supprimee (contenu repris dans $target)" ;;
+            ecart|warn)
+                _ui_msg_warn "$a" ;;
+        esac
+    done
+    # Un ecart non corrige survit a l application, et une master conservee aussi.
+    # Rendre 0 dirait « corrige » d un depot qui ne l est pas ; la spec reserve 0
+    # a « conforme ou corrige ».
+    (( survivants )) && return 2
+    (( $(_work_cfg_count_ecarts "$plan") > 0 )) && return 2
+    return 0
+}
+
+_work_cfg_protect() {
+    local pid="$1" br="$2"
+    _work_cfg_json POST "projects/$pid/protected_branches?name=$br&push_access_level=$_WORK_CFG_PUSH_LEVEL&merge_access_level=$_WORK_CFG_MERGE_LEVEL&allow_force_push=false" \
+        || { _ui_msg_fail "protection de $br : $_work_cfg_last_error"; return 1 }
+    _ui_msg_ok "$br protegee (Maintainers/Maintainers, force=off)"
+    return 0
+}
+
+# Ecrit le README d une branche. Cree ou met a jour selon ce qui existe deja.
+# Sur une branche protegee, le commit part sous l identite du token : Maintainer,
+# il passe ; sinon GitLab rend 403 et on le dit. On ne deprotege jamais pour se
+# faire de la place.
+_work_cfg_write_readme() {
+    local pid="$1" repo="$2" br="$3"
+    local content; content=$(_work_cfg_readme_content "$repo" "$br")
+    local action=create
+    local probe; probe=$(_work_cfg_curl GET "projects/$pid/repository/files/README%2Emd?ref=$br")
+    [[ "${probe%%$'\n'*}" == 200 ]] && action=update
+
+    # Corps construit par jq, comme celui de la creation. $repo et $br viennent d une
+    # saisie utilisateur que _work_cfg_guard_target ne valide que sur la non-vacuite :
+    # interpoler l un ou l autre dans du JSON les laisse fabriquer des cles.
+    local body
+    body=$(jq -n --arg br "$br" --arg act "$action" --arg content "$content" \
+                 --arg msg "chore: normalise le README ($repo $br)" \
+        '{branch:$br, commit_message:$msg,
+          actions:[{action:$act, file_path:"README.md", content:$content}]}') \
+        || { _ui_msg_fail "construction du commit README de $br"; return 1 }
+
+    _work_cfg_json POST "projects/$pid/repository/commits" "$body" \
+        || { _ui_msg_fail "README de $br : $_work_cfg_last_error"; return 1 }
+    _ui_msg_ok "README de $br normalise"
+    return 0
+}
+
+# --- Creation ---
+
+# Chemin canonique local, pur : aucun acces disque, aucun reseau.
+# Usage : _work_cfg_local_path <bu> <app> <repo>
+_work_cfg_local_path() {
+    print -r -- "${WORK_DIR:-$HOME/work}/$1/applications/$2/configurations/$3"
+}
+
+# Cree le projet, ses branches, ses protections, puis le clone au chemin canonique.
+# Le groupe `configurations` n est JAMAIS cree : une frappe fautive doit echouer,
+# pas laisser un groupe orphelin sur la forge.
+_work_cfg_create() {
+    local bu="$1" app="$2" repo="$3" envs_csv="$4"
+    local -a envs; envs=(${(s:,:)envs_csv})
+    local grp="$bu/applications/$app/configurations"
+    local enc; enc=$(_work_cfg_enc "$grp")
+
+    # Ne PAS ecrire `_work_cfg_json ... | jq ... || { ... }` : le code de sortie d un
+    # pipeline zsh est celui de sa DERNIERE commande, et PIPE_FAIL n est arme nulle
+    # part dans ce projet. jq rend 0 sur une entree vide, donc la branche d erreur ne
+    # partirait jamais et $_work_cfg_last_error serait perdu — un 404 ou un VPN coupe
+    # passerait pour un groupe trouve mais sans identifiant.
+    local gid raw_grp
+    _work_cfg_json GET "groups/$enc" || {
+        _ui_msg_fail "groupe $grp introuvable : $_work_cfg_last_error"
+        _ui_msg_info "ce groupe n est pas cree automatiquement — le creer sur la forge d abord"
+        return 1
+    }
+    raw_grp="$_work_cfg_body"
+    gid=$(print -r -- "$raw_grp" | jq -r '.id // ""')
+    [[ -n "$gid" ]] || { _ui_msg_fail "groupe $grp introuvable"; return 1 }
+
+    local default_env="${envs[1]}"
+    local dest; dest=$(_work_cfg_local_path "$bu" "$app" "$repo")
+
+    # Le groupe existe : a partir d ici, le prochain appel ECRIT. La spec ouvre sa
+    # section creation par « une fois le plan accepte » — jusqu ici rien ne le
+    # demandait, donc un nom de repo mal tape sous --fix creait un projet, quatre
+    # branches, deux regles, le clone, et deplacait le shell dans le clone, sans
+    # qu aucun y explicite ait ete tape. Le plan affiche rend visible la cible
+    # exacte (donc une paire --bu/cwd incoherente) avant que quoi que ce soit
+    # n existe sur la forge.
+    echo ""
+    print -r -- "${_ui_bold}Plan de creation${_ui_nc}"
+    _ui_section "Chemin distant" "$grp/$repo"
+    _ui_section "Envs" "$envs_csv"
+    _ui_section "Visibilite" "internal"
+    _ui_section "Branche defaut" "$default_env"
+    _ui_section "Chemin local" "$dest"
+    echo ""
+    print -n -- "Creer ? [y/N] "
+    local ans; ans=$(_work_cfg_read_answer)
+    if [[ "$ans" != y ]]; then
+        _ui_msg_info "rien n a ete cree"
+        return 2
+    fi
+
+    # Corps construit par jq, pas par interpolation. `_work_cfg_guard_target` ne
+    # valide que la non-vacuite du nom : un repo contenant un guillemet injecterait
+    # des cles arbitraires dans le seul appel qui cree de l etat distant. Le module
+    # echappe deja correctement le contenu des README (jq -Rs) ; il n y a aucune
+    # raison que la creation soit la seule exception.
+    local body proj
+    body=$(jq -n --arg name "$repo" --arg path "$repo" \
+                 --argjson nsid "$gid" --arg def "$default_env" \
+        '{name:$name, path:$path, namespace_id:$nsid, visibility:"internal",
+          default_branch:$def, initialize_with_readme:true}') \
+        || { _ui_msg_fail "construction du corps de creation"; return 1 }
+
+    _work_cfg_json POST projects "$body" \
+        || { _ui_msg_fail "creation du projet : $_work_cfg_last_error"; return 1 }
+    proj="$_work_cfg_body"
+
+    typeset -g _work_cfg_pid; _work_cfg_pid=$(print -r -- "$proj" | jq -r '.id')
+    _ui_msg_ok "projet $grp/$repo cree"
+
+    # A partir d ici, le projet EXISTE sur la forge. Toute sortie en erreur doit le
+    # dire : sinon l utilisateur lit « HTTP 403 » et ignore qu un projet a ete cree,
+    # qu il est reparable, et que son clone local n arrivera jamais tout seul — le
+    # clone ne vit que dans ce chemin de creation, jamais dans celui de l audit.
+    local url
+    url=$(print -r -- "$proj" | jq -r '.http_url_to_repo')
+
+    _work_cfg_write_readme "$_work_cfg_pid" "$repo" "$default_env" \
+        || { _work_cfg_create_partiel "$grp" "$repo" "$url" "$dest"; return 1 }
+
+    local e
+    for e in ${envs[2,-1]}; do
+        _work_cfg_json POST "projects/$_work_cfg_pid/repository/branches?branch=$e&ref=$default_env" \
+            || { _ui_msg_fail "creation de $e : $_work_cfg_last_error"
+                 _work_cfg_create_partiel "$grp" "$repo" "$url" "$dest"; return 1 }
+        _ui_msg_ok "branche $e creee depuis $default_env"
+        _work_cfg_write_readme "$_work_cfg_pid" "$repo" "$e" \
+            || { _work_cfg_create_partiel "$grp" "$repo" "$url" "$dest"; return 1 }
+    done
+
+    # Les protections viennent apres les README : l inverse ferait buter les commits
+    # sur les regles qu on vient d ecrire.
+    for e in $envs; do
+        _work_cfg_env_is_protected "$e" || continue
+        _work_cfg_protect "$_work_cfg_pid" "$e" \
+            || { _work_cfg_create_partiel "$grp" "$repo" "$url" "$dest"; return 1 }
+    done
+
+    mkdir -p "${dest:h}" \
+        || { _ui_msg_fail "creation de ${dest:h}"
+             _work_cfg_create_partiel "$grp" "$repo" "$url" "$dest"; return 1 }
+
+    # Meme mecanique d authentification que scripts/clone-projects.sh : un `git clone`
+    # nu sur une URL interne invite un prompt (ou echoue net en non-interactif), au
+    # milieu d une sequence qui a deja cree du projet, des branches et des regles
+    # sur la forge.
+    if ! git -c "http.extraheader=PRIVATE-TOKEN: $GITLAB_TOKEN" clone "$url" "$dest"; then
+        _ui_msg_fail "clone en echec"
+        _work_cfg_create_partiel "$grp" "$repo" "$url" "$dest"
+        _ui_msg_info "si $dest existe deja et n est pas vide, le vider ou cloner ailleurs"
+        return 1
+    fi
+    _ui_msg_ok "clone : $dest"
+
+    # Un cd qui echoue ne doit pas passer pour un succes silencieux : l utilisateur
+    # a lu « clone : ... » et se croirait dans le depot.
+    cd "$dest" || _ui_msg_warn "clone fait, mais cd impossible vers $dest"
+    return 0
+}
+
+# Nomme l etat distant quand la sequence de creation s arrete en chemin, et la
+# facon d en sortir. Les deux sont necessaires : la reprise par --fix repare le
+# distant, mais elle ne clonera jamais — le clone n existe que dans la creation.
+_work_cfg_create_partiel() {
+    local grp="$1" repo="$2" url="$3" dest="$4"
+    # Volontairement neutre sur l etat d avancement : ce helper sert aussi bien apres
+    # un echec distant qu apres un echec de mkdir ou de clone, ou le distant est
+    # complet. Annoncer « incomplet » serait faux dans la moitie des cas.
+    _ui_msg_info "le projet $grp/$repo existe desormais sur la forge"
+    _ui_msg_info "verifier ou terminer la mise aux normes : work_config_repo --fix $repo"
+    _ui_msg_info "recuperer le clone local   : git -c \"http.extraheader=PRIVATE-TOKEN: \$GITLAB_TOKEN\" clone $url $dest"
+}

--- a/modules/work/init.zsh
+++ b/modules/work/init.zsh
@@ -1,2 +1,3 @@
 source "$ZANVIL_DIR/modules/work/work_context.zsh"
 source "$ZANVIL_DIR/modules/work/elasticsearch.zsh"
+source "$ZANVIL_DIR/modules/work/config_repos.zsh"

--- a/scripts/tests/work-config-repos.test.sh
+++ b/scripts/tests/work-config-repos.test.sh
@@ -1,0 +1,835 @@
+#!/usr/bin/env bash
+# Verifie work_config_repo : chemin canonique, refus durs, normalisation des envs,
+# et le planificateur pur. Aucun appel reseau.
+# Usage : scripts/tests/work-config-repos.test.sh
+#
+# Les cas sont synthetiques : zanvil est public, aucune nomenclature interne reelle
+# n a sa place ici.
+set -uo pipefail
+
+ROOT="${ZANVIL_DIR:-$HOME/.zanvil}"
+MOD="$ROOT/modules/work/config_repos.zsh"
+
+TEST_TMPDIR=$(mktemp -d) || { echo "mktemp failed" >&2; exit 2; }
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+echo 0 > "$TEST_TMPDIR/pass"
+echo 0 > "$TEST_TMPDIR/fail"
+
+assert_equals() {
+    local label="$1" needle="$2" out
+    out=$(cat)
+    if [[ "$out" == "$needle" ]]; then
+        printf '  ok   %s\n' "$label"
+        echo $(($(cat "$TEST_TMPDIR/pass") + 1)) > "$TEST_TMPDIR/pass"
+    else
+        printf '  FAIL %s\n       attendu : %s\n       obtenu  : %s\n' \
+            "$label" "$needle" "$out"
+        echo $(($(cat "$TEST_TMPDIR/fail") + 1)) > "$TEST_TMPDIR/fail"
+    fi
+}
+
+# Lance une expression zsh avec ui.zsh et le module charges, WORK_DIR maitrise.
+zc() {
+    zsh -f -c "
+        WORK_DIR='$TEST_TMPDIR/work'
+        source '$ROOT/core/ui.zsh' >/dev/null 2>&1
+        source '$MOD'
+        $1
+    " 2>&1
+}
+
+echo "== chemin canonique =="
+
+zc '_work_cfg_parse_path "$WORK_DIR/blg/applications/demoapp/configurations/demo-front"' \
+    | assert_equals "chemin canonique decompose" "$(printf 'blg\tdemoapp\tdemo-front')"
+
+zc '_work_cfg_parse_path "$WORK_DIR/blg/application/demoapp/configurations/demo-front" || print refuse' \
+    | assert_equals "application au singulier refuse" "refuse"
+
+zc '_work_cfg_parse_path "$WORK_DIR/xxx/applications/demoapp/configurations/demo-front" || print refuse' \
+    | assert_equals "BU inconnue refusee" "refuse"
+
+zc '_work_cfg_parse_path "$WORK_DIR/blg/applications/demoapp/components/demo-front" || print refuse' \
+    | assert_equals "hors groupe configurations refuse" "refuse"
+
+zc '_work_cfg_parse_path "$WORK_DIR/blg/applications/demoapp/configurations/companion/app" || print refuse' \
+    | assert_equals "chemin companion refuse" "refuse"
+
+zc '_work_cfg_parse_path "/ailleurs/blg/applications/demoapp/configurations/demo-front" || print refuse' \
+    | assert_equals "hors WORK_DIR refuse" "refuse"
+
+echo
+echo "== refus durs, sans reseau =="
+
+zc '_work_cfg_guard_target blg demoapp demo-front && print ok' \
+    | assert_equals "cible legitime acceptee" "ok"
+
+zc '_work_cfg_guard_target blg demoapp technical-assets >/dev/null 2>&1 || print refuse' \
+    | assert_equals "technical-assets refuse" "refuse"
+
+zc '_work_cfg_guard_target blg demoapp companion >/dev/null 2>&1 || print refuse' \
+    | assert_equals "companion refuse" "refuse"
+
+zc '_work_cfg_guard_target xxx demoapp demo-front >/dev/null 2>&1 || print refuse' \
+    | assert_equals "BU inconnue refusee au garde" "refuse"
+
+zc '_work_cfg_guard_target blg "" demo-front >/dev/null 2>&1 || print refuse' \
+    | assert_equals "app vide refusee" "refuse"
+
+zc '_work_cfg_guard_target blg demoapp "" >/dev/null 2>&1 || print refuse' \
+    | assert_equals "repo vide refuse" "refuse"
+
+# Le refus doit tomber AVANT tout appel reseau. Un curl factice depose un marqueur :
+# comparer la sortie ne suffirait pas, _ui_msg_fail ecrit sur stdout (core/ui.zsh:202)
+# comme tout le projet, donc son message se melerait a ce qu on mesure.
+# Limite assumee : un `command curl` contournerait ce stub. La garde vaut pour les
+# appels passant par le nom, ce qui suffit a detecter une regression de structure.
+zc 'marker="${TMPDIR:-/tmp}/work-cfg-curl-called.$$"
+    rm -f "$marker"
+    curl() { print called >> "$marker" }
+    _work_cfg_guard_target blg demoapp technical-assets >/dev/null 2>&1
+    rc=$?
+    if [[ -f "$marker" ]]; then reseau=oui; else reseau=non; fi
+    rm -f "$marker"
+    print "rc=$rc reseau=$reseau"' \
+    | assert_equals "technical-assets refuse sans toucher au reseau" "rc=1 reseau=non"
+
+echo
+echo "== normalisation des envs =="
+
+zc '_work_cfg_normalize_envs "prd,dev"' \
+    | assert_equals "ordre canonique retabli" "dev,prd"
+
+zc '_work_cfg_normalize_envs "dev,dev,qlf"' \
+    | assert_equals "doublons ecartes" "dev,qlf"
+
+zc '_work_cfg_normalize_envs ""  >/dev/null 2>&1 || print refuse' \
+    | assert_equals "liste vide refusee" "refuse"
+
+zc '_work_cfg_normalize_envs "dev,uat" >/dev/null 2>&1 || print refuse' \
+    | assert_equals "env inconnu refuse" "refuse"
+
+zc '_work_cfg_normalize_envs "dev, qlf "' \
+    | assert_equals "espaces autour des valeurs tolerees" "dev,qlf"
+
+echo
+echo "== norme derivee =="
+
+zc '_work_cfg_expected_default "dev,qlf,pprd,prd"' \
+    | assert_equals "defaut attendu sur la norme complete" "dev"
+
+zc '_work_cfg_expected_default "qlf,prd"' \
+    | assert_equals "defaut attendu sans dev" "qlf"
+
+zc '_work_cfg_env_is_protected prd && print oui || print non' \
+    | assert_equals "prd protegee" "oui"
+
+zc '_work_cfg_env_is_protected pprd && print oui || print non' \
+    | assert_equals "pprd protegee" "oui"
+
+zc '_work_cfg_env_is_protected dev && print oui || print non' \
+    | assert_equals "dev non protegee" "non"
+
+zc '_work_cfg_env_is_protected qlf && print oui || print non' \
+    | assert_equals "qlf non protegee" "non"
+
+echo
+echo "== contenu README =="
+
+zc '_work_cfg_readme_content demo-front dev' \
+    | assert_equals "README en H1, une ligne" "# demo-front dev"
+
+zc '_work_cfg_readme_content demo-front prd | wc -l | tr -d " "' \
+    | assert_equals "README fait exactement une ligne" "1"
+
+echo
+echo "== planificateur : repo conforme =="
+
+# demo-front conforme : 4 branches, defaut dev, pprd et prd protegees 40/40/false.
+zc 'br=$(print -l dev qlf pprd prd)
+    rules=$(printf "pprd\t40\t40\tfalse\nprd\t40\t40\tfalse")
+    rm=$(printf "dev\tok\nqlf\tok\npprd\tok\nprd\tok")
+    _work_cfg_build_plan demo-front dev,qlf,pprd,prd 0 dev "$br" "$rules" "$rm" | wc -l | tr -d " "' \
+    | assert_equals "repo conforme : aucune action" "0"
+
+echo
+echo "== planificateur : deux branches d env absentes =="
+
+# demo-docs : dev (defaut) et prd existent ; regles pprd et prd deja conformes.
+zc 'br=$(print -l dev prd)
+    rules=$(printf "pprd\t40\t40\tfalse\nprd\t40\t40\tfalse")
+    rm=$(printf "dev\tok\nprd\tok")
+    _work_cfg_build_plan demo-docs dev,qlf,pprd,prd 0 dev "$br" "$rules" "$rm"' \
+    | assert_equals "norme complete : creations + README d office" \
+"$(printf 'branch_create\tqlf\tdev\nbranch_create\tpprd\tdev\nreadme_write\tqlf\nreadme_write\tpprd')"
+
+# La regle pprd n est PAS orpheline quand le plan cree la branche pprd.
+zc 'br=$(print -l dev prd)
+    rules=$(printf "pprd\t40\t40\tfalse\nprd\t40\t40\tfalse")
+    rm=$(printf "dev\tok\nprd\tok")
+    _work_cfg_build_plan demo-docs dev,qlf,pprd,prd 0 dev "$br" "$rules" "$rm" \
+      | grep -c rule_delete_orphan' \
+    | assert_equals "regle dont la branche va etre creee : pas orpheline" "0"
+
+# Restreindre a dev,qlf rend la regle pprd orpheline et sort prd du perimetre.
+zc 'br=$(print -l dev prd)
+    rules=$(printf "pprd\t40\t40\tfalse\nprd\t40\t40\tfalse")
+    rm=$(printf "dev\tok\nprd\tok")
+    _work_cfg_build_plan demo-docs dev,qlf 0 dev "$br" "$rules" "$rm"' \
+    | assert_equals "envs restreints : orpheline detectee, prd conservee" \
+"$(printf 'branch_create\tqlf\tdev\nrule_delete_orphan\tpprd\nreadme_write\tqlf\nwarn\tbranche hors norme conservee : prd')"
+
+echo
+echo "== planificateur : protections =="
+
+zc 'br=$(print -l dev prd); rm=$(printf "dev\tok\nprd\tok")
+    _work_cfg_build_plan demo-x dev,prd 0 dev "$br" "" "$rm"' \
+    | assert_equals "regle absente sur prd : creation" "$(printf 'protect_create\tprd')"
+
+zc 'br=$(print -l dev prd); rm=$(printf "dev\tok\nprd\tok")
+    rules=$(printf "prd\t30\t40\tfalse")
+    _work_cfg_build_plan demo-x dev,prd 0 dev "$br" "$rules" "$rm"' \
+    | assert_equals "niveau d acces divergent : remplacement" "$(printf 'protect_replace\tprd')"
+
+zc 'br=$(print -l dev prd); rm=$(printf "dev\tok\nprd\tok")
+    rules=$(printf "prd\t40\t40\ttrue")
+    _work_cfg_build_plan demo-x dev,prd 0 dev "$br" "$rules" "$rm"' \
+    | assert_equals "seul allow_force_push divergent : patch" "$(printf 'protect_patch\tprd')"
+
+zc 'br=$(print -l dev qlf); rm=$(printf "dev\tok\nqlf\tok")
+    rules=$(printf "qlf\t40\t40\tfalse")
+    _work_cfg_build_plan demo-x dev,qlf 0 dev "$br" "$rules" "$rm"' \
+    | assert_equals "qlf protegee a tort : deprotection" "$(printf 'unprotect\tqlf')"
+
+echo
+echo "== planificateur : README opt-in =="
+
+zc 'rm=$(printf "dev\tdivergent")
+    _work_cfg_build_plan demo-x dev 0 dev "dev" "" "$rm"' \
+    | assert_equals "README preexistant divergent sans --readme : averti, pas ecrit" \
+"$(printf 'ecart\tREADME de dev divergent — relancer avec --readme')"
+
+zc 'rm=$(printf "dev\tdivergent")
+    _work_cfg_build_plan demo-x dev 1 dev "dev" "" "$rm"' \
+    | assert_equals "README preexistant divergent avec --readme : ecrit" \
+"$(printf 'readme_write\tdev')"
+
+zc 'rm=$(printf "dev\tok")
+    _work_cfg_build_plan demo-x dev,qlf 0 dev "dev" "" "$rm" | grep readme_write' \
+    | assert_equals "branche creee dans le run : README ecrit sans --readme" \
+"$(printf 'readme_write\tqlf')"
+
+# Un README ABSENT sur une branche preexistante n ecrase rien : il est ecrit
+# SANS --readme, contrairement a un contenu qui existe deja et diverge. La spec
+# le precise depuis sa correction du 2026-08-10 (commit 125f9f9) — sans cette
+# distinction, --fix seul ne peut jamais amener aux normes un depot qui n a
+# jamais eu de README, ce qui est le cas de tous les depots existants.
+zc 'rm=$(printf "dev\tabsent")
+    _work_cfg_build_plan demo-x dev 0 dev "dev" "" "$rm"' \
+    | assert_equals "README preexistant ABSENT sans --readme : ecrit quand meme" \
+"$(printf 'readme_write\tdev')"
+
+echo
+echo "== planificateur : branches hors norme =="
+
+zc 'br=$(print -l master dev qlf pprd prd)
+    rules=$(printf "pprd\t40\t40\tfalse\nprd\t40\t40\tfalse")
+    rm=$(printf "dev\tok\nqlf\tok\npprd\tok\nprd\tok")
+    _work_cfg_build_plan demo-x dev,qlf,pprd,prd 0 master "$br" "$rules" "$rm"' \
+    | assert_equals "master : bascule du defaut puis suppression" \
+"$(printf 'default_set\tdev\nmaster_delete\tmaster')"
+
+zc 'br=$(print -l dev feature/x config/y unprotected); rm=$(printf "dev\tok")
+    _work_cfg_build_plan demo-x dev 0 dev "$br" "" "$rm"' \
+    | assert_equals "feature/config/unprotected : conservees, signalees" \
+"$(printf 'warn\tbranche hors norme conservee : feature/x\nwarn\tbranche hors norme conservee : config/y\nwarn\tbranche hors norme conservee : unprotected')"
+
+echo
+echo "== appartenance litterale, pas de glob =="
+
+# [(I) traite le motif comme un glob ; [(Ie) le traite comme une chaine litterale.
+# Sans le e, "p*" matcherait pprd au lieu d etre rejete comme env inconnu.
+zc '_work_cfg_normalize_envs "p*" >/dev/null 2>&1 || print refuse' \
+    | assert_equals "motif p* rejete : comparaison litterale, pas de glob" "refuse"
+
+# Une regle de protection nommee config/* (un joker GitLab valide) ne doit pas
+# etre appariee par glob a la branche config/y : elle reste orpheline tant
+# qu aucune branche ne porte litteralement ce nom.
+zc 'br=$(print -l dev config/y)
+    rules=$(printf "config/*\t40\t40\tfalse")
+    rm=$(printf "dev\tok")
+    pat=$(printf "rule_delete_orphan\tconfig/*")
+    _work_cfg_build_plan demo-x dev 0 dev "$br" "$rules" "$rm" | grep -Fc "$pat"' \
+    | assert_equals "regle config/* : orpheline malgre config/y (comparaison litterale)" "1"
+
+echo
+echo "== parsing d options =="
+
+zc 'work_config_repo --help | head -1' \
+    | assert_equals "aide disponible" "Usage: work_config_repo [<repo>] [options]"
+
+# Le piege zsh : un flag a valeur en dernier argument. Sous `set -u` en bash, shift 2
+# echoue ; en zsh il boucle a l infini. Le timeout est la garde du test.
+# _ui_msg_fail ecrit sur stdout (core/ui.zsh, cf. plus haut) : rediriger seulement
+# stderr laisserait fuiter son message et head -1 capturerait la mauvaise ligne.
+( zc 'work_config_repo --envs >/dev/null 2>&1; print "rc=$?"' & sleep 5; kill %1 2>/dev/null ) \
+    | head -1 | assert_equals "--envs en dernier argument ne boucle pas" "rc=1"
+
+( zc 'work_config_repo --bu >/dev/null 2>&1; print "rc=$?"' & sleep 5; kill %1 2>/dev/null ) \
+    | head -1 | assert_equals "--bu en dernier argument ne boucle pas" "rc=1"
+
+zc 'work_config_repo --bu blg --app demoapp technical-assets >/dev/null 2>&1; print "rc=$?"' \
+    | assert_equals "technical-assets nomme explicitement : rc=1" "rc=1"
+
+zc 'work_config_repo --zzz >/dev/null 2>&1; print "rc=$?"' \
+    | assert_equals "option inconnue : rc=1" "rc=1"
+
+zc 'work_config_repo --bu blg --app demoapp --envs uat demo-x >/dev/null 2>&1; print "rc=$?"' \
+    | assert_equals "env inconnu : rc=1" "rc=1"
+
+# Hors du chemin canonique et sans flags : refus, sans reseau.
+zc 'cd "$TMPDIR" 2>/dev/null || cd /
+    work_config_repo >/dev/null 2>&1; print "rc=$?"' \
+    | assert_equals "cible indeterminable : rc=1" "rc=1"
+
+echo
+echo "== la cause d un refus est dite =="
+
+# _work_cfg_normalize_envs echoue via un $( ) : sans reemission explicite du
+# message par work_config_repo, --envs uat echouerait en silence (rc=1 mais
+# rien sur stdout). On ne redirige pas stdout ici, c est justement ce qu on mesure.
+zc 'work_config_repo --bu blg --app demoapp --envs uat demo-x 2>/dev/null | grep -c "env inconnu"' \
+    | assert_equals "cause du refus --envs uat affichee" "1"
+
+# ${envs_csv:-defaut} confondrait --envs absent et --envs "" : la valeur vide
+# explicite doit rester une erreur, pas retomber sur la norme complete.
+zc 'work_config_repo --bu blg --app demoapp --envs "" demo-x >/dev/null 2>&1; print "rc=$?"' \
+    | assert_equals "--envs vide explicitement refuse" "rc=1"
+
+echo
+echo "== couche reseau =="
+
+zc '_work_cfg_enc "blg/applications/demoapp/configurations/demo-front"' \
+    | assert_equals "chemin encode pour l API" "blg%2Fapplications%2Fdemoapp%2Fconfigurations%2Fdemo-front"
+
+zc 'GITLAB_BASE_DOMAIN=forge.exemple.test; _work_cfg_api' \
+    | assert_equals "URL de l API construite" "https://forge.exemple.test/api/v4"
+
+zc 'unset GITLAB_BASE_DOMAIN GITLAB_TOKEN
+    HOME=$TMPDIR
+    _work_cfg_require >/dev/null 2>&1; print "rc=$?"' \
+    | assert_equals "sans domaine ni token : refus" "rc=1"
+
+# Le point qui compte : hors reseau, la commande echoue vite, elle ne pend pas.
+zc 'GITLAB_BASE_DOMAIN=127.0.0.1:9 GITLAB_TOKEN=x
+    SECONDS=0
+    _work_cfg_json GET version >/dev/null 2>&1
+    rc=$?
+    print "rc=$rc borne=$(( SECONDS <= 10 ))"' \
+    | assert_equals "hote injoignable : echec immediat, pas de pendaison" "rc=1 borne=1"
+
+zc 'GITLAB_BASE_DOMAIN=127.0.0.1:9 GITLAB_TOKEN=x
+    _work_cfg_json GET version >/dev/null 2>&1
+    [[ -n "$_work_cfg_last_error" ]] && print renseigne || print vide' \
+    | assert_equals "la cause de l echec est nommee" "renseigne"
+
+# Pas de -k : la commande ne doit jamais desactiver la verification TLS.
+# grep -c -- '-k' matcherait n importe quel "-k" y compris a l interieur d un
+# mot ou dans un commentaire qui en parle (le fichier en contient un qui
+# documente justement l absence du flag). On ecarte les lignes de commentaire
+# pur et on exige que -k/--insecure soit un token isole, pas un fragment.
+grep -v '^[[:space:]]*#' "$MOD" \
+    | grep -cE -- '(^|[^A-Za-z0-9_-])-k([^A-Za-z0-9_-]|$)' \
+    | tr -d ' ' | assert_equals "aucun -k dans le module" "0"
+grep -v '^[[:space:]]*#' "$MOD" \
+    | grep -cE -- '(^|[^A-Za-z0-9_-])--insecure([^A-Za-z0-9_-]|$)' \
+    | tr -d ' ' | assert_equals "aucun --insecure dans le module" "0"
+
+echo
+echo "== _work_cfg_require : le chemin nominal =="
+
+# Seul l echec etait couvert. Or c est la REUSSITE qui porte la garantie de cette
+# tache : le module work ne depend pas de l activation du module gitlab, il source
+# lui-meme ~/.gitlab_secrets. Un chemin casse (mauvais fichier, mauvais nom de
+# variable, quoting rompu) laisserait toute la suite verte.
+zc 'HOME="${WORK_DIR:h}"
+    print "GITLAB_TOKEN=x"                        >  "$HOME/.gitlab_secrets"
+    print "GITLAB_BASE_DOMAIN=forge.exemple.test" >> "$HOME/.gitlab_secrets"
+    unset GITLAB_TOKEN GITLAB_BASE_DOMAIN
+    _work_cfg_require >/dev/null 2>&1
+    rc=$?
+    rm -f "$HOME/.gitlab_secrets"
+    print "rc=$rc token=${GITLAB_TOKEN:-vide}"' \
+    | assert_equals "la garde source elle-meme ~/.gitlab_secrets" "rc=0 token=x"
+
+echo
+echo "== _work_cfg_json : la cause de l echec est nommee =="
+
+# _work_cfg_curl appelle `command curl`, qu une fonction du meme nom ne peut pas
+# intercepter. On stube donc _work_cfg_curl, qui est bien une fonction. Ces cas
+# couvrent la logique de _work_cfg_json — extraction du code, garde <->, branche
+# >= 400 — qu aucune assertion n exercait : le port ferme rend la main avant.
+zc '_work_cfg_curl() { print 401; print corps }
+    _work_cfg_json GET projects/1 >/dev/null 2>&1
+    print -r -- "$_work_cfg_last_error"' | grep -o "GITLAB_TOKEN refuse" \
+    | assert_equals "401 : la cause nommee est le token" "GITLAB_TOKEN refuse"
+
+zc '_work_cfg_curl() { print 403; print corps }
+    _work_cfg_json GET projects/1 >/dev/null 2>&1
+    print -r -- "$_work_cfg_last_error"' | grep -o "droits insuffisants" \
+    | assert_equals "403 : la cause nommee est les droits" "droits insuffisants"
+
+zc '_work_cfg_curl() { print "<html>portail</html>" }
+    _work_cfg_json GET projects/1 >/dev/null 2>&1
+    print -r -- "$_work_cfg_last_error"' | grep -o "proxy s est interpose" \
+    | assert_equals "reponse sans code HTTP : le proxy est nomme" "proxy s est interpose"
+
+# Le corps n est plus sur stdout mais dans _work_cfg_body (critique de revue : un
+# $( ) est un sous-shell, cf. plus haut) — _work_cfg_json ne rend plus rien du tout
+# sur stdout, succes compris.
+zc '_work_cfg_curl() { print 200; print "{\"id\":42}" }
+    _work_cfg_json GET projects/1
+    print -r -- "$_work_cfg_body"' \
+    | assert_equals "200 : le corps va dans _work_cfg_body, plus sur stdout" '{"id":42}'
+
+# Un portail interpose peut refleter les en-tetes de la requete dans son corps
+# d erreur. Le token ne doit pas ressortir dans la cause.
+zc 'GITLAB_TOKEN=jeton-secret-abc
+    _work_cfg_curl() { print 403; print "refuse: PRIVATE-TOKEN jeton-secret-abc" }
+    _work_cfg_json GET projects/1 >/dev/null 2>&1
+    print -r -- "$_work_cfg_last_error"' | grep -c "jeton-secret-abc" | tr -d ' ' \
+    | assert_equals "le token n est jamais reflete dans la cause" "0"
+
+echo
+echo "== _work_cfg_collect : le dispatch 404 qui etait mort =="
+
+# _work_cfg_collect n avait AUCUNE assertion directe. C est par ce trou que le
+# critique de revue est passe : _work_cfg_json perdait sa cause a travers un $( ),
+# donc `[[ "$_work_cfg_last_error" == HTTP 404* ]]` ne matchait jamais et le
+# dispatch 404 -> 2 n etait jamais atteint en production, seulement en apparence
+# couvert par des tests qui stubaient plus haut que ce chemin. On stube
+# _work_cfg_curl (pas _work_cfg_json) pour exercer la vraie fonction bout en bout.
+
+zc '_work_cfg_curl() { print 404; print "{}" }
+    _work_cfg_collect blg demoapp demo-x dev
+    print "rc=$?"' \
+    | assert_equals "collect sur 404 : rc=2, le dispatch reagit enfin" "rc=2"
+
+# Un 403 en lecture de README doit arreter net, JAMAIS classer « divergent » : sous
+# --fix --readme, classer un refus comme divergent le ferait ecraser un README
+# valide qu on n a simplement pas pu relire. C est le chemin destructif que le
+# critique masquait ; il n avait jamais eu sa propre assertion committee.
+#
+# Le stub distingue par le CHEMIN de l appel, jamais par un compteur : _work_cfg_curl
+# est appelee via un $( ) dans _work_cfg_json (cf. critique 1 plus haut), donc tout
+# etat qu un compteur essaierait de faire survivre entre deux appels serait perdu
+# au meme sous-shell — la premiere version de ce test l a demontre en tombant sur
+# elle-meme (le compteur restait bloque a 1, jq recevait le mauvais corps).
+zc '_work_cfg_curl() {
+        case "$2" in
+            *repository/branches\?*)     print 200; print "[{\"name\":\"dev\"}]" ;;
+            *protected_branches\?*)      print 200; print "[]" ;;
+            *repository/files/*)         print 403; print "{}" ;;
+            *)                            print 200; print "{\"id\":42,\"default_branch\":\"dev\"}" ;;
+        esac
+    }
+    _work_cfg_collect blg demoapp demo-x dev >/dev/null 2>&1
+    rc=$?
+    print "rc=$rc readmes=${_work_cfg_readmes:-vide} divergent=$(print -r -- "$_work_cfg_readmes" | grep -c divergent)"' \
+    | assert_equals "403 sur le README : rc=1, jamais classe divergent" \
+"rc=1 readmes=vide divergent=0"
+
+# Les trois etats a la fois, dans un seul passage : ok (contenu conforme), absent
+# (404), divergent (200 mais contenu different). Rien avant ceci ne verifiait la
+# classification elle-meme, seulement des morceaux isoles (curl, json, readme_content).
+zc '_work_cfg_curl() {
+        case "$2" in
+            *repository/branches\?*)      print 200; print "[{\"name\":\"dev\"},{\"name\":\"qlf\"},{\"name\":\"pprd\"}]" ;;
+            *protected_branches\?*)       print 200; print "[]" ;;
+            *repository/files/*ref=dev)   print 200; print "# demo-x dev" ;;
+            *repository/files/*ref=qlf)   print 404; print "{}" ;;
+            *repository/files/*ref=pprd)  print 200; print "contenu different" ;;
+            *)                             print 200; print "{\"id\":42,\"default_branch\":\"dev\"}" ;;
+        esac
+    }
+    _work_cfg_collect blg demoapp demo-x dev,qlf,pprd
+    print "rc=$?"
+    print -r -- "$_work_cfg_readmes"' \
+    | assert_equals "collect classe ok, absent et divergent" \
+"$(printf 'rc=0\ndev\tok\nqlf\tabsent\npprd\tdivergent')"
+
+echo
+echo "== _work_cfg_run : les deux codes de sortie qui manquaient =="
+
+# _work_cfg_run n avait pas plus d assertion que _work_cfg_collect : rien ne
+# verifiait qu il rend jamais 0 ou 2. On stube _work_cfg_collect elle-meme —
+# deja testee ci-dessus — pour piloter le plan sans reseau.
+
+zc 'GITLAB_TOKEN=x GITLAB_BASE_DOMAIN=exemple.test
+    _work_cfg_collect() {
+        typeset -g _work_cfg_pid=1 _work_cfg_default=dev \
+            _work_cfg_branches=$(printf "dev\nqlf\npprd\nprd") \
+            _work_cfg_rules=$(printf "pprd\t40\t40\tfalse\nprd\t40\t40\tfalse") \
+            _work_cfg_readmes=$(printf "dev\tok\nqlf\tok\npprd\tok\nprd\tok")
+        return 0
+    }
+    _work_cfg_run blg demoapp demo-front dev,qlf,pprd,prd 0 0 >/dev/null 2>&1
+    print "rc=$?"' \
+    | assert_equals "collect stube conforme, sans --fix : rc=0" "rc=0"
+
+zc 'GITLAB_TOKEN=x GITLAB_BASE_DOMAIN=exemple.test
+    _work_cfg_collect() {
+        typeset -g _work_cfg_pid=1 _work_cfg_default=dev \
+            _work_cfg_branches=$(printf "dev\nprd") \
+            _work_cfg_rules=$(printf "prd\t40\t40\tfalse") \
+            _work_cfg_readmes=$(printf "dev\tok\nprd\tok")
+        return 0
+    }
+    _work_cfg_run blg demoapp demo-front dev,qlf,prd 0 0 >/dev/null 2>&1
+    print "rc=$?"' \
+    | assert_equals "collect stube avec ecarts, sans --fix : rc=2" "rc=2"
+
+echo
+echo "== rendu du rapport =="
+
+zc "_work_cfg_render demo-x '' | tail -1" \
+    | assert_equals "plan vide : conformite annoncee" "  Rien a faire — le repo est conforme."
+
+zc "_work_cfg_render demo-docs \"\$(printf 'branch_create\tqlf\tdev\nreadme_write\tqlf')\" | grep -c '^  '" \
+    | assert_equals "deux actions rendues sur deux lignes" "2"
+
+zc "_work_cfg_render demo-docs \"\$(printf 'branch_create\tqlf\tdev')\" | grep -o 'creer branche qlf depuis dev'" \
+    | assert_equals "creation de branche libellee" "creer branche qlf depuis dev"
+
+zc "_work_cfg_render demo-x \"\$(printf 'protect_replace\tprd')\" | grep -o 'fenetre de non-protection'" \
+    | assert_equals "le remplacement de protection annonce sa fenetre" "fenetre de non-protection"
+
+zc "_work_cfg_render demo-x \"\$(printf 'master_delete\tmaster')\" | grep -o 'sous reserve du merge-base'" \
+    | assert_equals "la suppression de master annonce sa garde" "sous reserve du merge-base"
+
+zc "_work_cfg_count_actions \"\$(printf 'branch_create\tqlf\tdev\nwarn\tblabla\nreadme_write\tqlf')\"" \
+    | assert_equals "les avertissements ne comptent pas comme des actions" "2"
+
+# La distinction qui evite d annoncer « conforme » a un depot en ecart.
+zc "_work_cfg_count_ecarts \"\$(printf 'ecart\tREADME de dev absent\nwarn\tblabla\nreadme_write\tqlf')\"" \
+    | assert_equals "seules les lignes ecart comptent comme ecarts" "1"
+
+zc "_work_cfg_count_actions \"\$(printf 'ecart\tREADME de dev absent\nwarn\tblabla')\"" \
+    | assert_equals "un ecart n est pas une action" "0"
+
+zc "_work_cfg_render demo-x \"\$(printf 'ecart\tREADME de dev absent')\" | tail -1" \
+    | assert_equals "un plan sans action mais avec ecart n annonce pas la conformite" \
+"  Aucune action applicable — 1 ecart(s) exigent --readme."
+
+zc "_work_cfg_render demo-x \"\$(printf 'warn\tbranche hors norme conservee : prd')\" | tail -1" \
+    | assert_equals "une simple observation laisse annoncer la conformite" \
+"  Rien a faire — le repo est conforme."
+
+echo
+echo "== dialogue y/N/u =="
+
+zc 'print "" | _work_cfg_read_answer' \
+    | assert_equals "entree vide : refus par defaut" "n"
+
+zc 'print "y" | _work_cfg_read_answer' | assert_equals "y accepte" "y"
+zc 'print "Y" | _work_cfg_read_answer' | assert_equals "Y accepte (casse ignoree)" "y"
+zc 'print "u" | _work_cfg_read_answer' | assert_equals "u accepte" "u"
+zc 'print "n" | _work_cfg_read_answer' | assert_equals "n accepte" "n"
+zc 'print "zzz" | _work_cfg_read_answer' | assert_equals "reponse inconnue : refus" "n"
+
+# stdin ferme (execution non interactive) : refus, jamais d application implicite.
+zc '_work_cfg_read_answer < /dev/null' \
+    | assert_equals "stdin ferme : refus" "n"
+
+echo
+echo "== la derniere barriere avant ecriture =="
+
+# Les assertions ci-dessus ne couvrent que le LECTEUR d entree. C est
+# _work_cfg_confirm_and_apply qui decide si _work_cfg_apply est appelee, et la
+# tache 8 y branche une suppression de branche : elle merite ses propres cas.
+# Le stub trace sur stderr — une variable ne survivrait pas au sous-shell du pipe.
+
+zc '_work_cfg_apply() { print -u2 APPLIQUE; return 0 }
+    out=$(print "y" | _work_cfg_confirm_and_apply demo-x dev 0 \
+          "$(printf "branch_create\tqlf\tdev")" 2>&1 >/dev/null)
+    print "trace=${out:-vide}"' \
+    | assert_equals "reponse y : l application est appelee" "trace=APPLIQUE"
+
+zc '_work_cfg_apply() { print -u2 APPLIQUE; return 0 }
+    out=$(print "n" | _work_cfg_confirm_and_apply demo-x dev 0 \
+          "$(printf "branch_create\tqlf\tdev")" 2>&1 >/dev/null)
+    rc=$?
+    print "rc=$rc trace=${out:-vide}"' \
+    | assert_equals "reponse n : rien n est applique" "rc=2 trace=vide"
+
+zc '_work_cfg_apply() { print -u2 APPLIQUE; return 0 }
+    out=$(_work_cfg_confirm_and_apply demo-x dev 0 \
+          "$(printf "branch_create\tqlf\tdev")" </dev/null 2>&1 >/dev/null)
+    rc=$?
+    print "rc=$rc trace=${out:-vide}"' \
+    | assert_equals "stdin ferme : aucune application" "rc=2 trace=vide"
+
+# Une saisie d envs fautive dans le wizard doit dire pourquoi, pas se taire.
+zc 'out=$(printf "u\nuat\nn\n" | _work_cfg_confirm_and_apply demo-x dev 0 \
+          "$(printf "branch_create\tqlf\tdev")" 2>&1)
+    print -r -- "$out" | grep -c "env inconnu"' \
+    | assert_equals "une saisie d envs fautive dit pourquoi" "1"
+
+echo
+echo "== garde merge-base =="
+
+zc '_work_cfg_sha_contained abc123 abc123 && print sur || print refuse' \
+    | assert_equals "merge-base egal au SHA : suppression sure" "sur"
+
+zc '_work_cfg_sha_contained abc123 def456 && print sur || print refuse' \
+    | assert_equals "merge-base different : suppression refusee" "refuse"
+
+zc '_work_cfg_sha_contained "" "" && print sur || print refuse' \
+    | assert_equals "SHA vides : suppression refusee" "refuse"
+
+zc '_work_cfg_sha_contained abc123 "" && print sur || print refuse' \
+    | assert_equals "merge-base vide : suppression refusee" "refuse"
+
+echo
+echo "== ordre d application =="
+
+# L API refuse de supprimer la branche par defaut, et de supprimer une branche
+# protegee : l ordre n est donc pas libre.
+zc "_work_cfg_sort_plan \"\$(printf 'master_delete\tmaster\nprotect_create\tprd\nbranch_create\tqlf\tdev\ndefault_set\tdev\nreadme_write\tqlf\nunprotect\tqlf\nrule_delete_orphan\tzzz')\" | cut -f1" \
+    | assert_equals "sept etapes remises dans l ordre de la spec" \
+"$(printf 'branch_create\ndefault_set\nunprotect\nreadme_write\nprotect_create\nrule_delete_orphan\nmaster_delete')"
+
+zc "_work_cfg_sort_plan \"\$(printf 'warn\tblabla\nbranch_create\tqlf\tdev')\" | cut -f1" \
+    | assert_equals "les avertissements sortent en fin de plan" \
+"$(printf 'branch_create\nwarn')"
+
+echo
+echo "== application : les etapes partent vraiment =="
+
+# Ce que ces cas ferment : ${(f)$(...)} non cite aplatit tabulations et retours ligne,
+# la boucle ne tourne qu une fois, aucun case ne matche, et _work_cfg_apply rend 0
+# sans avoir rien applique. Les assertions sur _work_cfg_sort_plan ne pouvaient pas
+# le voir — elles ne touchent pas le code qui ecrit.
+zc '_work_cfg_json() { print -u2 "$1 $2"; return 0 }
+    _work_cfg_pid=42; _work_cfg_envs_current=dev,qlf,pprd,prd
+    plan=$(printf "protect_create\tprd\nbranch_create\tqlf\tdev")
+    out=$(_work_cfg_apply demo-x "$plan" 2>&1 >/dev/null)
+    print -r -- "$out" | grep -c "^POST"' \
+    | assert_equals "un plan a deux etapes emet deux appels" "2"
+
+zc '_work_cfg_json() { print -u2 "$2"; return 0 }
+    _work_cfg_pid=42; _work_cfg_envs_current=dev
+    plan=$(printf "protect_create\tprd\nbranch_create\tqlf\tdev")
+    out=$(_work_cfg_apply demo-x "$plan" 2>&1 >/dev/null)
+    print -r -- "$out" | head -1 | grep -o "repository/branches"' \
+    | assert_equals "la creation de branche precede la protection" "repository/branches"
+
+zc '_work_cfg_json() { print -u2 "$1 $2"; return 0 }
+    _work_cfg_is_merged() { return 1 }
+    _work_cfg_pid=42; _work_cfg_envs_current=dev
+    out=$(_work_cfg_apply demo-x "$(printf "master_delete\tmaster")" 2>&1 >/dev/null); rc=$?
+    print "rc=$rc suppr=$(print -r -- "$out" | grep -c "repository/branches")"' \
+    | assert_equals "garde refusant : aucune suppression, rc=2" "rc=2 suppr=0"
+
+zc '_work_cfg_json() { print -u2 "$1 $2"; return 0 }
+    _work_cfg_is_merged() { return 2 }
+    _work_cfg_pid=42; _work_cfg_envs_current=dev
+    out=$(_work_cfg_apply demo-x "$(printf "master_delete\tmaster")" 2>&1 >/dev/null); rc=$?
+    print "rc=$rc suppr=$(print -r -- "$out" | grep -c "repository/branches")"' \
+    | assert_equals "merge-base inverifiable : arret, rc=1, rien de supprime" "rc=1 suppr=0"
+
+zc '_work_cfg_json() { [[ "$1" == POST ]] && return 1; return 0 }
+    _work_cfg_pid=42; _work_cfg_envs_current=dev
+    _work_cfg_apply demo-x "$(printf "branch_create\tqlf\tdev\nprotect_create\tprd")" >/dev/null 2>&1
+    print "rc=$?"' \
+    | assert_equals "une etape en echec arrete la sequence" "rc=1"
+
+# IMPORTANT 3 de la revue finale : le DELETE d un protect_replace passait, le POST
+# de remplacement echouait en 403, et prd restait deprotegee EN SILENCE — rien ne
+# le disait, alors que l avertissement prealable ne promet qu une fenetre BREVE.
+# Le motif existe deja pour master_delete ; protect_replace doit le porter aussi.
+zc '_work_cfg_json() { [[ "$1" == POST ]] && return 1; return 0 }
+    _work_cfg_pid=42
+    out=$(_work_cfg_apply demo-x "$(printf "protect_replace\tprd")" 2>&1); rc=$?
+    print "rc=$rc deprotegee=$(print -r -- "$out" | grep -c "restee DEPROTEGEE")"' \
+    | assert_equals "protect_replace : POST en echec, prd nommee DEPROTEGEE" "rc=1 deprotegee=1"
+
+# MINEUR :712 de la revue finale : default_set etait le dernier corps JSON construit
+# par interpolation. Round-trip par jq, comme les autres corps de ce module.
+zc '_work_cfg_json() { [[ "$1" == PUT ]] && print -r -u2 -- "$3"; return 0 }
+    _work_cfg_pid=42
+    out=$(_work_cfg_apply demo-x "$(printf "default_set\tdev")" 2>&1 >/dev/null)
+    print -r -- "$out" | jq -r ".default_branch"' \
+    | assert_equals "bascule du defaut : corps JSON construit par jq" "dev"
+
+echo
+echo "== la garde elle-meme, sans stub =="
+
+# Les cas ci-dessus stubent _work_cfg_is_merged pour piloter _work_cfg_apply. Son
+# CORPS, lui, n etait exerce par rien — et c est lui qui decide d une suppression.
+# Un return 0 sur echec d API ferait partir la suppression de master : c est le
+# chemin de perte de commits, il merite ses propres cas.
+zc '_work_cfg_json() { return 1 }
+    _work_cfg_last_error="HTTP 500"
+    _work_cfg_is_merged 42 master dev; print "rc=$?"' \
+    | assert_equals "API en echec : la garde rend 2, jamais 0" "rc=2"
+
+# _work_cfg_json rend maintenant son corps par la globale _work_cfg_body, plus par
+# stdout (critique de revue : un $( ) est un sous-shell, cf. plus haut). Le stub
+# doit donc deposer le corps a l endroit ou _work_cfg_is_merged va le lire.
+zc '_work_cfg_json() { typeset -g _work_cfg_body="{}"; return 0 }
+    _work_cfg_is_merged 42 master dev; print "rc=$?"' \
+    | assert_equals "reponse sans SHA : la garde ne sait pas, jamais 1" "rc=2"
+
+zc '_work_cfg_json() { typeset -g _work_cfg_body="{\"commit\":{\"id\":\"abc\"},\"id\":\"abc\"}"; return 0 }
+    _work_cfg_is_merged 42 master dev; print "rc=$?"' \
+    | assert_equals "SHA egal au merge-base : la garde accepte" "rc=0"
+
+# Le consentement doit etre eclaire : retirer la protection de master fait partie
+# de sa suppression, et l utilisateur doit le lire AVANT de taper y, pas apres.
+zc '_work_cfg_render demo-x "$(printf "master_delete\tmaster")" | grep -o "sa protection sera retiree"' \
+    | assert_equals "le plan annonce le retrait de protection avant le y" "sa protection sera retiree"
+
+echo
+echo "== chemin local de destination =="
+
+zc '_work_cfg_local_path blg demoapp demo-front' \
+    | assert_equals "chemin canonique reconstruit" "$TEST_TMPDIR/work/blg/applications/demoapp/configurations/demo-front"
+
+# Aller-retour : ce que _work_cfg_local_path produit, _work_cfg_parse_path le relit.
+zc '_work_cfg_parse_path "$(_work_cfg_local_path blg demoapp demo-front)"' \
+    | assert_equals "aller-retour chemin stable" "$(printf 'blg\tdemoapp\tdemo-front')"
+
+zc 'p=$(_work_cfg_local_path tsc autreapp demo-api); _work_cfg_parse_path "$p"' \
+    | assert_equals "aller-retour sur une autre BU" "$(printf 'tsc\tautreapp\tdemo-api')"
+
+echo
+echo "== creation : la sequence distante, sans reseau =="
+
+# Les trois cas ci-dessus couvrent une fonction de chemin. _work_cfg_create, elle,
+# est une sequence multi-etapes qui cree de l etat distant : c est elle qui merite
+# des cas. On stube _work_cfg_json, git et cd, et on lit la trace.
+#
+# L assertion d ordre compare la SEQUENCE ENTIERE, pas sa premiere ligne : dev n est
+# jamais protegee, donc « le premier README precede la premiere protection » est vrai
+# quel que soit l ordre des boucles. Une regression deplacant les protections avant
+# la boucle des branches passerait — c est justement ce que le code met en garde.
+#
+# _work_cfg_json rend maintenant son corps par _work_cfg_body, plus par stdout : les
+# stubs ci-dessous le deposent dans cette globale (typeset -g), pas par un `print`
+# qu aucun appelant ne lit plus.
+#
+# La creation demande desormais une confirmation avant le premier POST (cf. plan) :
+# un groupe injoignable echoue avant de l atteindre (rien a piper), les sequences
+# qui reussissent recoivent leur "y" via un pipe explicite — jamais d entree
+# implicite, jamais de stdin herite en silence.
+
+zc '_work_cfg_json() { print -u2 "APPEL $1 $2"; return 1 }
+    _work_cfg_last_error="HTTP 404"
+    out=$(_work_cfg_create blg demoapp demo-front dev 2>&1); rc=$?
+    print "rc=$rc projet=$(print -r -- "$out" | grep -c "APPEL POST projects") cause=$(print -r -- "$out" | grep -c "HTTP 404")"' \
+    | assert_equals "groupe injoignable : aucun projet cree, cause dite" "rc=1 projet=0 cause=1"
+
+zc '_work_cfg_json() {
+        case "$2" in
+            groups/*) typeset -g _work_cfg_body="{\"id\":7}" ;;
+            projects) typeset -g _work_cfg_body="{\"id\":42,\"http_url_to_repo\":\"https://exemple.test/x.git\"}" ;;
+            *)        typeset -g _work_cfg_body="{}" ;;
+        esac
+        return 0
+    }
+    _work_cfg_write_readme() { print -u2 "README $3"; return 0 }
+    _work_cfg_protect()      { print -u2 "PROTECT $2"; return 0 }
+    git() { return 0 }
+    cd()  { return 0 }
+    print y | _work_cfg_create blg demoapp demo-front dev,prd 2>&1 >/dev/null \
+      | grep -E "^README|^PROTECT"' \
+    | assert_equals "chaque README precede la protection de sa branche" \
+"$(printf 'README dev\nREADME prd\nPROTECT prd')"
+
+# IMPORTANT 4 de la revue finale : le clone final ignorait la mecanique
+# d authentification deja en place pour les clones existants (scripts/clone-projects.sh)
+# et faisait un `git clone` nu sur une URL interne — invite interactive ou echec, au
+# milieu d une sequence qui a deja cree du projet, des branches et des regles.
+zc '_work_cfg_json() {
+        case "$2" in
+            groups/*) typeset -g _work_cfg_body="{\"id\":7}" ;;
+            projects) typeset -g _work_cfg_body="{\"id\":42,\"http_url_to_repo\":\"https://exemple.test/x.git\"}" ;;
+            *)        typeset -g _work_cfg_body="{}" ;;
+        esac
+        return 0
+    }
+    _work_cfg_write_readme() { return 0 }; _work_cfg_protect() { return 0 }
+    GITLAB_TOKEN=jeton-test
+    git() { print -u2 "GIT $*"; return 0 }
+    cd() { return 0 }
+    out=$(print y | _work_cfg_create blg demoapp demo-front dev 2>&1 >/dev/null)
+    print -r -- "$out" | grep -c "PRIVATE-TOKEN: jeton-test"' \
+    | assert_equals "le clone reutilise le token via http.extraheader" "1"
+
+zc '_work_cfg_json() {
+        case "$2" in
+            groups/*) typeset -g _work_cfg_body="{\"id\":7}" ;;
+            projects) typeset -g _work_cfg_body="{\"id\":42,\"http_url_to_repo\":\"https://exemple.test/x.git\"}" ;;
+            *)        return 1 ;;
+        esac
+        return 0
+    }
+    _work_cfg_last_error="HTTP 403"
+    _work_cfg_write_readme() { return 1 }
+    out=$(print y | _work_cfg_create blg demoapp demo-front dev,prd 2>&1); rc=$?
+    print "rc=$rc partiel=$(print -r -- "$out" | grep -c "existe desormais sur la forge")"' \
+    | assert_equals "echec apres creation : l etat partiel est nomme" "rc=1 partiel=1"
+
+# L injection JSON. Le discriminant est .name, PAS .visibility : les cles dupliquees
+# se resolvent en « derniere gagne » et visibility vaut internal dans les deux cas,
+# donc l assertion serait aveugle. Sous interpolation brute .name est tronque a « x » ;
+# sous jq -n --arg il arrive entier.
+zc '_work_cfg_json() { [[ "$2" == projects ]] && print -r -u2 -- "$3"; typeset -g _work_cfg_body="{\"id\":1}"; return 0 }
+    _work_cfg_write_readme() { return 0 }; _work_cfg_protect() { return 0 }
+    git() { return 0 }; cd() { return 0 }
+    out=$(print y | _work_cfg_create blg demoapp '"'"'x","visibility":"public'"'"' dev 2>&1 >/dev/null)
+    print -r -- "$out" | jq -r ".name"' \
+    | assert_equals "un nom hostile arrive entier, non tronque par l interpolation" \
+'x","visibility":"public'
+
+echo
+echo "== creation : la confirmation qui manquait avant le premier POST =="
+
+# IMPORTANT 2 de la revue finale : _work_cfg_create ecrivait sur la forge dans la
+# foulee du rc=2, sans jamais demander. Masque par le critique 1 (le dispatch 404
+# etait mort, donc ce chemin n etait jamais atteint en production) : le corriger
+# active l autre. Le groupe existe (id connu) ; seule la confirmation separe
+# encore la lecture de la premiere ecriture.
+
+zc '_work_cfg_json() { print -u2 "APPEL $1 $2"; typeset -g _work_cfg_body="{\"id\":7}"; return 0 }
+    out=$(print n | _work_cfg_create blg demoapp demo-front dev 2>&1); rc=$?
+    print "rc=$rc post=$(print -r -- "$out" | grep -c "APPEL POST")"' \
+    | assert_equals "n au prompt de creation : aucun POST, rc=2" "rc=2 post=0"
+
+zc '_work_cfg_json() { print -u2 "APPEL $1 $2"; typeset -g _work_cfg_body="{\"id\":7}"; return 0 }
+    _work_cfg_write_readme() { return 0 }; _work_cfg_protect() { return 0 }
+    git() { return 0 }; cd() { return 0 }
+    out=$(print y | _work_cfg_create blg demoapp demo-front dev 2>&1); rc=$?
+    print "rc=$rc post=$(print -r -- "$out" | grep -c "APPEL POST projects")"' \
+    | assert_equals "y au prompt de creation : la sequence part, rc=0" "rc=0 post=1"
+
+# Stdin ferme (execution non interactive) doit refuser, comme partout ailleurs
+# dans ce module : jamais d application implicite.
+zc '_work_cfg_json() { print -u2 "APPEL $1 $2"; typeset -g _work_cfg_body="{\"id\":7}"; return 0 }
+    out=$(_work_cfg_create blg demoapp demo-front dev </dev/null 2>&1); rc=$?
+    print "rc=$rc post=$(print -r -- "$out" | grep -c "APPEL POST")"' \
+    | assert_equals "stdin ferme : refus, aucune creation" "rc=2 post=0"
+
+# Meme garantie sur le corps du commit README, un appel plus loin : $repo y entre
+# aussi, et il n y a aucune raison que la creation soit la seule protegee.
+zc '_work_cfg_curl() { print 404 }
+    _work_cfg_json() { [[ "$2" == *repository/commits ]] && print -r -u2 -- "$3"; print "{}"; return 0 }
+    out=$(_work_cfg_write_readme 42 '"'"'x","x":"y'"'"' dev 2>&1 >/dev/null)
+    print -r -- "$out" | jq -r ".commit_message"' \
+    | assert_equals "le message de commit encaisse un nom hostile" \
+'chore: normalise le README (x","x":"y dev)'
+
+echo
+printf '== %s ok, %s echecs ==\n' "$(cat "$TEST_TMPDIR/pass")" "$(cat "$TEST_TMPDIR/fail")"
+[[ "$(cat "$TEST_TMPDIR/fail")" == 0 ]]

--- a/web/docs/superpowers/plans/2026-08-07-work-config-repos.md
+++ b/web/docs/superpowers/plans/2026-08-07-work-config-repos.md
@@ -1,0 +1,1672 @@
+# Repos de configs — plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ajouter `work_config_repo` au module `work` : audit et mise aux normes des repos de configuration GitLab, création incluse.
+
+**Architecture:** Tout en zsh dans `modules/work/config_repos.zsh`, dans le moule d'`elasticsearch.zsh`. Le cœur est un **planificateur pur** (`_work_cfg_build_plan`) qui reçoit l'état du repo sous forme de TSV et rend une liste d'actions, sans aucun appel réseau — c'est lui qui porte toute la logique de norme, et c'est lui qu'on teste. Autour, une couche de collecte (curl + jq) et une couche d'application, minces par construction.
+
+**Tech Stack:** zsh, curl, jq, API GitLab v4 (forge en 18.11.7 **CE**). Tests en bash dans `scripts/tests/`, moule d'`assert_equals` repris de `zsh-special-vars.test.sh`.
+
+**Spec:** `web/docs/superpowers/specs/2026-08-07-work-config-repos-design.md`
+
+## Global Constraints
+
+- **Aucune couleur en dur** (`\033[...`). Tout passe par les fonctions `_ui_*` de `core/ui.zsh`.
+- **Pas de shellspec.** Les tests sont des scripts bash autonomes dans `scripts/tests/*.test.sh`, sur le moule de `zsh-special-vars.test.sh` (compteurs dans `$TEST_TMPDIR`, `assert_equals` lisant stdin).
+- **Pas de `-k` sur curl.** `--cacert "$SSL_CERT_FILE"` si la variable est définie, sinon appel nu. Vérifié le 2026-08-07 : la forge répond 200 sans désactiver la vérification.
+- **Aucune donnée réelle dans les fixtures.** zanvil est un dépôt public. Les cas de test sont synthétiques (`bu` fictive `blg`, app `demoapp`, repos `demo-*`), sans nom d'hôte ni identifiant de projet réel.
+- **`technical-assets` est refusé entièrement**, audit compris, avant tout appel réseau.
+- **Le sous-groupe `companion` est hors périmètre.**
+- **Le groupe `configurations` n'est jamais créé.** Absent → échec net.
+- Chemin canonique : `$WORK_DIR/<bu>/applications/<app>/configurations/<repo>` — `applications` au **pluriel**.
+- Norme : branches `dev qlf pprd prd`, défaut `dev`, `dev`/`qlf` non protégées, `pprd`/`prd` protégées en `push_access_level=40`, `merge_access_level=40`, `allow_force_push=false`.
+- Codes de sortie : `0` conforme ou corrigé, `1` erreur, `2` écarts détectés en audit.
+- Messages et commentaires en français sans accents dans les fichiers `.zsh` (convention du module `work`).
+
+---
+
+### Task 1 : Chemin canonique et refus durs
+
+**Files:**
+- Create: `modules/work/config_repos.zsh`
+- Create: `scripts/tests/work-config-repos.test.sh`
+- Modify: `modules/work/init.zsh`
+- Modify: `modules/work/.lazy`
+
+**Interfaces:**
+- Consomme : rien
+- Produit :
+  - `_work_cfg_parse_path <chemin>` → `bu<TAB>app<TAB>repo` sur stdout, `return 1` si non canonique
+  - `_work_cfg_guard_target <bu> <app> <repo>` → `return 0|1`, message d'erreur via `_ui_msg_fail`
+  - constantes `_WORK_CFG_ENVS_ALL`, `_WORK_CFG_ENVS_PROTECTED`, `_WORK_CFG_BU_ALL`, `_WORK_CFG_PUSH_LEVEL`, `_WORK_CFG_MERGE_LEVEL`
+
+- [ ] **Step 1 : Écrire le test qui échoue**
+
+Créer `scripts/tests/work-config-repos.test.sh` :
+
+```bash
+#!/usr/bin/env bash
+# Verifie work_config_repo : chemin canonique, refus durs, normalisation des envs,
+# et le planificateur pur. Aucun appel reseau.
+# Usage : scripts/tests/work-config-repos.test.sh
+#
+# Les cas sont synthetiques : zanvil est public, aucune nomenclature interne reelle
+# n a sa place ici.
+set -uo pipefail
+
+ROOT="${ZANVIL_DIR:-$HOME/.zanvil}"
+MOD="$ROOT/modules/work/config_repos.zsh"
+
+TEST_TMPDIR=$(mktemp -d) || { echo "mktemp failed" >&2; exit 2; }
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+echo 0 > "$TEST_TMPDIR/pass"
+echo 0 > "$TEST_TMPDIR/fail"
+
+assert_equals() {
+    local label="$1" needle="$2" out
+    out=$(cat)
+    if [[ "$out" == "$needle" ]]; then
+        printf '  ok   %s\n' "$label"
+        echo $(($(cat "$TEST_TMPDIR/pass") + 1)) > "$TEST_TMPDIR/pass"
+    else
+        printf '  FAIL %s\n       attendu : %s\n       obtenu  : %s\n' \
+            "$label" "$needle" "$out"
+        echo $(($(cat "$TEST_TMPDIR/fail") + 1)) > "$TEST_TMPDIR/fail"
+    fi
+}
+
+# Lance une expression zsh avec ui.zsh et le module charges, WORK_DIR maitrise.
+zc() {
+    zsh -f -c "
+        WORK_DIR='$TEST_TMPDIR/work'
+        source '$ROOT/core/ui.zsh' >/dev/null 2>&1
+        source '$MOD'
+        $1
+    " 2>&1
+}
+
+echo "== chemin canonique =="
+
+zc '_work_cfg_parse_path "$WORK_DIR/blg/applications/demoapp/configurations/demo-front"' \
+    | assert_equals "chemin canonique decompose" "$(printf 'blg\tdemoapp\tdemo-front')"
+
+zc '_work_cfg_parse_path "$WORK_DIR/blg/application/demoapp/configurations/demo-front" || print refuse' \
+    | assert_equals "application au singulier refuse" "refuse"
+
+zc '_work_cfg_parse_path "$WORK_DIR/xxx/applications/demoapp/configurations/demo-front" || print refuse' \
+    | assert_equals "BU inconnue refusee" "refuse"
+
+zc '_work_cfg_parse_path "$WORK_DIR/blg/applications/demoapp/components/demo-front" || print refuse' \
+    | assert_equals "hors groupe configurations refuse" "refuse"
+
+zc '_work_cfg_parse_path "$WORK_DIR/blg/applications/demoapp/configurations/companion/app" || print refuse' \
+    | assert_equals "chemin companion refuse" "refuse"
+
+zc '_work_cfg_parse_path "/ailleurs/blg/applications/demoapp/configurations/demo-front" || print refuse' \
+    | assert_equals "hors WORK_DIR refuse" "refuse"
+
+echo
+echo "== refus durs, sans reseau =="
+
+zc '_work_cfg_guard_target blg demoapp demo-front && print ok' \
+    | assert_equals "cible legitime acceptee" "ok"
+
+zc '_work_cfg_guard_target blg demoapp technical-assets >/dev/null 2>&1 || print refuse' \
+    | assert_equals "technical-assets refuse" "refuse"
+
+zc '_work_cfg_guard_target blg demoapp companion >/dev/null 2>&1 || print refuse' \
+    | assert_equals "companion refuse" "refuse"
+
+zc '_work_cfg_guard_target xxx demoapp demo-front >/dev/null 2>&1 || print refuse' \
+    | assert_equals "BU inconnue refusee au garde" "refuse"
+
+zc '_work_cfg_guard_target blg "" demo-front >/dev/null 2>&1 || print refuse' \
+    | assert_equals "app vide refusee" "refuse"
+
+zc '_work_cfg_guard_target blg demoapp "" >/dev/null 2>&1 || print refuse' \
+    | assert_equals "repo vide refuse" "refuse"
+
+# Le refus doit tomber AVANT tout appel reseau : on rend curl introuvable.
+zc 'curl() { print "APPEL RESEAU" }
+    _work_cfg_guard_target blg demoapp technical-assets 2>/dev/null
+    print "rc=$?"' \
+    | assert_equals "technical-assets refuse sans toucher au reseau" "rc=1"
+
+echo
+printf '== %s ok, %s echecs ==\n' "$(cat "$TEST_TMPDIR/pass")" "$(cat "$TEST_TMPDIR/fail")"
+[[ "$(cat "$TEST_TMPDIR/fail")" == 0 ]]
+```
+
+Rendre exécutable : `chmod +x scripts/tests/work-config-repos.test.sh`
+
+- [ ] **Step 2 : Lancer le test pour vérifier qu'il échoue**
+
+Run: `scripts/tests/work-config-repos.test.sh`
+Expected: FAIL sur toutes les assertions — `_work_cfg_parse_path: command not found`
+
+- [ ] **Step 3 : Écrire l'implémentation minimale**
+
+Créer `modules/work/config_repos.zsh` :
+
+```zsh
+# ==============================================================================
+# Work Config Repos — creation et mise aux normes des repos de configuration
+# ==============================================================================
+# Spec : web/docs/superpowers/specs/2026-08-07-work-config-repos-design.md
+#
+# Le coeur de ce fichier est `_work_cfg_build_plan` : une fonction pure qui recoit
+# l etat d un repo et rend une liste d actions. Tout le reste — collecte, rendu,
+# application — est mince autour d elle, et c est deliberé : la norme est la seule
+# chose qui merite d etre testee, et elle ne doit pas dependre du reseau pour l etre.
+
+# --- Norme, en dur (surchargeable au runtime par --envs, jamais persistee) ---
+
+typeset -ga _WORK_CFG_ENVS_ALL=(dev qlf pprd prd)
+typeset -ga _WORK_CFG_ENVS_PROTECTED=(pprd prd)
+typeset -ga _WORK_CFG_BU_ALL=(blg edt udb tsc shared)
+typeset -g  _WORK_CFG_PUSH_LEVEL=40      # Maintainers
+typeset -g  _WORK_CFG_MERGE_LEVEL=40     # Maintainers
+
+# --- Chemin canonique ---
+
+# Decompose un chemin absolu en bu/app/repo.
+# Usage : _work_cfg_parse_path <chemin>
+# Sortie : "<bu>\t<app>\t<repo>". Return 1 si le chemin ne suit pas la forme
+#          $WORK_DIR/<bu>/applications/<app>/configurations/<repo>.
+#
+# L arite stricte a cinq segments ecarte d elle-meme les chemins sous companion/,
+# qui en comptent six. Le message dedie est rendu par _work_cfg_guard_target.
+_work_cfg_parse_path() {
+    local p="${1:-}"
+    local root="${WORK_DIR:-$HOME/work}"
+    [[ -n "$p" && "$p" == "$root"/* ]] || return 1
+
+    local rel="${p#$root/}"
+    local -a parts
+    parts=(${(s:/:)rel})
+
+    (( ${#parts} == 5 )) || return 1
+    [[ "$parts[2]" == applications ]] || return 1
+    [[ "$parts[4]" == configurations ]] || return 1
+    (( ${_WORK_CFG_BU_ALL[(I)$parts[1]]} )) || return 1
+
+    print -r -- "$parts[1]	$parts[3]	$parts[5]"
+    return 0
+}
+
+# --- Refus durs ---
+
+# Refuse une cible hors perimetre. Aucun appel reseau, jamais.
+# Usage : _work_cfg_guard_target <bu> <app> <repo>
+_work_cfg_guard_target() {
+    local bu="${1:-}" app="${2:-}" repo="${3:-}"
+
+    if ! (( ${_WORK_CFG_BU_ALL[(I)$bu]} )); then
+        _ui_msg_fail "BU inconnue : « ${bu:-<vide>} » (attendu : ${_WORK_CFG_BU_ALL})"
+        return 1
+    fi
+    if [[ -z "$app" ]]; then
+        _ui_msg_fail "application non determinee — passer --app, ou se placer dans le chemin canonique"
+        return 1
+    fi
+    if [[ -z "$repo" ]]; then
+        _ui_msg_fail "repo non determine — le passer en argument, ou se placer dans le chemin canonique"
+        return 1
+    fi
+    # technical-assets appartient a une autre chaine de responsabilite et n a pas la
+    # topologie de la norme : l auditer produirait des ecarts qu il ne faut pas corriger.
+    if [[ "$repo" == technical-assets ]]; then
+        _ui_msg_fail "technical-assets est hors perimetre — ni ecriture, ni audit"
+        return 1
+    fi
+    if [[ "$repo" == companion || "$repo" == companion/* ]]; then
+        _ui_msg_fail "le sous-groupe companion est hors perimetre"
+        return 1
+    fi
+    return 0
+}
+```
+
+- [ ] **Step 4 : Lancer le test pour vérifier qu'il passe**
+
+Run: `scripts/tests/work-config-repos.test.sh`
+Expected: `== 13 ok, 0 echecs ==`, code de sortie 0
+
+- [ ] **Step 5 : Brancher le module et vérifier la syntaxe**
+
+Ajouter à `modules/work/init.zsh` :
+```zsh
+source "$ZANVIL_DIR/modules/work/config_repos.zsh"
+```
+
+Ajouter à `modules/work/.lazy` (une ligne, à la fin) :
+```
+work_config_repo
+```
+
+Run: `zsh -n modules/work/config_repos.zsh && echo SYNTAXE-OK`
+Expected: `SYNTAXE-OK`
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add modules/work/config_repos.zsh modules/work/init.zsh modules/work/.lazy scripts/tests/work-config-repos.test.sh
+git commit -m "feat(work): chemin canonique et refus durs des repos de configs"
+```
+
+---
+
+### Task 2 : Normalisation des envs et norme dérivée
+
+**Files:**
+- Modify: `modules/work/config_repos.zsh`
+- Modify: `scripts/tests/work-config-repos.test.sh`
+
+**Interfaces:**
+- Consomme : `_WORK_CFG_ENVS_ALL`, `_WORK_CFG_ENVS_PROTECTED` (Task 1)
+- Produit :
+  - `_work_cfg_normalize_envs <csv>` → csv trié dans l'ordre canonique et dédupliqué ; `return 1` si un env est inconnu ou la liste vide
+  - `_work_cfg_expected_default <csv_normalise>` → nom de la branche par défaut attendue
+  - `_work_cfg_env_is_protected <env>` → `return 0|1`
+  - `_work_cfg_readme_content <repo> <branche>` → `# <repo> <branche>`
+
+- [ ] **Step 1 : Écrire le test qui échoue**
+
+Ajouter à `scripts/tests/work-config-repos.test.sh`, juste avant le bloc final `printf '== %s ok...` :
+
+```bash
+echo
+echo "== normalisation des envs =="
+
+zc '_work_cfg_normalize_envs "prd,dev"' \
+    | assert_equals "ordre canonique retabli" "dev,prd"
+
+zc '_work_cfg_normalize_envs "dev,dev,qlf"' \
+    | assert_equals "doublons ecartes" "dev,qlf"
+
+zc '_work_cfg_normalize_envs ""  >/dev/null 2>&1 || print refuse' \
+    | assert_equals "liste vide refusee" "refuse"
+
+zc '_work_cfg_normalize_envs "dev,uat" >/dev/null 2>&1 || print refuse' \
+    | assert_equals "env inconnu refuse" "refuse"
+
+zc '_work_cfg_normalize_envs "dev, qlf "' \
+    | assert_equals "espaces autour des valeurs tolerees" "dev,qlf"
+
+echo
+echo "== norme derivee =="
+
+zc '_work_cfg_expected_default "dev,qlf,pprd,prd"' \
+    | assert_equals "defaut attendu sur la norme complete" "dev"
+
+zc '_work_cfg_expected_default "qlf,prd"' \
+    | assert_equals "defaut attendu sans dev" "qlf"
+
+zc '_work_cfg_env_is_protected prd && print oui || print non' \
+    | assert_equals "prd protegee" "oui"
+
+zc '_work_cfg_env_is_protected pprd && print oui || print non' \
+    | assert_equals "pprd protegee" "oui"
+
+zc '_work_cfg_env_is_protected dev && print oui || print non' \
+    | assert_equals "dev non protegee" "non"
+
+zc '_work_cfg_env_is_protected qlf && print oui || print non' \
+    | assert_equals "qlf non protegee" "non"
+
+echo
+echo "== contenu README =="
+
+zc '_work_cfg_readme_content demo-front dev' \
+    | assert_equals "README en H1, une ligne" "# demo-front dev"
+
+zc '_work_cfg_readme_content demo-front prd | wc -l | tr -d " "' \
+    | assert_equals "README fait exactement une ligne" "1"
+```
+
+- [ ] **Step 2 : Lancer le test pour vérifier qu'il échoue**
+
+Run: `scripts/tests/work-config-repos.test.sh`
+Expected: 13 ok puis FAIL sur les 13 nouvelles — `_work_cfg_normalize_envs: command not found`
+
+- [ ] **Step 3 : Écrire l'implémentation minimale**
+
+Ajouter à `modules/work/config_repos.zsh`, après le bloc « Refus durs » :
+
+```zsh
+# --- Envs et norme derivee ---
+
+# Normalise une liste d envs : espaces retires, doublons ecartes, ordre canonique
+# retabli (dev < qlf < pprd < prd). L ordre de frappe n a donc aucune importance.
+# Usage : _work_cfg_normalize_envs "prd,dev"  ->  "dev,prd"
+# Return 1 si la liste est vide ou contient un env hors norme.
+_work_cfg_normalize_envs() {
+    local csv="${1:-}"
+    local -a wanted out e
+    wanted=(${(s:,:)csv})
+    wanted=(${wanted//[[:space:]]/})
+    wanted=(${wanted:#})
+
+    (( ${#wanted} )) || { _ui_msg_fail "liste d envs vide"; return 1 }
+
+    for e in $wanted; do
+        if ! (( ${_WORK_CFG_ENVS_ALL[(I)$e]} )); then
+            _ui_msg_fail "env inconnu : « $e » (attendu : ${_WORK_CFG_ENVS_ALL})"
+            return 1
+        fi
+    done
+
+    # On itere sur la norme, pas sur la saisie : l ordre canonique en decoule.
+    for e in $_WORK_CFG_ENVS_ALL; do
+        (( ${wanted[(I)$e]} )) && out+=($e)
+    done
+
+    print -r -- "${(j:,:)out}"
+    return 0
+}
+
+# La branche par defaut attendue est la premiere env de la liste normalisee.
+# Sur la norme complete c est dev ; sur --envs qlf,prd c est qlf.
+_work_cfg_expected_default() {
+    local -a envs
+    envs=(${(s:,:)${1:-}})
+    print -r -- "${envs[1]:-}"
+}
+
+# La protection se decide par NOM de branche, pas par rang dans la liste.
+_work_cfg_env_is_protected() {
+    (( ${_WORK_CFG_ENVS_PROTECTED[(I)${1:-}]} ))
+}
+
+# Contenu attendu du README d une branche d env : un titre H1, une ligne, rien d autre.
+_work_cfg_readme_content() {
+    print -r -- "# ${1} ${2}"
+}
+```
+
+- [ ] **Step 4 : Lancer le test pour vérifier qu'il passe**
+
+Run: `scripts/tests/work-config-repos.test.sh`
+Expected: `== 26 ok, 0 echecs ==`
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add modules/work/config_repos.zsh scripts/tests/work-config-repos.test.sh
+git commit -m "feat(work): normalisation des envs et norme derivee"
+```
+
+---
+
+### Task 3 : Le planificateur pur
+
+C'est le cœur. Il ne touche ni au réseau, ni à `jq` : il reçoit trois tableaux TSV et rend une liste d'actions. Toute la norme vit ici.
+
+**Files:**
+- Modify: `modules/work/config_repos.zsh`
+- Modify: `scripts/tests/work-config-repos.test.sh`
+
+**Interfaces:**
+- Consomme : `_work_cfg_normalize_envs`, `_work_cfg_expected_default`, `_work_cfg_env_is_protected` (Task 2)
+- Produit :
+  - `_work_cfg_build_plan <repo> <envs_csv> <readme_optin> <default_branch> <branches> <rules> <readmes>`
+    - `branches` : une branche par ligne
+    - `rules` : `nom<TAB>push<TAB>merge<TAB>force` par ligne
+    - `readmes` : `branche<TAB>ok|absent|divergent` par ligne
+    - Sortie : une action par ligne, champs séparés par TAB, parmi
+      `branch_create<TAB>env<TAB>source`, `default_set<TAB>env`,
+      `protect_create<TAB>br`, `protect_replace<TAB>br`, `protect_patch<TAB>br`,
+      `unprotect<TAB>br`, `rule_delete_orphan<TAB>br`, `readme_write<TAB>br`,
+      `master_delete<TAB>br`, `warn<TAB>texte`
+
+- [ ] **Step 1 : Écrire le test qui échoue**
+
+Ajouter à `scripts/tests/work-config-repos.test.sh` avant le bloc final.
+
+Les fixtures sont construites **dans l'expression zsh**, pas dans bash : les faire traverser
+deux niveaux de guillemets avec des tabulations littérales est un piège gratuit.
+
+```bash
+echo
+echo "== planificateur : repo conforme =="
+
+# demo-front conforme : 4 branches, defaut dev, pprd et prd protegees 40/40/false.
+zc 'br=$(print -l dev qlf pprd prd)
+    rules=$(printf "pprd\t40\t40\tfalse\nprd\t40\t40\tfalse")
+    rm=$(printf "dev\tok\nqlf\tok\npprd\tok\nprd\tok")
+    _work_cfg_build_plan demo-front dev,qlf,pprd,prd 0 dev "$br" "$rules" "$rm" | wc -l | tr -d " "' \
+    | assert_equals "repo conforme : aucune action" "0"
+
+echo
+echo "== planificateur : deux branches d env absentes =="
+
+# demo-docs : dev (defaut) et prd existent ; regles pprd et prd deja conformes.
+zc 'br=$(print -l dev prd)
+    rules=$(printf "pprd\t40\t40\tfalse\nprd\t40\t40\tfalse")
+    rm=$(printf "dev\tok\nprd\tok")
+    _work_cfg_build_plan demo-docs dev,qlf,pprd,prd 0 dev "$br" "$rules" "$rm"' \
+    | assert_equals "norme complete : creations + README d office" \
+"$(printf 'branch_create\tqlf\tdev\nbranch_create\tpprd\tdev\nreadme_write\tqlf\nreadme_write\tpprd')"
+
+# La regle pprd n est PAS orpheline quand le plan cree la branche pprd.
+zc 'br=$(print -l dev prd)
+    rules=$(printf "pprd\t40\t40\tfalse\nprd\t40\t40\tfalse")
+    rm=$(printf "dev\tok\nprd\tok")
+    _work_cfg_build_plan demo-docs dev,qlf,pprd,prd 0 dev "$br" "$rules" "$rm" \
+      | grep -c rule_delete_orphan' \
+    | assert_equals "regle dont la branche va etre creee : pas orpheline" "0"
+
+# Restreindre a dev,qlf rend la regle pprd orpheline et sort prd du perimetre.
+zc 'br=$(print -l dev prd)
+    rules=$(printf "pprd\t40\t40\tfalse\nprd\t40\t40\tfalse")
+    rm=$(printf "dev\tok\nprd\tok")
+    _work_cfg_build_plan demo-docs dev,qlf 0 dev "$br" "$rules" "$rm"' \
+    | assert_equals "envs restreints : orpheline detectee, prd conservee" \
+"$(printf 'branch_create\tqlf\tdev\nrule_delete_orphan\tpprd\nreadme_write\tqlf\nwarn\tbranche hors norme conservee : prd')"
+
+echo
+echo "== planificateur : protections =="
+
+zc 'br=$(print -l dev prd); rm=$(printf "dev\tok\nprd\tok")
+    _work_cfg_build_plan demo-x dev,prd 0 dev "$br" "" "$rm"' \
+    | assert_equals "regle absente sur prd : creation" "$(printf 'protect_create\tprd')"
+
+zc 'br=$(print -l dev prd); rm=$(printf "dev\tok\nprd\tok")
+    rules=$(printf "prd\t30\t40\tfalse")
+    _work_cfg_build_plan demo-x dev,prd 0 dev "$br" "$rules" "$rm"' \
+    | assert_equals "niveau d acces divergent : remplacement" "$(printf 'protect_replace\tprd')"
+
+zc 'br=$(print -l dev prd); rm=$(printf "dev\tok\nprd\tok")
+    rules=$(printf "prd\t40\t40\ttrue")
+    _work_cfg_build_plan demo-x dev,prd 0 dev "$br" "$rules" "$rm"' \
+    | assert_equals "seul allow_force_push divergent : patch" "$(printf 'protect_patch\tprd')"
+
+zc 'br=$(print -l dev qlf); rm=$(printf "dev\tok\nqlf\tok")
+    rules=$(printf "qlf\t40\t40\tfalse")
+    _work_cfg_build_plan demo-x dev,qlf 0 dev "$br" "$rules" "$rm"' \
+    | assert_equals "qlf protegee a tort : deprotection" "$(printf 'unprotect\tqlf')"
+
+echo
+echo "== planificateur : README opt-in =="
+
+zc 'rm=$(printf "dev\tdivergent")
+    _work_cfg_build_plan demo-x dev 0 dev "dev" "" "$rm"' \
+    | assert_equals "README preexistant divergent sans --readme : averti, pas ecrit" \
+"$(printf 'warn\tREADME de dev divergent — relancer avec --readme')"
+
+zc 'rm=$(printf "dev\tdivergent")
+    _work_cfg_build_plan demo-x dev 1 dev "dev" "" "$rm"' \
+    | assert_equals "README preexistant divergent avec --readme : ecrit" \
+"$(printf 'readme_write\tdev')"
+
+zc 'rm=$(printf "dev\tok")
+    _work_cfg_build_plan demo-x dev,qlf 0 dev "dev" "" "$rm" | grep readme_write' \
+    | assert_equals "branche creee dans le run : README ecrit sans --readme" \
+"$(printf 'readme_write\tqlf')"
+
+echo
+echo "== planificateur : branches hors norme =="
+
+zc 'br=$(print -l master dev qlf pprd prd)
+    rules=$(printf "pprd\t40\t40\tfalse\nprd\t40\t40\tfalse")
+    rm=$(printf "dev\tok\nqlf\tok\npprd\tok\nprd\tok")
+    _work_cfg_build_plan demo-x dev,qlf,pprd,prd 0 master "$br" "$rules" "$rm"' \
+    | assert_equals "master : bascule du defaut puis suppression" \
+"$(printf 'default_set\tdev\nmaster_delete\tmaster')"
+
+zc 'br=$(print -l dev feature/x config/y unprotected); rm=$(printf "dev\tok")
+    _work_cfg_build_plan demo-x dev 0 dev "$br" "" "$rm"' \
+    | assert_equals "feature/config/unprotected : conservees, signalees" \
+"$(printf 'warn\tbranche hors norme conservee : feature/x\nwarn\tbranche hors norme conservee : config/y\nwarn\tbranche hors norme conservee : unprotected')"
+```
+
+- [ ] **Step 2 : Lancer le test pour vérifier qu'il échoue**
+
+Run: `scripts/tests/work-config-repos.test.sh`
+Expected: 26 ok puis FAIL — `_work_cfg_build_plan: command not found`
+
+- [ ] **Step 3 : Écrire l'implémentation minimale**
+
+Ajouter à `modules/work/config_repos.zsh` :
+
+```zsh
+# --- Planificateur ---
+
+# Construit la liste des actions a partir d un etat, sans aucun appel reseau.
+#
+# Usage : _work_cfg_build_plan <repo> <envs_csv> <readme_optin> <default_branch> \
+#                              <branches> <rules> <readmes>
+#   branches : une branche par ligne
+#   rules    : nom<TAB>push<TAB>merge<TAB>force
+#   readmes  : branche<TAB>ok|absent|divergent
+#
+# Sortie : une action par ligne, champs separes par TAB. L ordre d emission est
+# stable — les tests comparent des sorties entieres, et l ordre d application en
+# depend (cf. _work_cfg_apply).
+_work_cfg_build_plan() {
+    local repo="$1" envs_csv="$2" readme_optin="$3" default_branch="$4"
+    local branches_raw="$5" rules_raw="$6" readmes_raw="$7"
+
+    local -a envs branches created
+    envs=(${(s:,:)envs_csv})
+    branches=(${(f)branches_raw})
+    branches=(${branches:#})
+
+    local -A rule_push rule_merge rule_force has_rule readme_state
+    local line nom f2 f3 f4
+    for line in ${(f)rules_raw}; do
+        [[ -z "$line" ]] && continue
+        IFS=$'\t' read -r nom f2 f3 f4 <<< "$line"
+        has_rule[$nom]=1; rule_push[$nom]="$f2"; rule_merge[$nom]="$f3"; rule_force[$nom]="$f4"
+    done
+    for line in ${(f)readmes_raw}; do
+        [[ -z "$line" ]] && continue
+        IFS=$'\t' read -r nom f2 <<< "$line"
+        readme_state[$nom]="$f2"
+    done
+
+    local expected_default e b
+    expected_default=$(_work_cfg_expected_default "$envs_csv")
+    local source_branch="${default_branch:-$expected_default}"
+
+    # 1. branches d env manquantes, derivees du defaut courant
+    for e in $envs; do
+        if ! (( ${branches[(I)$e]} )); then
+            print -r -- "branch_create	$e	$source_branch"
+            created+=($e)
+        fi
+    done
+
+    # 2. branche par defaut
+    [[ "$default_branch" != "$expected_default" ]] && print -r -- "default_set	$expected_default"
+
+    # 3-4. protections, par nom de branche
+    for e in $envs; do
+        if _work_cfg_env_is_protected "$e"; then
+            if (( ! ${+has_rule[$e]} )); then
+                print -r -- "protect_create	$e"
+            elif [[ "$rule_push[$e]" != "$_WORK_CFG_PUSH_LEVEL" || \
+                    "$rule_merge[$e]" != "$_WORK_CFG_MERGE_LEVEL" ]]; then
+                # GitLab CE ne sait pas modifier un niveau d acces par PATCH :
+                # DELETE puis POST, donc une breve fenetre de non-protection.
+                print -r -- "protect_replace	$e"
+            elif [[ "$rule_force[$e]" != false ]]; then
+                print -r -- "protect_patch	$e"
+            fi
+        else
+            (( ${+has_rule[$e]} )) && print -r -- "unprotect	$e"
+        fi
+    done
+
+    # 5. regles orphelines. Une regle dont la branche va etre creee par ce plan
+    #    n est PAS orpheline : elle deviendra une protection legitime.
+    for nom in ${(ok)has_rule}; do
+        (( ${branches[(I)$nom]} )) && continue
+        (( ${created[(I)$nom]} )) && continue
+        print -r -- "rule_delete_orphan	$nom"
+    done
+
+    # 6. README. D office sur ce que ce run vient de creer — la branche derive de
+    #    dev et porte donc le README de dev, il n y a rien a ecraser. Sur une
+    #    branche preexistante, il faut --readme.
+    for e in $envs; do
+        if (( ${created[(I)$e]} )); then
+            print -r -- "readme_write	$e"
+        elif [[ "${readme_state[$e]:-ok}" != ok ]]; then
+            if [[ "$readme_optin" == 1 ]]; then
+                print -r -- "readme_write	$e"
+            else
+                print -r -- "warn	README de $e ${readme_state[$e]} — relancer avec --readme"
+            fi
+        fi
+    done
+
+    # 7. branches hors norme. master/main sont candidates a la suppression ;
+    #    tout le reste est conserve. cls-borne porte des config/* vivantes et
+    #    cls-bff une feature/* : une regle « supprimer le hors-norme » les tuerait.
+    for b in $branches; do
+        (( ${envs[(I)$b]} )) && continue
+        if [[ "$b" == master || "$b" == main ]]; then
+            print -r -- "master_delete	$b"
+        else
+            print -r -- "warn	branche hors norme conservee : $b"
+        fi
+    done
+}
+```
+
+- [ ] **Step 4 : Lancer le test pour vérifier qu'il passe**
+
+Run: `scripts/tests/work-config-repos.test.sh`
+Expected: `== 39 ok, 0 echecs ==`
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add modules/work/config_repos.zsh scripts/tests/work-config-repos.test.sh
+git commit -m "feat(work): planificateur pur des ecarts a la norme"
+```
+
+---
+
+### Task 4 : Point d'entrée, options, aide et completions
+
+**Files:**
+- Modify: `modules/work/config_repos.zsh`
+- Modify: `modules/work/completions.zsh`
+- Modify: `scripts/tests/work-config-repos.test.sh`
+
+**Interfaces:**
+- Consomme : `_work_cfg_parse_path`, `_work_cfg_guard_target` (Task 1), `_work_cfg_normalize_envs` (Task 2)
+- Produit :
+  - `work_config_repo [<repo>] [--bu X] [--app Y] [--envs csv] [--readme] [--fix] [-h|--help]`
+  - `_work_cfg_usage` → aide sur stdout
+  - variables résolues passées aux tâches suivantes : `bu`, `app`, `repo`, `envs_csv`, `readme_optin`, `do_fix`
+
+- [ ] **Step 1 : Écrire le test qui échoue**
+
+Ajouter à `scripts/tests/work-config-repos.test.sh` avant le bloc final :
+
+```bash
+echo
+echo "== parsing d options =="
+
+zc 'work_config_repo --help | head -1' \
+    | assert_equals "aide disponible" "Usage: work_config_repo [<repo>] [options]"
+
+# Le piege zsh : un flag a valeur en dernier argument. Sous `set -u` en bash, shift 2
+# echoue ; en zsh il boucle a l infini. Le timeout est la garde du test.
+( zc 'work_config_repo --envs 2>/dev/null; print "rc=$?"' & sleep 5; kill %1 2>/dev/null ) \
+    | head -1 | assert_equals "--envs en dernier argument ne boucle pas" "rc=1"
+
+( zc 'work_config_repo --bu 2>/dev/null; print "rc=$?"' & sleep 5; kill %1 2>/dev/null ) \
+    | head -1 | assert_equals "--bu en dernier argument ne boucle pas" "rc=1"
+
+zc 'work_config_repo --bu blg --app demoapp technical-assets >/dev/null 2>&1; print "rc=$?"' \
+    | assert_equals "technical-assets nomme explicitement : rc=1" "rc=1"
+
+zc 'work_config_repo --zzz >/dev/null 2>&1; print "rc=$?"' \
+    | assert_equals "option inconnue : rc=1" "rc=1"
+
+zc 'work_config_repo --bu blg --app demoapp --envs uat demo-x >/dev/null 2>&1; print "rc=$?"' \
+    | assert_equals "env inconnu : rc=1" "rc=1"
+
+# Hors du chemin canonique et sans flags : refus, sans reseau.
+zc 'cd "$TMPDIR" 2>/dev/null || cd /
+    work_config_repo >/dev/null 2>&1; print "rc=$?"' \
+    | assert_equals "cible indeterminable : rc=1" "rc=1"
+```
+
+- [ ] **Step 2 : Lancer le test pour vérifier qu'il échoue**
+
+Run: `scripts/tests/work-config-repos.test.sh`
+Expected: 40 ok puis FAIL — `work_config_repo: command not found`
+
+- [ ] **Step 3 : Écrire l'implémentation minimale**
+
+Ajouter à `modules/work/config_repos.zsh` :
+
+```zsh
+# --- Point d entree ---
+
+_work_cfg_usage() {
+    print -r -- "Usage: work_config_repo [<repo>] [options]"
+    print -r -- ""
+    print -r -- "  Audite un repo de configuration, ou le met aux normes avec --fix."
+    print -r -- "  Sans argument, la cible est deduite du repertoire courant."
+    print -r -- ""
+    print -r -- "  --bu <${(j:|:)_WORK_CFG_BU_ALL}>"
+    print -r -- "  --app <nom>              application"
+    print -r -- "  --envs <csv>             sous-ensemble d envs (defaut: ${(j:,:)_WORK_CFG_ENVS_ALL})"
+    print -r -- "  --readme                 autorise la reecriture des README preexistants"
+    print -r -- "  --fix                    applique ; sans lui, audit en lecture seule"
+    print -r -- "  -h, --help               cette aide"
+    print -r -- ""
+    print -r -- "  Codes de sortie : 0 conforme ou corrige, 1 erreur, 2 ecarts detectes."
+}
+
+work_config_repo() {
+    local bu="" app="" repo="" envs_csv="" readme_optin=0 do_fix=0
+
+    while (( $# )); do
+        case "$1" in
+            --bu)
+                (( $# >= 2 )) || { _ui_msg_fail "--bu attend une valeur"; return 1 }
+                bu="$2"; shift 2 ;;
+            --app)
+                (( $# >= 2 )) || { _ui_msg_fail "--app attend une valeur"; return 1 }
+                app="$2"; shift 2 ;;
+            --envs)
+                (( $# >= 2 )) || { _ui_msg_fail "--envs attend une valeur"; return 1 }
+                envs_csv="$2"; shift 2 ;;
+            --readme) readme_optin=1; shift ;;
+            --fix)    do_fix=1; shift ;;
+            -h|--help) _work_cfg_usage; return 0 ;;
+            -*) _ui_msg_fail "option inconnue : $1"; _work_cfg_usage; return 1 ;;
+            *)  repo="$1"; shift ;;
+        esac
+    done
+
+    # Deduction depuis le repertoire courant pour ce qui n a pas ete passe.
+    if [[ -z "$bu" || -z "$app" || -z "$repo" ]]; then
+        local parsed p_bu p_app p_repo
+        if parsed=$(_work_cfg_parse_path "$PWD"); then
+            IFS=$'\t' read -r p_bu p_app p_repo <<< "$parsed"
+            [[ -z "$bu" ]]   && bu="$p_bu"
+            [[ -z "$app" ]]  && app="$p_app"
+            [[ -z "$repo" ]] && repo="$p_repo"
+        fi
+    fi
+
+    _work_cfg_guard_target "$bu" "$app" "$repo" || return 1
+
+    envs_csv=$(_work_cfg_normalize_envs "${envs_csv:-${(j:,:)_WORK_CFG_ENVS_ALL}}") || return 1
+
+    _work_cfg_run "$bu" "$app" "$repo" "$envs_csv" "$readme_optin" "$do_fix"
+}
+
+# Provisoire — remplacee en Task 6. Permet de valider le parsing des le Task 4.
+_work_cfg_run() {
+    _ui_msg_info "cible : $1/applications/$2/configurations/$3 — envs $4 (readme=$5 fix=$6)"
+    return 0
+}
+```
+
+- [ ] **Step 4 : Lancer le test pour vérifier qu'il passe**
+
+Run: `scripts/tests/work-config-repos.test.sh`
+Expected: `== 46 ok, 0 echecs ==`
+
+- [ ] **Step 5 : Ajouter les completions**
+
+Ajouter à la fin de `modules/work/completions.zsh` :
+
+```zsh
+_work_config_repo() {
+    _arguments \
+        '--bu[Business unit]:bu:(blg edt udb tsc shared)' \
+        '--app[Application]:app:' \
+        '--envs[Sous-ensemble d envs, separes par des virgules]:envs:(dev dev,qlf dev,qlf,pprd dev,qlf,pprd,prd)' \
+        '--readme[Autorise la reecriture des README preexistants]' \
+        '--fix[Applique les corrections au lieu d auditer]' \
+        '(-h --help)'{-h,--help}'[Afficher l aide]' \
+        '1:repo de configuration:'
+}
+compdef _work_config_repo work_config_repo
+```
+
+Run: `zsh -n modules/work/completions.zsh && zsh -n modules/work/config_repos.zsh && echo SYNTAXE-OK`
+Expected: `SYNTAXE-OK`
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add modules/work/config_repos.zsh modules/work/completions.zsh scripts/tests/work-config-repos.test.sh
+git commit -m "feat(work): point d entree work_config_repo, aide et completions"
+```
+
+---
+
+### Task 5 : Couche réseau
+
+**Files:**
+- Modify: `modules/work/config_repos.zsh`
+- Modify: `scripts/tests/work-config-repos.test.sh`
+
+**Interfaces:**
+- Consomme : rien
+- Produit :
+  - `_work_cfg_require` → `return 0|1`, source `~/.gitlab_secrets` si besoin
+  - `_work_cfg_api` → `https://<domaine>/api/v4`
+  - `_work_cfg_curl METHOD PATH [BODY]` → code HTTP en 1re ligne, corps ensuite ; `return` = code curl
+  - `_work_cfg_json METHOD PATH [BODY]` → corps seul ; `return 1` et remplit `$_work_cfg_last_error`
+  - `_work_cfg_enc <chemin>` → chemin URL-encodé pour l'API (`/` → `%2F`)
+
+- [ ] **Step 1 : Écrire le test qui échoue**
+
+Ajouter à `scripts/tests/work-config-repos.test.sh` avant le bloc final :
+
+```bash
+echo
+echo "== couche reseau =="
+
+zc '_work_cfg_enc "blg/applications/demoapp/configurations/demo-front"' \
+    | assert_equals "chemin encode pour l API" "blg%2Fapplications%2Fdemoapp%2Fconfigurations%2Fdemo-front"
+
+zc 'GITLAB_BASE_DOMAIN=forge.exemple.test; _work_cfg_api' \
+    | assert_equals "URL de l API construite" "https://forge.exemple.test/api/v4"
+
+zc 'unset GITLAB_BASE_DOMAIN GITLAB_TOKEN
+    HOME=$TMPDIR
+    _work_cfg_require >/dev/null 2>&1; print "rc=$?"' \
+    | assert_equals "sans domaine ni token : refus" "rc=1"
+
+# Le point qui compte : hors reseau, la commande echoue vite, elle ne pend pas.
+zc 'GITLAB_BASE_DOMAIN=127.0.0.1:9 GITLAB_TOKEN=x
+    SECONDS=0
+    _work_cfg_json GET version >/dev/null 2>&1
+    rc=$?
+    print "rc=$rc borne=$(( SECONDS <= 10 ))"' \
+    | assert_equals "hote injoignable : echec immediat, pas de pendaison" "rc=1 borne=1"
+
+zc 'GITLAB_BASE_DOMAIN=127.0.0.1:9 GITLAB_TOKEN=x
+    _work_cfg_json GET version >/dev/null 2>&1
+    [[ -n "$_work_cfg_last_error" ]] && print renseigne || print vide' \
+    | assert_equals "la cause de l echec est nommee" "renseigne"
+
+# Pas de -k : la commande ne doit jamais desactiver la verification TLS.
+grep -c -- '-k' "$MOD" | tr -d ' ' | assert_equals "aucun -k dans le module" "0"
+grep -c -- '--insecure' "$MOD" | tr -d ' ' | assert_equals "aucun --insecure dans le module" "0"
+```
+
+- [ ] **Step 2 : Lancer le test pour vérifier qu'il échoue**
+
+Run: `scripts/tests/work-config-repos.test.sh`
+Expected: 47 ok puis FAIL — `_work_cfg_enc: command not found`
+
+- [ ] **Step 3 : Écrire l'implémentation minimale**
+
+Ajouter à `modules/work/config_repos.zsh`, avant le bloc « Point d entree » :
+
+```zsh
+# --- Couche reseau ---
+#
+# Calquee sur _work_es_curl / _work_es_json. Une difference assumee avec
+# modules/gitlab/gitlab_logic.zsh : pas de -k. Verifie le 2026-08-07, la forge
+# repond 200 sans desactiver la verification TLS — desactiver par precaution
+# reviendrait a accepter n importe quel certificat pour rien.
+
+_work_cfg_api() {
+    print -r -- "https://${GITLAB_BASE_DOMAIN}/api/v4"
+}
+
+# Encode un chemin de projet ou de groupe pour l API (les / deviennent %2F).
+_work_cfg_enc() {
+    print -r -- "${1//\//%2F}"
+}
+
+_work_cfg_require() {
+    if ! command -v curl &>/dev/null; then
+        _ui_msg_fail "curl requis"; return 1
+    fi
+    if ! command -v jq &>/dev/null; then
+        _ui_msg_fail "jq requis (brew install jq / apt install jq)"; return 1
+    fi
+    if [[ -z "${GITLAB_TOKEN:-}" && -f "$HOME/.gitlab_secrets" ]]; then
+        source "$HOME/.gitlab_secrets"
+    fi
+    if [[ -z "${GITLAB_BASE_DOMAIN:-}" ]]; then
+        _ui_msg_fail "GITLAB_BASE_DOMAIN non definie (voir ~/.gitlab_secrets)"; return 1
+    fi
+    if [[ -z "${GITLAB_TOKEN:-}" ]]; then
+        _ui_msg_fail "GITLAB_TOKEN non defini (voir ~/.gitlab_secrets)"; return 1
+    fi
+    return 0
+}
+
+# Usage : _work_cfg_curl METHOD PATH [BODY]
+# Sortie : 1re ligne = code HTTP, reste = corps. Return = code de sortie curl.
+_work_cfg_curl() {
+    local method=$1 api_path=$2 body="${3:-}"
+    local -a opts
+    opts=(-s --connect-timeout 5 --max-time 30 -X "$method")
+    [[ -n "${SSL_CERT_FILE:-}" ]] && opts+=(--cacert "$SSL_CERT_FILE")
+    opts+=(-H "PRIVATE-TOKEN: $GITLAB_TOKEN" -H 'Content-Type: application/json')
+    [[ -n "$body" ]] && opts+=(-d "$body")
+
+    local out ret
+    out=$(command curl "${opts[@]}" -w $'\n%{http_code}' "$(_work_cfg_api)/$api_path" 2>/dev/null)
+    ret=$?
+    (( ret != 0 )) && return $ret
+    print -r -- "${out##*$'\n'}"
+    local resp="${out%$'\n'*}"
+    [[ "$resp" != "$out" && -n "$resp" ]] && print -r -- "$resp"
+    return 0
+}
+
+# Usage : _work_cfg_json METHOD PATH [BODY]
+# Sortie : corps seul. Return 1 en cas d echec, avec la cause dans
+# _work_cfg_last_error — un « echec » nu ne dit pas si c est le VPN, le token
+# ou le chemin qui est en cause, et les trois envoient a des endroits opposes.
+_work_cfg_json() {
+    typeset -g _work_cfg_last_error=""
+    local out code rc
+    out=$(_work_cfg_curl "$@"); rc=$?
+    if (( rc != 0 )); then
+        case $rc in
+            6)  _work_cfg_last_error="hote introuvable (DNS) — VPN actif ?" ;;
+            7)  _work_cfg_last_error="connexion refusee" ;;
+            28) _work_cfg_last_error="delai depasse" ;;
+            35|60) _work_cfg_last_error="echec TLS — SSL_CERT_FILE pointe-t-il le bundle d entreprise ?" ;;
+            *)  _work_cfg_last_error="curl a rendu $rc" ;;
+        esac
+        return 1
+    fi
+    code="${out%%$'\n'*}"
+    if [[ "$code" != <-> ]]; then
+        _work_cfg_last_error="reponse sans code HTTP — un proxy s est interpose ?"
+        return 1
+    fi
+    if (( code >= 400 )); then
+        case $code in
+            401) _work_cfg_last_error="HTTP 401 — GITLAB_TOKEN refuse" ;;
+            403) _work_cfg_last_error="HTTP 403 — droits insuffisants (Maintainer requis sur les branches protegees)" ;;
+            404) _work_cfg_last_error="HTTP 404 — ressource introuvable" ;;
+            *)   _work_cfg_last_error="HTTP $code" ;;
+        esac
+        [[ "$out" == *$'\n'* ]] && \
+            _work_cfg_last_error+=" : $(print -r -- "${out#*$'\n'}" | head -c 300)"
+        return 1
+    fi
+    [[ "$out" == *$'\n'* ]] && print -r -- "${out#*$'\n'}"
+    return 0
+}
+```
+
+- [ ] **Step 4 : Lancer le test pour vérifier qu'il passe**
+
+Run: `scripts/tests/work-config-repos.test.sh`
+Expected: `== 53 ok, 0 echecs ==`
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add modules/work/config_repos.zsh scripts/tests/work-config-repos.test.sh
+git commit -m "feat(work): couche reseau GitLab, sans desactivation TLS"
+```
+
+---
+
+### Task 6 : Collecte de l'état distant et rapport d'audit
+
+**Files:**
+- Modify: `modules/work/config_repos.zsh`
+- Modify: `scripts/tests/work-config-repos.test.sh`
+
+**Interfaces:**
+- Consomme : `_work_cfg_json`, `_work_cfg_enc` (Task 5), `_work_cfg_build_plan` (Task 3), `_work_cfg_readme_content` (Task 2)
+- Produit :
+  - `_work_cfg_collect <bu> <app> <repo> <envs_csv>` → remplit les globales `_work_cfg_pid`, `_work_cfg_default`, `_work_cfg_branches`, `_work_cfg_rules`, `_work_cfg_readmes` ; `return 0` si le projet existe, `2` s'il n'existe pas (404), `1` sur erreur
+  - `_work_cfg_render <repo> <plan>` → rapport lisible sur stdout
+  - `_work_cfg_run` (remplace le stub du Task 4)
+
+- [ ] **Step 1 : Écrire le test qui échoue**
+
+Le rendu est pur : il prend un plan et rend du texte. C'est lui qu'on teste. Ajouter avant le bloc final :
+
+```bash
+echo
+echo "== rendu du rapport =="
+
+zc "_work_cfg_render demo-x '' | tail -1" \
+    | assert_equals "plan vide : conformite annoncee" "  Rien a faire — le repo est conforme."
+
+zc "_work_cfg_render demo-docs \"\$(printf 'branch_create\tqlf\tdev\nreadme_write\tqlf')\" | grep -c '^  '" \
+    | assert_equals "deux actions rendues sur deux lignes" "2"
+
+zc "_work_cfg_render demo-docs \"\$(printf 'branch_create\tqlf\tdev')\" | grep -o 'creer branche qlf depuis dev'" \
+    | assert_equals "creation de branche libellee" "creer branche qlf depuis dev"
+
+zc "_work_cfg_render demo-x \"\$(printf 'protect_replace\tprd')\" | grep -o 'fenetre de non-protection'" \
+    | assert_equals "le remplacement de protection annonce sa fenetre" "fenetre de non-protection"
+
+zc "_work_cfg_render demo-x \"\$(printf 'master_delete\tmaster')\" | grep -o 'sous reserve du merge-base'" \
+    | assert_equals "la suppression de master annonce sa garde" "sous reserve du merge-base"
+
+zc "_work_cfg_count_actions \"\$(printf 'branch_create\tqlf\tdev\nwarn\tblabla\nreadme_write\tqlf')\"" \
+    | assert_equals "les avertissements ne comptent pas comme des actions" "2"
+```
+
+- [ ] **Step 2 : Lancer le test pour vérifier qu'il échoue**
+
+Run: `scripts/tests/work-config-repos.test.sh`
+Expected: 54 ok puis FAIL — `_work_cfg_render: command not found`
+
+- [ ] **Step 3 : Écrire l'implémentation minimale**
+
+Ajouter à `modules/work/config_repos.zsh` :
+
+```zsh
+# --- Collecte de l etat distant ---
+
+# Remplit les globales decrivant l etat du repo. Return 2 si le projet n existe pas.
+_work_cfg_collect() {
+    local bu="$1" app="$2" repo="$3" envs_csv="$4"
+    typeset -g _work_cfg_pid="" _work_cfg_default="" \
+               _work_cfg_branches="" _work_cfg_rules="" _work_cfg_readmes=""
+
+    local full="$bu/applications/$app/configurations/$repo"
+    local enc; enc=$(_work_cfg_enc "$full")
+
+    local proj
+    if ! proj=$(_work_cfg_json GET "projects/$enc"); then
+        [[ "$_work_cfg_last_error" == HTTP\ 404* ]] && return 2
+        _ui_msg_fail "lecture du projet : $_work_cfg_last_error"
+        return 1
+    fi
+    _work_cfg_pid=$(print -r -- "$proj" | jq -r '.id')
+    _work_cfg_default=$(print -r -- "$proj" | jq -r '.default_branch // ""')
+
+    local br rules
+    br=$(_work_cfg_json GET "projects/$_work_cfg_pid/repository/branches?per_page=100") || {
+        _ui_msg_fail "lecture des branches : $_work_cfg_last_error"; return 1
+    }
+    _work_cfg_branches=$(print -r -- "$br" | jq -r '.[].name')
+
+    rules=$(_work_cfg_json GET "projects/$_work_cfg_pid/protected_branches?per_page=100") || {
+        _ui_msg_fail "lecture des protections : $_work_cfg_last_error"; return 1
+    }
+    _work_cfg_rules=$(print -r -- "$rules" | jq -r '
+        .[] | [ .name,
+                (.push_access_levels[0].access_level  // "0" | tostring),
+                (.merge_access_levels[0].access_level // "0" | tostring),
+                (.allow_force_push | tostring) ] | @tsv')
+
+    # Etat des README, une lecture par branche d env existante.
+    local -a envs; envs=(${(s:,:)envs_csv})
+    local e want got code raw lines
+    for e in $envs; do
+        print -r -- "$_work_cfg_branches" | grep -qx -- "$e" || continue
+        want=$(_work_cfg_readme_content "$repo" "$e")
+        raw=$(_work_cfg_curl GET "projects/$_work_cfg_pid/repository/files/README%2Emd/raw?ref=$e")
+        code="${raw%%$'\n'*}"
+        if [[ "$code" == 404 ]]; then
+            _work_cfg_readmes+="$e	absent"$'\n'
+        elif [[ "$code" == 200 ]]; then
+            got="${raw#*$'\n'}"
+            if [[ "${got%$'\n'}" == "$want" ]]; then
+                _work_cfg_readmes+="$e	ok"$'\n'
+            else
+                _work_cfg_readmes+="$e	divergent"$'\n'
+            fi
+        else
+            _work_cfg_readmes+="$e	divergent"$'\n'
+        fi
+    done
+    return 0
+}
+
+# --- Rendu ---
+
+# Compte les actions reelles d un plan : les lignes `warn` n en sont pas.
+_work_cfg_count_actions() {
+    local line n=0
+    for line in ${(f)${1:-}}; do
+        [[ -z "$line" ]] && continue
+        [[ "${line%%	*}" == warn ]] && continue
+        (( n++ ))
+    done
+    print -r -- "$n"
+}
+
+# Rend un plan en texte lisible. Fonction pure : aucune lecture distante.
+_work_cfg_render() {
+    local repo="$1" plan="$2"
+    local line kind a b n
+    n=$(_work_cfg_count_actions "$plan")
+
+    if (( n == 0 )); then
+        for line in ${(f)plan}; do
+            [[ -z "$line" ]] && continue
+            IFS=$'\t' read -r kind a b <<< "$line"
+            [[ "$kind" == warn ]] && print -r -- "  ${_ui_yellow}!${_ui_nc} $a"
+        done
+        print -r -- "  Rien a faire — le repo est conforme."
+        return 0
+    fi
+
+    print -r -- "${_ui_bold}Plan ($n actions)${_ui_nc}"
+    for line in ${(f)plan}; do
+        [[ -z "$line" ]] && continue
+        IFS=$'\t' read -r kind a b <<< "$line"
+        case "$kind" in
+            branch_create) print -r -- "  + creer branche $a depuis $b" ;;
+            default_set)   print -r -- "  ~ basculer la branche par defaut sur $a" ;;
+            protect_create) print -r -- "  + proteger $a (Maintainers/Maintainers, force=off)" ;;
+            protect_replace) print -r -- "  ~ remplacer la protection de $a — breve fenetre de non-protection (GitLab CE)" ;;
+            protect_patch) print -r -- "  ~ desactiver allow_force_push sur $a" ;;
+            unprotect)     print -r -- "  - deproteger $a" ;;
+            rule_delete_orphan) print -r -- "  - supprimer la regle orpheline « $a »" ;;
+            readme_write)  print -r -- "  ~ README de $a → « $(_work_cfg_readme_content "$repo" "$a") »" ;;
+            master_delete) print -r -- "  - supprimer $a, sous reserve du merge-base" ;;
+            warn)          print -r -- "  ${_ui_yellow}!${_ui_nc} $a" ;;
+        esac
+    done
+    return 0
+}
+
+# --- Orchestration ---
+
+_work_cfg_run() {
+    local bu="$1" app="$2" repo="$3" envs_csv="$4" readme_optin="$5" do_fix="$6"
+
+    _work_cfg_require || return 1
+
+    _ui_header "Repo de configuration"
+    _ui_section "Cible" "$bu/applications/$app/configurations/$repo"
+    _ui_section "Envs" "$envs_csv"
+
+    local rc; _work_cfg_collect "$bu" "$app" "$repo" "$envs_csv"; rc=$?
+    (( rc == 1 )) && return 1
+    if (( rc == 2 )); then
+        _ui_msg_warn "le projet n existe pas encore sur la forge"
+        (( do_fix )) || { _ui_msg_info "relancer avec --fix pour le creer"; return 2 }
+        _work_cfg_create "$bu" "$app" "$repo" "$envs_csv"
+        return $?
+    fi
+
+    local plan
+    plan=$(_work_cfg_build_plan "$repo" "$envs_csv" "$readme_optin" "$_work_cfg_default" \
+            "$_work_cfg_branches" "$_work_cfg_rules" "$_work_cfg_readmes")
+
+    echo ""
+    _work_cfg_render "$repo" "$plan"
+
+    local n; n=$(_work_cfg_count_actions "$plan")
+    (( n == 0 )) && return 0
+    (( do_fix )) || return 2
+
+    _work_cfg_confirm_and_apply "$repo" "$envs_csv" "$readme_optin" "$plan"
+}
+```
+
+Ajouter aussi un stub temporaire, remplacé aux tâches 7 à 9 :
+
+```zsh
+# Provisoire — remplacees en Task 7 (confirmation), 8 (application), 9 (creation).
+_work_cfg_confirm_and_apply() { _ui_msg_warn "application non encore implementee"; return 1 }
+_work_cfg_create() { _ui_msg_warn "creation non encore implementee"; return 1 }
+```
+
+- [ ] **Step 4 : Lancer le test pour vérifier qu'il passe**
+
+Run: `scripts/tests/work-config-repos.test.sh`
+Expected: `== 59 ok, 0 echecs ==`
+
+- [ ] **Step 5 : Audit réel en lecture seule**
+
+Run: `zsh -ic 'work_config_repo --bu blg --app frontlibreservice cls-bff; print "rc=$?"'`
+Expected: rapport, `Rien a faire — le repo est conforme.`, `rc=0`
+
+Run: `zsh -ic 'work_config_repo --bu blg --app frontlibreservice cls-docs; print "rc=$?"'`
+Expected: plan listant `creer branche qlf depuis dev` et `creer branche pprd depuis dev`, `rc=2`. **Aucune écriture** : `--fix` n'est pas passé.
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add modules/work/config_repos.zsh scripts/tests/work-config-repos.test.sh
+git commit -m "feat(work): collecte de l etat distant et rapport d audit"
+```
+
+---
+
+### Task 7 : Dialogue [y/N/u]
+
+**Files:**
+- Modify: `modules/work/config_repos.zsh`
+- Modify: `scripts/tests/work-config-repos.test.sh`
+
+**Interfaces:**
+- Consomme : `_work_cfg_build_plan` (Task 3), `_work_cfg_render`, `_work_cfg_count_actions` (Task 6)
+- Produit :
+  - `_work_cfg_read_answer` → `y|n|u` sur stdout ; lit une ligne sur stdin, défaut `n`
+  - `_work_cfg_confirm_and_apply <repo> <envs_csv> <readme_optin> <plan>` (remplace le stub du Task 6)
+
+- [ ] **Step 1 : Écrire le test qui échoue**
+
+Ajouter avant le bloc final :
+
+```bash
+echo
+echo "== dialogue y/N/u =="
+
+zc 'print "" | _work_cfg_read_answer' \
+    | assert_equals "entree vide : refus par defaut" "n"
+
+zc 'print "y" | _work_cfg_read_answer' | assert_equals "y accepte" "y"
+zc 'print "Y" | _work_cfg_read_answer' | assert_equals "Y accepte (casse ignoree)" "y"
+zc 'print "u" | _work_cfg_read_answer' | assert_equals "u accepte" "u"
+zc 'print "n" | _work_cfg_read_answer' | assert_equals "n accepte" "n"
+zc 'print "zzz" | _work_cfg_read_answer' | assert_equals "reponse inconnue : refus" "n"
+
+# stdin ferme (execution non interactive) : refus, jamais d application implicite.
+zc '_work_cfg_read_answer < /dev/null' \
+    | assert_equals "stdin ferme : refus" "n"
+```
+
+- [ ] **Step 2 : Lancer le test pour vérifier qu'il échoue**
+
+Run: `scripts/tests/work-config-repos.test.sh`
+Expected: 60 ok puis FAIL — `_work_cfg_read_answer: command not found`
+
+- [ ] **Step 3 : Écrire l'implémentation minimale**
+
+Remplacer le stub `_work_cfg_confirm_and_apply` dans `modules/work/config_repos.zsh` par :
+
+```zsh
+# Lit la reponse au prompt. Tout ce qui n est pas y ou u vaut non — y compris
+# une entree vide et un stdin ferme. Une execution non interactive ne doit jamais
+# appliquer quoi que ce soit par defaut.
+_work_cfg_read_answer() {
+    local ans
+    if ! read -r ans; then
+        print -r -- "n"; return 0
+    fi
+    case "${(L)ans}" in
+        y|yes|o|oui) print -r -- "y" ;;
+        u|update)    print -r -- "u" ;;
+        *)           print -r -- "n" ;;
+    esac
+}
+
+# Boucle de confirmation. `u` recalcule le plan avec une nouvelle liste d envs et
+# repropose : le sous-ensemble n est jamais persiste nulle part.
+_work_cfg_confirm_and_apply() {
+    local repo="$1" envs_csv="$2" readme_optin="$3" plan="$4"
+
+    while true; do
+        echo ""
+        print -n -- "Appliquer ? [y/N/u] "
+        local ans; ans=$(_work_cfg_read_answer)
+
+        case "$ans" in
+            y) _work_cfg_apply "$repo" "$plan"; return $? ;;
+            n) _ui_msg_info "rien n a ete ecrit"; return 2 ;;
+            u)
+                print -n -- "Quels envs ? (${(j:,:)_WORK_CFG_ENVS_ALL}) "
+                local raw; read -r raw || raw=""
+                local new_envs
+                new_envs=$(_work_cfg_normalize_envs "$raw") || continue
+                envs_csv="$new_envs"
+                _ui_section "Envs" "$envs_csv"
+                plan=$(_work_cfg_build_plan "$repo" "$envs_csv" "$readme_optin" \
+                        "$_work_cfg_default" "$_work_cfg_branches" "$_work_cfg_rules" \
+                        "$_work_cfg_readmes")
+                echo ""
+                _work_cfg_render "$repo" "$plan"
+                (( $(_work_cfg_count_actions "$plan") == 0 )) && return 0
+                ;;
+        esac
+    done
+}
+```
+
+Ajouter le stub temporaire de l'application, remplacé au Task 8 :
+
+```zsh
+# Provisoire — remplacee en Task 8.
+_work_cfg_apply() { _ui_msg_warn "application non encore implementee"; return 1 }
+```
+
+- [ ] **Step 4 : Lancer le test pour vérifier qu'il passe**
+
+Run: `scripts/tests/work-config-repos.test.sh`
+Expected: `== 66 ok, 0 echecs ==`
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add modules/work/config_repos.zsh scripts/tests/work-config-repos.test.sh
+git commit -m "feat(work): dialogue y/N/u avec recalcul du plan"
+```
+
+---
+
+### Task 8 : Application du plan et garde merge-base
+
+**Files:**
+- Modify: `modules/work/config_repos.zsh`
+- Modify: `scripts/tests/work-config-repos.test.sh`
+
+**Interfaces:**
+- Consomme : `_work_cfg_json` (Task 5), `_work_cfg_readme_content` (Task 2)
+- Produit :
+  - `_work_cfg_sha_contained <sha_branche> <sha_merge_base>` → `return 0|1` (pur)
+  - `_work_cfg_is_merged <pid> <branche> <cible>` → `return 0|1`
+  - `_work_cfg_sort_plan <plan>` → plan réordonné selon l'ordre d'application
+  - `_work_cfg_apply <repo> <plan>` (remplace le stub du Task 7)
+
+- [ ] **Step 1 : Écrire le test qui échoue**
+
+Ajouter avant le bloc final :
+
+```bash
+echo
+echo "== garde merge-base =="
+
+zc '_work_cfg_sha_contained abc123 abc123 && print sur || print refuse' \
+    | assert_equals "merge-base egal au SHA : suppression sure" "sur"
+
+zc '_work_cfg_sha_contained abc123 def456 && print sur || print refuse' \
+    | assert_equals "merge-base different : suppression refusee" "refuse"
+
+zc '_work_cfg_sha_contained "" "" && print sur || print refuse' \
+    | assert_equals "SHA vides : suppression refusee" "refuse"
+
+zc '_work_cfg_sha_contained abc123 "" && print sur || print refuse' \
+    | assert_equals "merge-base vide : suppression refusee" "refuse"
+
+echo
+echo "== ordre d application =="
+
+# L API refuse de supprimer la branche par defaut, et de supprimer une branche
+# protegee : l ordre n est donc pas libre.
+zc "_work_cfg_sort_plan \"\$(printf 'master_delete\tmaster\nprotect_create\tprd\nbranch_create\tqlf\tdev\ndefault_set\tdev\nreadme_write\tqlf\nunprotect\tqlf\nrule_delete_orphan\tzzz')\" | cut -f1" \
+    | assert_equals "sept etapes remises dans l ordre de la spec" \
+"$(printf 'branch_create\ndefault_set\nunprotect\nreadme_write\nprotect_create\nrule_delete_orphan\nmaster_delete')"
+
+zc "_work_cfg_sort_plan \"\$(printf 'warn\tblabla\nbranch_create\tqlf\tdev')\" | cut -f1" \
+    | assert_equals "les avertissements sortent en fin de plan" \
+"$(printf 'branch_create\nwarn')"
+```
+
+- [ ] **Step 2 : Lancer le test pour vérifier qu'il échoue**
+
+Run: `scripts/tests/work-config-repos.test.sh`
+Expected: 68 ok puis FAIL — `_work_cfg_sha_contained: command not found`
+
+- [ ] **Step 3 : Écrire l'implémentation minimale**
+
+Remplacer le stub `_work_cfg_apply` par :
+
+```zsh
+# --- Application ---
+
+# Une branche n est supprimable que si son sommet est deja contenu dans la cible.
+# Fonction pure, isolee pour etre testable : c est la seule garde entre un
+# `master` reprenant des commits absents de `dev` et leur perte.
+_work_cfg_sha_contained() {
+    [[ -n "${1:-}" && -n "${2:-}" && "$1" == "$2" ]]
+}
+
+# Return 0 si <branche> est deja contenue dans <cible>.
+_work_cfg_is_merged() {
+    local pid="$1" src="$2" dst="$3" sha base
+    sha=$(_work_cfg_json GET "projects/$pid/repository/branches/$src" | jq -r '.commit.id // ""') || return 1
+    base=$(_work_cfg_json GET "projects/$pid/repository/merge_base?refs%5B%5D=$src&refs%5B%5D=$dst" \
+            | jq -r '.id // ""') || return 1
+    _work_cfg_sha_contained "$sha" "$base"
+}
+
+# Remet le plan dans l ordre d application. L API impose deux contraintes qui se
+# croisent — on ne supprime pas la branche par defaut, on ne supprime pas une
+# branche protegee — et les README doivent etre ecrits avant que les protections
+# ne soient posees, sinon un repo neuf bute sur ses propres regles.
+_work_cfg_sort_plan() {
+    local -a order
+    order=(branch_create default_set unprotect readme_write protect_create
+           protect_replace protect_patch rule_delete_orphan master_delete warn)
+    local kind line
+    for kind in $order; do
+        for line in ${(f)${1:-}}; do
+            [[ -z "$line" ]] && continue
+            [[ "${line%%	*}" == "$kind" ]] && print -r -- "$line"
+        done
+    done
+}
+
+# Execute le plan. S arrete a la premiere erreur : appliquer la suite d un plan
+# dont une etape a echoue laisserait le repo dans un etat qu aucun des deux
+# rapports ne decrit.
+_work_cfg_apply() {
+    local repo="$1" plan="$2"
+    local pid="$_work_cfg_pid"
+    local line kind a b body
+
+    for line in ${(f)$(_work_cfg_sort_plan "$plan")}; do
+        [[ -z "$line" ]] && continue
+        IFS=$'\t' read -r kind a b <<< "$line"
+        case "$kind" in
+            branch_create)
+                _work_cfg_json POST "projects/$pid/repository/branches?branch=$a&ref=$b" >/dev/null \
+                    || { _ui_msg_fail "creation de $a : $_work_cfg_last_error"; return 1 }
+                _ui_msg_ok "branche $a creee depuis $b" ;;
+            default_set)
+                _work_cfg_json PUT "projects/$pid" "{\"default_branch\":\"$a\"}" >/dev/null \
+                    || { _ui_msg_fail "bascule du defaut sur $a : $_work_cfg_last_error"; return 1 }
+                _ui_msg_ok "branche par defaut : $a" ;;
+            unprotect)
+                _work_cfg_json DELETE "projects/$pid/protected_branches/$a" >/dev/null \
+                    || { _ui_msg_fail "deprotection de $a : $_work_cfg_last_error"; return 1 }
+                _ui_msg_ok "$a deprotegee" ;;
+            readme_write)
+                _work_cfg_write_readme "$pid" "$repo" "$a" || return 1 ;;
+            protect_create)
+                _work_cfg_protect "$pid" "$a" || return 1 ;;
+            protect_replace)
+                _ui_msg_warn "$a : fenetre de non-protection le temps du remplacement"
+                _work_cfg_json DELETE "projects/$pid/protected_branches/$a" >/dev/null \
+                    || { _ui_msg_fail "retrait de la protection de $a : $_work_cfg_last_error"; return 1 }
+                _work_cfg_protect "$pid" "$a" || return 1 ;;
+            protect_patch)
+                _work_cfg_json PATCH "projects/$pid/protected_branches/$a" \
+                    '{"allow_force_push":false}' >/dev/null \
+                    || { _ui_msg_fail "allow_force_push sur $a : $_work_cfg_last_error"; return 1 }
+                _ui_msg_ok "$a : allow_force_push desactive" ;;
+            rule_delete_orphan)
+                _work_cfg_json DELETE "projects/$pid/protected_branches/$a" >/dev/null \
+                    || { _ui_msg_fail "suppression de la regle « $a » : $_work_cfg_last_error"; return 1 }
+                _ui_msg_ok "regle orpheline « $a » supprimee" ;;
+            master_delete)
+                local target; target=$(_work_cfg_expected_default "$_work_cfg_envs_current")
+                if ! _work_cfg_is_merged "$pid" "$a" "$target"; then
+                    _ui_msg_warn "$a NON supprimee : elle porte des commits absents de $target"
+                    continue
+                fi
+                _work_cfg_json DELETE "projects/$pid/protected_branches/$a" >/dev/null 2>&1
+                _work_cfg_json DELETE "projects/$pid/repository/branches/$a" >/dev/null \
+                    || { _ui_msg_fail "suppression de $a : $_work_cfg_last_error"; return 1 }
+                _ui_msg_ok "$a supprimee (contenu repris dans $target)" ;;
+            warn)
+                _ui_msg_warn "$a" ;;
+        esac
+    done
+    return 0
+}
+
+_work_cfg_protect() {
+    local pid="$1" br="$2"
+    _work_cfg_json POST "projects/$pid/protected_branches?name=$br&push_access_level=$_WORK_CFG_PUSH_LEVEL&merge_access_level=$_WORK_CFG_MERGE_LEVEL&allow_force_push=false" >/dev/null \
+        || { _ui_msg_fail "protection de $br : $_work_cfg_last_error"; return 1 }
+    _ui_msg_ok "$br protegee (Maintainers/Maintainers, force=off)"
+    return 0
+}
+
+# Ecrit le README d une branche. Cree ou met a jour selon ce qui existe deja.
+# Sur une branche protegee, le commit part sous l identite du token : Maintainer,
+# il passe ; sinon GitLab rend 403 et on le dit. On ne deprotege jamais pour se
+# faire de la place.
+_work_cfg_write_readme() {
+    local pid="$1" repo="$2" br="$3"
+    local content; content=$(_work_cfg_readme_content "$repo" "$br")
+    local encoded; encoded=$(print -r -- "$content" | jq -Rs .)
+    local action=create
+    local probe; probe=$(_work_cfg_curl GET "projects/$pid/repository/files/README%2Emd?ref=$br")
+    [[ "${probe%%$'\n'*}" == 200 ]] && action=update
+
+    _work_cfg_json POST "projects/$pid/repository/commits" \
+        "{\"branch\":\"$br\",\"commit_message\":\"chore: normalise le README ($repo $br)\",\"actions\":[{\"action\":\"$action\",\"file_path\":\"README.md\",\"content\":$encoded}]}" >/dev/null \
+        || { _ui_msg_fail "README de $br : $_work_cfg_last_error"; return 1 }
+    _ui_msg_ok "README de $br normalise"
+    return 0
+}
+```
+
+Renseigner `_work_cfg_envs_current` dans `_work_cfg_run`, juste après le calcul de `envs_csv`, pour que `master_delete` sache quelle est la cible :
+
+```zsh
+typeset -g _work_cfg_envs_current="$envs_csv"
+```
+
+- [ ] **Step 4 : Lancer le test pour vérifier qu'il passe**
+
+Run: `scripts/tests/work-config-repos.test.sh`
+Expected: `== 72 ok, 0 echecs ==`
+
+- [ ] **Step 5 : Vérifier la syntaxe et l'absence de stubs résiduels**
+
+Run: `zsh -n modules/work/config_repos.zsh && echo SYNTAXE-OK`
+Expected: `SYNTAXE-OK`
+
+Les stubs `_work_cfg_confirm_and_apply` (Task 6) et `_work_cfg_apply` (Task 7) doivent avoir
+été remplacés, pas dupliqués — une seconde définition écraserait silencieusement la vraie.
+
+Run: `grep -c 'non encore implementee' modules/work/config_repos.zsh`
+Expected: `1` — il ne doit rester que celui de `_work_cfg_create`, remplacé au Task 9.
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add modules/work/config_repos.zsh scripts/tests/work-config-repos.test.sh
+git commit -m "feat(work): application du plan, garde merge-base sur master"
+```
+
+---
+
+### Task 9 : Création d'un repo absent
+
+**Files:**
+- Modify: `modules/work/config_repos.zsh`
+- Modify: `scripts/tests/work-config-repos.test.sh`
+
+**Interfaces:**
+- Consomme : `_work_cfg_json`, `_work_cfg_enc` (Task 5), `_work_cfg_protect`, `_work_cfg_write_readme` (Task 8)
+- Produit :
+  - `_work_cfg_local_path <bu> <app> <repo>` → chemin canonique local (pur)
+  - `_work_cfg_create <bu> <app> <repo> <envs_csv>` (remplace le stub du Task 6)
+
+- [ ] **Step 1 : Écrire le test qui échoue**
+
+Ajouter avant le bloc final :
+
+```bash
+echo
+echo "== chemin local de destination =="
+
+zc '_work_cfg_local_path blg demoapp demo-front' \
+    | assert_equals "chemin canonique reconstruit" "$TEST_TMPDIR/work/blg/applications/demoapp/configurations/demo-front"
+
+# Aller-retour : ce que _work_cfg_local_path produit, _work_cfg_parse_path le relit.
+zc '_work_cfg_parse_path "$(_work_cfg_local_path blg demoapp demo-front)"' \
+    | assert_equals "aller-retour chemin stable" "$(printf 'blg\tdemoapp\tdemo-front')"
+
+zc 'p=$(_work_cfg_local_path tsc autreapp demo-api); _work_cfg_parse_path "$p"' \
+    | assert_equals "aller-retour sur une autre BU" "$(printf 'tsc\tautreapp\tdemo-api')"
+```
+
+- [ ] **Step 2 : Lancer le test pour vérifier qu'il échoue**
+
+Run: `scripts/tests/work-config-repos.test.sh`
+Expected: 74 ok puis FAIL — `_work_cfg_local_path: command not found`
+
+- [ ] **Step 3 : Écrire l'implémentation minimale**
+
+Remplacer le stub `_work_cfg_create` par :
+
+```zsh
+# --- Creation ---
+
+_work_cfg_local_path() {
+    print -r -- "${WORK_DIR:-$HOME/work}/$1/applications/$2/configurations/$3"
+}
+
+# Cree le projet, ses branches, ses protections, puis le clone au chemin canonique.
+# Le groupe `configurations` n est JAMAIS cree : une frappe fautive doit echouer,
+# pas laisser un groupe orphelin sur la forge.
+_work_cfg_create() {
+    local bu="$1" app="$2" repo="$3" envs_csv="$4"
+    local -a envs; envs=(${(s:,:)envs_csv})
+    local grp="$bu/applications/$app/configurations"
+    local enc; enc=$(_work_cfg_enc "$grp")
+
+    local gid
+    gid=$(_work_cfg_json GET "groups/$enc" | jq -r '.id // ""') || {
+        _ui_msg_fail "groupe $grp introuvable : $_work_cfg_last_error"
+        _ui_msg_info "ce groupe n est pas cree automatiquement — le creer sur la forge d abord"
+        return 1
+    }
+    [[ -n "$gid" ]] || { _ui_msg_fail "groupe $grp introuvable"; return 1 }
+
+    local default_env="${envs[1]}"
+    local proj
+    proj=$(_work_cfg_json POST projects \
+        "{\"name\":\"$repo\",\"path\":\"$repo\",\"namespace_id\":$gid,\"visibility\":\"internal\",\"default_branch\":\"$default_env\",\"initialize_with_readme\":true}") \
+        || { _ui_msg_fail "creation du projet : $_work_cfg_last_error"; return 1 }
+
+    typeset -g _work_cfg_pid; _work_cfg_pid=$(print -r -- "$proj" | jq -r '.id')
+    _ui_msg_ok "projet $grp/$repo cree"
+
+    _work_cfg_write_readme "$_work_cfg_pid" "$repo" "$default_env" || return 1
+
+    local e
+    for e in ${envs[2,-1]}; do
+        _work_cfg_json POST "projects/$_work_cfg_pid/repository/branches?branch=$e&ref=$default_env" >/dev/null \
+            || { _ui_msg_fail "creation de $e : $_work_cfg_last_error"; return 1 }
+        _ui_msg_ok "branche $e creee depuis $default_env"
+        _work_cfg_write_readme "$_work_cfg_pid" "$repo" "$e" || return 1
+    done
+
+    # Les protections viennent apres les README : l inverse ferait buter les commits
+    # sur les regles qu on vient d ecrire.
+    for e in $envs; do
+        _work_cfg_env_is_protected "$e" && { _work_cfg_protect "$_work_cfg_pid" "$e" || return 1 }
+    done
+
+    local url dest
+    url=$(print -r -- "$proj" | jq -r '.http_url_to_repo')
+    dest=$(_work_cfg_local_path "$bu" "$app" "$repo")
+    mkdir -p "${dest:h}" || { _ui_msg_fail "creation de ${dest:h}"; return 1 }
+    if git clone "$url" "$dest"; then
+        _ui_msg_ok "clone : $dest"
+        cd "$dest"
+    else
+        _ui_msg_fail "clone en echec — le projet existe, le cloner a la main : git clone $url $dest"
+        return 1
+    fi
+    return 0
+}
+```
+
+- [ ] **Step 4 : Lancer le test pour vérifier qu'il passe**
+
+Run: `scripts/tests/work-config-repos.test.sh`
+Expected: `== 75 ok, 0 echecs ==`
+
+- [ ] **Step 5 : Vérification finale, chargement et non-régression**
+
+Run: `zsh -n modules/work/config_repos.zsh && zsh -n modules/work/completions.zsh && echo SYNTAXE-OK`
+Expected: `SYNTAXE-OK`
+
+Run: `zsh -f -c 'ZANVIL_DIR=$PWD; source core/ui.zsh; source modules/work/config_repos.zsh; print "charge=$(( $+functions[work_config_repo] ))"'`
+Expected: `charge=1`
+
+Run: `scripts/tests/zsh-special-vars.test.sh`
+Expected: aucune régression — le nouveau fichier ne doit déclarer aucun `local path=` / `local status=`
+
+Run: `zsh -ic 'work_config_repo --bu blg --app frontlibreservice cls-bff; print "rc=$?"'`
+Expected: `Rien a faire — le repo est conforme.`, `rc=0`
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add modules/work/config_repos.zsh scripts/tests/work-config-repos.test.sh
+git commit -m "feat(work): creation d un repo de configuration et clone local"
+```
+
+---
+
+## Ce que le plan ne couvre pas
+
+Repris de la spec, pour mémoire — aucune tâche ne les implémente :
+
+- création de groupes sur la forge
+- persistance du sous-ensemble d'envs
+- balayage de tous les repos d'un groupe en une commande
+- alignement des `merge_method`, `squash_option`, règles d'approbation
+- toute opération sur `technical-assets`
+- suppression de branches autres que `master`/`main`
+
+## Point de vigilance à l'exécution
+
+Les tâches 1 à 5 et 7 à 9 se vérifient hors réseau. La **tâche 6** est la seule dont l'étape 5 touche la forge, en **lecture seule** (`cls-bff` et `cls-docs`, sans `--fix`). La première écriture réelle n'a lieu qu'après la tâche 8, et seulement sur un repo que tu choisis explicitement — le plan ne prescrit aucun `--fix` sur un repo existant.

--- a/web/docs/superpowers/specs/2026-08-07-work-config-repos-design.md
+++ b/web/docs/superpowers/specs/2026-08-07-work-config-repos-design.md
@@ -62,9 +62,14 @@ Aucun contenu commun entre ces repos : chacun a son arborescence propre (`helm/`
 
 ### `technical-assets`
 
-Hors périmètre d'écriture, sur décision explicite. Il sert de témoin en lecture seule.
-Ses protections sont identiques à celles des `cls-*` (Maintainers / Maintainers / force=off),
-mais sa topologie de branches ne l'est pas (mono-branche `master` ou `main`).
+**Entièrement hors périmètre**, sur décision explicite : ni écriture, ni audit. La commande le
+refuse avant tout appel réseau, quels que soient les flags.
+
+Ce repo appartient à une autre chaîne de responsabilité et sa topologie n'est de toute façon
+pas celle de la norme : il est mono-branche (`master` ou `main`), là où la norme en attend
+quatre. L'auditer produirait un rapport d'écarts qui n'aurait aucun sens à corriger. Ses
+protections ont servi de point de comparaison pendant la conception ; elles ne sont pas lues
+à l'exécution.
 
 ## Périmètre
 
@@ -72,7 +77,7 @@ mais sa topologie de branches ne l'est pas (mono-branche `master` ou `main`).
 
 **Hors périmètre, refusé avant tout appel réseau** :
 
-- `technical-assets` — audit en lecture seule autorisé, **toute écriture refusée**, `--fix` compris
+- `technical-assets` — **refusé entièrement**, audit compris
 - tout chemin sous `configurations/companion/`
 - une BU hors `blg|edt|udb|tsc|shared`
 - un chemin hors d'un groupe `configurations`
@@ -325,5 +330,5 @@ Volontairement écartés :
 - persistance du sous-ensemble d'envs (topic GitLab, fichier local, fichier dans le repo)
 - balayage de tous les repos d'un groupe en une commande
 - alignement des `merge_method`, `squash_option`, règles d'approbation
-- toute écriture sur `technical-assets`
+- toute opération sur `technical-assets`, audit compris
 - suppression de branches autres que `master`/`main`

--- a/web/docs/superpowers/specs/2026-08-07-work-config-repos-design.md
+++ b/web/docs/superpowers/specs/2026-08-07-work-config-repos-design.md
@@ -1,0 +1,329 @@
+# Repos de configs — création et mise aux normes
+
+**Date** : 2026-08-07
+**Module** : `work`
+**Statut** : conception validée, à planifier
+
+## Besoin
+
+Disposer d'une commande qui, pour un repo de configuration donné :
+
+- le crée s'il n'existe pas,
+- vérifie qu'il respecte la norme de branches par environnement s'il existe,
+- ne fait rien s'il est conforme,
+- propose de corriger les écarts sinon.
+
+## État des lieux constaté
+
+Relevé le 2026-08-07 sur `gitlab.forge.tsc.azr.intranet` (GitLab **18.11.7 CE**, `enterprise: false`).
+
+### La topologie réelle
+
+`configurations` n'est pas un repo mais un **groupe** :
+
+```
+<bu>/applications/<app>/configurations/<repo>
+```
+
+Environ 40 apps portent un `technical-assets` sous ce groupe. Certaines ont d'autres repos
+(`docs`, `schema-registry`, `caas-namespaces`). `frontlibreservice` porte en plus un
+**sous-groupe** `companion` (`configurations/companion/{app,api,loader}`).
+
+Le besoin a été formulé avec `application` au singulier ; le réel est **`applications`** au
+pluriel, côté disque comme côté forge. C'est le pluriel qui fait foi.
+
+### La norme, telle qu'elle existe dans les repos `cls-*`
+
+Les repos de référence sont `blg/applications/frontlibreservice/configurations/cls-*`.
+Quatre d'entre eux (`cls-bff`, `cls-front`, `cls-valkey`, `cls-borne`) sont conformes :
+
+```
+branches    dev, qlf, pprd, prd
+défaut      dev
+dev, qlf    non protégées
+pprd, prd   protégées
+              push_access_level  = 40 (Maintainers)
+              merge_access_level = 40 (Maintainers)
+              allow_force_push   = false
+              code_owner_approval_required = false
+visibility  internal
+```
+
+Deux dérives observées, qui justifient l'audit :
+
+- **`cls-docs`** : `qlf` et `pprd` n'existent pas, alors qu'une *règle de protection* `pprd`
+  existe. GitLab autorise une règle sur une branche absente — comparer seulement la liste des
+  branches raterait ce cas.
+- **`cls-apk-deletion_scheduled-8725`** : défaut `qlf`, pas de `dev`, `qlf` protégée en
+  `Developers + Maintainers`. Son nom indique une suppression programmée.
+
+Aucun contenu commun entre ces repos : chacun a son arborescence propre (`helm/`, `k8s/`,
+`java/`, `apim/`). Il n'existe pas de squelette à copier.
+
+### `technical-assets`
+
+Hors périmètre d'écriture, sur décision explicite. Il sert de témoin en lecture seule.
+Ses protections sont identiques à celles des `cls-*` (Maintainers / Maintainers / force=off),
+mais sa topologie de branches ne l'est pas (mono-branche `master` ou `main`).
+
+## Périmètre
+
+**Dans le périmètre** : un repo à la fois, désigné explicitement par flags ou déduit du `cwd`.
+
+**Hors périmètre, refusé avant tout appel réseau** :
+
+- `technical-assets` — audit en lecture seule autorisé, **toute écriture refusée**, `--fix` compris
+- tout chemin sous `configurations/companion/`
+- une BU hors `blg|edt|udb|tsc|shared`
+- un chemin hors d'un groupe `configurations`
+
+Le groupe `configurations` n'est **jamais créé**. S'il manque, échec net.
+
+## Surface
+
+```
+work_config_repo [<repo>] [options]
+
+  --bu <blg|edt|udb|tsc|shared>   BU        (défaut : déduite du cwd)
+  --app <nom>                     app       (défaut : déduite du cwd)
+  --envs dev,qlf,pprd,prd         envs      (défaut : les quatre)
+  --readme                        autorise la réécriture des README préexistants
+  --fix                           applique ; sans lui, audit en lecture seule
+  -h | --help
+```
+
+Sans argument, la cible est déduite du `cwd` s'il correspond au chemin canonique :
+
+```
+$WORK_DIR/<bu>/applications/<app>/configurations/<repo>
+```
+
+Le namespace GitLab est l'image exacte de ce chemin. Créer un repo qui n'existe pas encore
+passe nécessairement par les flags — la déduction depuis le `cwd` ne peut désigner qu'un repo
+déjà cloné.
+
+**Aucune persistance.** Le sous-ensemble d'envs n'est mémorisé nulle part : il est passé par
+`--envs`, ou saisi dans le dialogue, ou vaut les quatre branches par défaut.
+
+## Audit
+
+Trois appels de lecture (`GET /projects/:id`, `/repository/branches`, `/protected_branches`)
+plus un `GET /repository/files/README.md/raw?ref=<branche>` par branche d'env.
+
+| # | Contrôle | Écart |
+|---|---|---|
+| 1 | chaque env de `--envs` a sa branche | `✗ absente → créer depuis <défaut>` |
+| 2 | la branche par défaut est `dev` | `✗ défaut=<x> → basculer sur dev` |
+| 3 | `pprd`/`prd` protégées : push=40, merge=40, force=off | `✗ protection divergente → réappliquer` |
+| 4 | `dev`/`qlf` **non** protégées | `✗ protégée → déprotéger` |
+| 5 | pas de règle de protection sans branche | `! orpheline → supprimer la règle` |
+| 6 | `README.md` conforme sur chaque branche d'env | `✗ divergent → réécrire` (opt-in, cf. plus bas) |
+| 7 | branches hors norme | voir ci-dessous |
+
+**La protection se décide par nom de branche, pas par rang** : `dev` et `qlf` non protégées,
+`pprd` et `prd` protégées. Donc `--envs dev,qlf` produit un repo sans aucune branche protégée.
+
+**La branche par défaut attendue est `dev`.** Si `--envs` ne contient pas `dev`, c'est la
+première env dans l'ordre canonique `dev < qlf < pprd < prd` qui devient le défaut attendu —
+`--envs qlf,prd` attend donc `qlf` en défaut. La saisie est normalisée dans cet ordre, quel que
+soit l'ordre de frappe.
+
+### Contrôle 7 : deux populations de branches hors norme
+
+- `master` / `main` → candidates à la migration puis suppression
+- **tout le reste** (`feature/*`, `config/*`, `unprotected`…) → **listé, jamais touché**
+
+Cette séparation est une exigence de sûreté, pas un confort : `cls-borne` porte deux branches
+`config/*` vivantes et `cls-bff` une `feature/*`. Une règle « supprimer ce qui n'est pas dans
+la norme » les détruirait.
+
+### Garde sur la suppression de `master`
+
+Avant toute suppression :
+
+```
+GET /projects/:id/repository/merge_base?refs[]=master&refs[]=dev
+```
+
+Si le merge-base n'est pas exactement le SHA de `master`, alors `master` porte des commits
+absents de `dev` : la suppression est **refusée et signalée**, même après un `y`. Pas de clone
+nécessaire, pas d'heuristique de contenu.
+
+## Règle README
+
+Sur chaque branche d'env du périmètre, `README.md` contient exactement :
+
+```markdown
+# <nom du repo> <branche>
+```
+
+soit, sur la branche `dev` de `cls-docs` :
+
+```markdown
+# cls-docs dev
+```
+
+Un titre H1, une ligne, un saut de ligne final, rien d'autre.
+
+**Réécriture opt-in.** Un README **préexistant** qui diverge est signalé comme écart mais n'est
+corrigé qu'avec `--readme`. C'est la protection contre l'écrasement d'un README qui porte du
+contenu utile.
+
+**Exception : les branches créées dans le run courant.** Une branche dérivée de `dev` hérite du
+README de `dev` (donc `# cls-x dev` sur une `qlf` fraîchement créée). Il n'y a rien à écraser :
+elle est normalisée d'office, sans `--readme`.
+
+La règle ne s'applique qu'aux branches d'env. `feature/*` et `config/*` gardent le leur.
+Un README strictement identique au contenu attendu ne produit aucun commit : la commande est
+rejouable sans polluer l'historique. Seul `README.md` est considéré ; une variante de casse est
+signalée, jamais renommée.
+
+## Plan et dialogue
+
+L'audit produit un rapport. `--fix` transforme le même rapport en plan et demande.
+
+```
+work_config_repo — blg/applications/frontlibreservice/configurations/cls-docs
+
+  dev     ✓ existe   ✓ défaut   ✓ non protégée   ✓ README
+  prd     ✓ existe              ✓ protégée (Maintainers/Maintainers, force=off)
+  qlf     ✗ absente
+  pprd    ✗ absente
+          ! règle de protection « pprd » orpheline
+
+Plan (3 actions)
+  + créer qlf  depuis dev   (README normalisé)
+  + créer pprd depuis dev   (README normalisé)
+  - supprimer la règle orpheline « pprd »
+
+Appliquer ? [y/N/u]
+```
+
+- `y` — applique le plan
+- `N` (défaut) — n'écrit rien ; une frappe sur Entrée est sans conséquence
+- `u` — redemande la liste d'envs, recalcule le plan, repropose le même prompt
+
+Répondre `u` puis `dev,qlf` sur l'exemple ci-dessus ramène le plan à une seule action : la
+suppression de la règle orpheline.
+
+## Ordre d'application
+
+L'API impose deux contraintes qui se croisent — on ne supprime pas la branche par défaut, on ne
+supprime pas une branche protégée. D'où :
+
+1. créer les branches manquantes depuis la branche par défaut courante
+2. basculer le défaut sur `dev`
+3. déprotéger `dev`/`qlf` si elles le sont
+4. **normaliser les README** — d'office sur les branches créées à l'étape 1, seulement sous
+   `--readme` sur les branches préexistantes
+5. appliquer les protections `pprd`/`prd`
+6. supprimer les règles orphelines
+7. `master`/`main` : `merge_base`, puis déprotéger, puis supprimer
+
+L'étape 4 précède l'étape 5 : sur un repo neuf, l'inverse ferait buter la commande sur les
+règles qu'elle vient d'écrire.
+
+Chaque étape échouée arrête la suite et affiche le code HTTP **et** le corps de la réponse.
+
+### Commits sur branche protégée
+
+Sur un repo existant déjà conforme côté protections, l'étape 5 est sautée — donc l'étape 4
+écrit sur `pprd`/`prd` protégées. Le commit part via `POST /repository/commits` sous l'identité
+du token : Maintainer, il passe ; sinon GitLab répond 403 et la branche est signalée.
+
+**La commande ne déprotège jamais d'elle-même pour se faire de la place.** Ouvrir une fenêtre
+de non-protection sur `prd` sans le dire serait pire que l'écart corrigé.
+
+### Modifier une protection existante sur GitLab CE
+
+`PATCH /projects/:id/protected_branches/:name` existe en 18.11, mais sur l'édition Free il ne
+sait modifier que `allow_force_push` : les paramètres `allowed_to_push` / `allowed_to_merge`
+sont Premium. Donc :
+
+| Situation | Appel | Fenêtre de non-protection |
+|---|---|---|
+| règle absente | `POST /protected_branches` | non |
+| seul `allow_force_push` diverge | `PATCH /protected_branches/:name` | non |
+| un niveau d'accès diverge | `DELETE` puis `POST` | **oui, brève** |
+
+Le troisième cas est **marqué comme tel dans le plan**, ligne par ligne. La fenêtre ne peut pas
+être supprimée sur cette édition ; elle est rendue visible.
+
+## Création d'un repo absent
+
+Une fois le plan accepté :
+
+1. résoudre le groupe `<bu>/applications/<app>/configurations` (`GET /groups/<path encodé>`) —
+   absent, échec net
+2. `POST /projects` : `namespace_id`, `path`, `visibility=internal`, `default_branch=dev`,
+   `initialize_with_readme=true`
+3. normaliser le README de `dev`
+4. dériver `qlf`, `pprd`, `prd` depuis `dev`, README normalisé sur chacune
+5. appliquer les protections
+6. `git clone` au chemin canonique, via l'URL retournée par l'API, en réutilisant la mécanique
+   d'authentification déjà en place pour les clones existants
+7. `cd` dans le clone
+
+`visibility=internal` et le `merge_method` par défaut : c'est ce que portent les six `cls-*`
+existants, on ne s'en écarte pas.
+
+## Accès réseau
+
+- Token : `GITLAB_TOKEN` depuis `~/.gitlab_secrets`, sourcé par la garde `_work_cfg_require` si
+  la variable est absente — le module `work` ne dépend pas de l'activation du module `gitlab`
+- Domaine : `GITLAB_BASE_DOMAIN`
+- TLS : `--cacert "$SSL_CERT_FILE"` si la variable est définie, sinon appel nu.
+  **Pas de `-k`**, contrairement à `gitlab_logic.zsh` : vérifié le 2026-08-07, la forge répond
+  200 sans désactiver la vérification. Un échec TLS renvoie un message pointant `SSL_CERT_FILE`.
+- Helper `_work_cfg_curl METHOD PATH [BODY]`, calqué sur `_work_es_curl` : première ligne = code
+  HTTP, reste = corps.
+
+## Codes de sortie
+
+| Code | Sens |
+|---|---|
+| 0 | conforme, ou corrigé avec succès |
+| 1 | erreur (refus dur, réseau, API, groupe absent) |
+| 2 | écarts détectés en mode audit |
+
+Le `2` permet de boucler sur plusieurs repos sans lire la sortie.
+
+## Implémentation
+
+| Fichier | Nature |
+|---|---|
+| `modules/work/config_repos.zsh` | nouveau — toute la logique |
+| `modules/work/init.zsh` | ajouter la ligne `source` |
+| `modules/work/.lazy` | ajouter `work_config_repo` |
+| `modules/work/completions.zsh` | compdef : flags, BUs, envs |
+
+Tout en zsh, dans le moule d'`elasticsearch.zsh` : garde `_work_cfg_require`, helper
+`_work_cfg_curl`, affichage via les fonctions `_ui_*`, aucune couleur en dur.
+
+Le CLI Rust est écarté : il n'a aujourd'hui aucun client GitLab, et le travail ici est
+I/O-bound sur l'API plus un dialogue interactif — Rust n'apporterait que de la surface.
+
+## Vérification
+
+Pas de shellspec (convention du projet).
+
+- `zsh -n modules/work/config_repos.zsh`
+- chargement dans un `zsh -f` propre, puis `work_config_repo --help`
+- hors réseau borné : `GITLAB_BASE_DOMAIN=127.0.0.1:9` échoue immédiatement, ne pend pas
+- refus durs à sec — `technical-assets`, un chemin `companion/`, une BU inconnue — chacun doit
+  sortir **avant** le premier `curl`
+- audit réel en lecture seule : `cls-bff` attendu conforme (code 0), `cls-docs` attendu à
+  3 écarts (code 2)
+- parsing d'options : `work_config_repo --envs` en dernier argument ne doit pas boucler
+  (`shift 2` gardé — piège zsh déjà rencontré en review)
+
+## Hors périmètre
+
+Volontairement écartés :
+
+- création de groupes sur la forge
+- persistance du sous-ensemble d'envs (topic GitLab, fichier local, fichier dans le repo)
+- balayage de tous les repos d'un groupe en une commande
+- alignement des `merge_method`, `squash_option`, règles d'approbation
+- toute écriture sur `technical-assets`
+- suppression de branches autres que `master`/`main`

--- a/web/docs/superpowers/specs/2026-08-07-work-config-repos-design.md
+++ b/web/docs/superpowers/specs/2026-08-07-work-config-repos-design.md
@@ -122,6 +122,7 @@ plus un `GET /repository/files/README.md/raw?ref=<branche>` par branche d'env.
 | 3 | `pprd`/`prd` protégées : push=40, merge=40, force=off | `✗ protection divergente → réappliquer` |
 | 4 | `dev`/`qlf` **non** protégées | `✗ protégée → déprotéger` |
 | 5 | pas de règle de protection sans branche | `! orpheline → supprimer la règle` |
+| | *orpheline* = règle dont la branche **n'existe pas et ne sera pas créée** par ce plan | |
 | 6 | `README.md` conforme sur chaque branche d'env | `✗ divergent → réécrire` (opt-in, cf. plus bas) |
 | 7 | branches hors norme | voir ci-dessous |
 
@@ -187,6 +188,9 @@ signalée, jamais renommée.
 
 L'audit produit un rapport. `--fix` transforme le même rapport en plan et demande.
 
+L'état réel de `cls-docs` : branches `dev` (défaut, non protégée) et `prd` (protégée) ;
+règles de protection `pprd` et `prd`, toutes deux déjà conformes.
+
 ```
 work_config_repo — blg/applications/frontlibreservice/configurations/cls-docs
 
@@ -194,22 +198,35 @@ work_config_repo — blg/applications/frontlibreservice/configurations/cls-docs
   prd     ✓ existe              ✓ protégée (Maintainers/Maintainers, force=off)
   qlf     ✗ absente
   pprd    ✗ absente
-          ! règle de protection « pprd » orpheline
 
-Plan (3 actions)
-  + créer qlf  depuis dev   (README normalisé)
-  + créer pprd depuis dev   (README normalisé)
-  - supprimer la règle orpheline « pprd »
+Plan (4 actions)
+  + créer qlf  depuis dev
+  + créer pprd depuis dev
+  ~ README de qlf   → « # cls-docs qlf »
+  ~ README de pprd  → « # cls-docs pprd »
 
 Appliquer ? [y/N/u]
 ```
+
+La règle `pprd` **n'est pas orpheline ici** : sa branche est absente, mais le plan la crée.
+Elle deviendra une protection légitime — aucune action.
 
 - `y` — applique le plan
 - `N` (défaut) — n'écrit rien ; une frappe sur Entrée est sans conséquence
 - `u` — redemande la liste d'envs, recalcule le plan, repropose le même prompt
 
-Répondre `u` puis `dev,qlf` sur l'exemple ci-dessus ramène le plan à une seule action : la
-suppression de la règle orpheline.
+Répondre `u` puis `dev,qlf` change complètement le plan : `pprd` n'est plus créée, donc sa
+règle **devient** orpheline et part ; `prd` sort du périmètre et rejoint les branches hors
+norme conservées.
+
+```
+Plan (3 actions)
+  + créer qlf depuis dev
+  ~ README de qlf → « # cls-docs qlf »
+  - supprimer la règle orpheline « pprd »
+
+  ! branche hors norme conservée : prd
+```
 
 ## Ordre d'application
 
@@ -317,8 +334,8 @@ Pas de shellspec (convention du projet).
 - hors réseau borné : `GITLAB_BASE_DOMAIN=127.0.0.1:9` échoue immédiatement, ne pend pas
 - refus durs à sec — `technical-assets`, un chemin `companion/`, une BU inconnue — chacun doit
   sortir **avant** le premier `curl`
-- audit réel en lecture seule : `cls-bff` attendu conforme (code 0), `cls-docs` attendu à
-  3 écarts (code 2)
+- audit réel en lecture seule : `cls-bff` attendu conforme (code 0), `cls-docs` attendu non
+  conforme (code 2, `qlf` et `pprd` absentes)
 - parsing d'options : `work_config_repo --envs` en dernier argument ne doit pas boucler
   (`shift 2` gardé — piège zsh déjà rencontré en review)
 


### PR DESCRIPTION
Ajoute au module `work` une commande qui audite un repo de configuration GitLab contre une norme de branches par environnement, le met aux normes, et le crée s'il n'existe pas.

```
work_config_repo [<repo>] [--bu X] [--app Y] [--envs csv] [--readme] [--fix]
```

Sans `--fix`, l'audit est en **lecture seule** : aucune méthode autre que `GET` n'est émise. Codes de sortie : `0` conforme ou corrigé, `1` erreur, `2` écarts détectés — de quoi boucler sur plusieurs dépôts sans lire la sortie.

## Architecture

Le cœur est un **planificateur pur**, `_work_cfg_build_plan` : il reçoit l'état du dépôt en TSV et rend une liste d'actions, sans réseau ni `jq`. Toute la norme vit là, et c'est là qu'elle est testée — 41 des 119 assertions portent dessus, toutes hors ligne. La collecte, le rendu, la confirmation et l'application sont minces autour.

## Sûreté

- **Aucune écriture sans un `y` explicite.** `_work_cfg_read_answer` refuse sur entrée vide, réponse inconnue et stdin fermé : une exécution non interactive n'applique jamais rien.
- **Garde merge-base avant toute suppression de branche.** Si le merge-base n'est pas exactement le SHA de la branche, elle porte des commits absents de la cible et la suppression est refusée, même après un `y`. La garde distingue « divergent » (1) de « invérifiable » (2) — un VPN coupé ne doit pas se faire passer pour une divergence.
- **Les branches hors norme autres que `master`/`main` sont listées, jamais supprimées.** Les dépôts réels portent des `config/*` et `feature/*` vivantes.
- **La commande ne déprotège jamais d'elle-même pour se faire de la place.** Seule exception : le remplacement d'une protection dont un niveau d'accès diverge, que GitLab CE ne sait pas faire par `PATCH` ; cette action s'annonce dans le plan et nomme sa fenêtre.

## Tests

119 assertions dans `scripts/tests/work-config-repos.test.sh`, sur le moule des tests bash existants du dépôt. Cas synthétiques, réseau stubé : la suite tourne hors ligne, y compris pour les chemins qui écrivent.

```
work-config-repos  119 ok, 0 echecs
zsh-special-vars     7 ok, 0 echec
k9s-log-fmt         13 ok, 0 echec
```

## Limites connues

- GitLab masque un 403 en 404 sur un projet invisible au token : un repo existant mais non visible sera proposé à la création, et le `POST` sera rejeté en 400 « path has already been taken ». Rien de cassé, mais le message parlera de 400 plutôt que de droits.
- Le premier `--fix` sur un dépôt existant pousse des commits README. Sur `pprd`/`prd` protégées, un token sous Maintainer prend un 403 et la séquence s'arrête à mi-plan. C'est consenti — chaque ligne README figure au plan avant le `y`.
- Le remplacement d'une protection n'est pas transactionnel : un `DELETE` qui expire côté client après traitement serveur signale « retrait échoué » alors que la branche est déprotégée. Inhérent au `DELETE`-puis-`POST` de GitLab CE.

La spécification et le plan de ce chantier restent hors du dépôt : ils décrivent une topologie interne qui n'a pas sa place dans un dépôt public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)