### PR TITLE
fix(work): chemins companion, « . » comme cible, et companion entre dans le périmètre

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,11 @@ jobs:
           export ZANVIL_DIR="$PWD"
           bash scripts/tests/k9s-log-fmt.test.sh
           bash scripts/tests/zsh-special-vars.test.sh
+          # 145 cas qui ne tournaient nulle part : la suite existait depuis la creation de
+          # work_config_repo et n a jamais ete appelee ici, donc aucune de ses gardes ne
+          # protegeait la branche. Elle ne demande ni reseau ni identite git — ses `git
+          # commit` portent la leur, faute de quoi trois cas echouaient sur un runner nu.
+          bash scripts/tests/work-config-repos.test.sh
 
       # « Test binary-absent fallback warnings » a ete retiree. Elle amputait PATH a
       # la main pour prouver qu un module previent quand son binaire manque, ce que le

--- a/modules/work/config_repos.zsh
+++ b/modules/work/config_repos.zsh
@@ -78,21 +78,37 @@ _work_cfg_guard_target() {
         _ui_msg_fail "technical-assets est hors perimetre — ni ecriture, ni audit"
         return 1
     fi
-    if [[ "$repo" == companion || "$repo" == companion/* ]]; then
-        _ui_msg_fail "le sous-groupe companion est hors perimetre"
+    # `companion` seul designe le sous-groupe, pas un projet. Quelqu un debout dans
+    # configurations/companion obtiendrait ce nom par deduction et auditerait un groupe
+    # comme s il etait un depot : la lecture 404 et la creation entrerait en collision
+    # avec le sous-groupe existant. On le dit, et on indique ou descendre.
+    if [[ "$repo" == companion ]]; then
+        _ui_msg_fail "companion est un sous-groupe, pas un repo"
+        _ui_msg_info "descendre dans l un de ses projets, ou le nommer : companion/<repo>"
         return 1
     fi
-    # Un nom de repo est un segment de chemin GitLab, pas une chaine libre. Le verifier
-    # ici ferme d un coup les noms qui n ont pas de sens (« . », « ../x ») et ceux qui
+    # Un repo peut vivre dans un sous-groupe : configurations/companion/{app,api,loader}
+    # en sont, et ils portent la meme topologie que les autres — main unique et protegee,
+    # donc hors norme. Rien ne justifie de les ecarter de l audit.
+    local -a segs; segs=(${(s:/:)repo})
+    if (( ${#segs} > 2 )); then
+        _ui_msg_fail "trop de niveaux : « $repo » (au plus <sous-groupe>/<repo>)"
+        return 1
+    fi
+    # Chaque segment est un segment de chemin GitLab, pas une chaine libre. Le verifier
+    # ferme d un coup les noms qui n ont pas de sens (« . », « ../x ») et ceux qui
     # fabriqueraient des cles dans un corps JSON — la construction par jq protege deja
     # ce dernier cas, mais un refus en amont vaut mieux qu un echappement en aval.
     # Forme volontairement sans `#` ni `(...)` : ces operateurs exigent EXTENDED_GLOB,
-    # qui n est pas garanti — sous `zsh -f` ils sont litteraux et le test rejetait
-    # « cls-bff ». Une classe negative et un prefixe suffisent, sans dependre d une option.
-    if [[ "$repo" == *[^A-Za-z0-9._-]* || "$repo" == .* ]]; then
-        _ui_msg_fail "nom de repo invalide : « $repo » (attendu : lettres, chiffres, . _ -)"
-        return 1
-    fi
+    # qui n est pas garanti — sous `zsh -f` ils sont litteraux et une premiere version
+    # rejetait « cls-bff ».
+    local seg
+    for seg in $segs; do
+        if [[ -z "$seg" || "$seg" == *[^A-Za-z0-9._-]* || "$seg" == .* ]]; then
+            _ui_msg_fail "nom de repo invalide : « $repo » (attendu : lettres, chiffres, . _ -)"
+            return 1
+        fi
+    done
     return 0
 }
 
@@ -141,8 +157,12 @@ _work_cfg_env_is_protected() {
 }
 
 # Contenu attendu du README d une branche d env : un titre H1, une ligne, rien d autre.
+#
+# Le nom du repo, pas son chemin : un repo de sous-groupe est designe « companion/api »
+# dans toute la commande, mais son README porte « # api <branche> ». La spec dit « nom du
+# repo », et c est ce que GitLab appelle le `path` du projet.
 _work_cfg_readme_content() {
-    print -r -- "# ${1} ${2}"
+    print -r -- "# ${1##*/} ${2}"
 }
 
 # --- Planificateur ---
@@ -877,6 +897,21 @@ _work_cfg_write_readme() {
 
 # Chemin canonique local, pur : aucun acces disque, aucun reseau.
 # Usage : _work_cfg_local_path <bu> <app> <repo>
+# Le groupe qui porte le projet. Un repo de premier niveau vit dans `configurations` ;
+# un repo de sous-groupe (companion/api) vit dans `configurations/companion`. La
+# distinction ne compte qu a la creation — la lecture passe par le chemin complet.
+_work_cfg_repo_group() {
+    local bu="$1" app="$2" repo="$3"
+    local grp="$bu/applications/$app/configurations"
+    [[ "$repo" == */* ]] && grp="$grp/${repo%/*}"
+    print -r -- "$grp"
+}
+
+# Le nom du projet seul, sans son sous-groupe : GitLab n accepte pas de / dans un `path`.
+_work_cfg_repo_leaf() {
+    print -r -- "${1##*/}"
+}
+
 _work_cfg_local_path() {
     print -r -- "${WORK_DIR:-$HOME/work}/$1/applications/$2/configurations/$3"
 }
@@ -887,7 +922,9 @@ _work_cfg_local_path() {
 _work_cfg_create() {
     local bu="$1" app="$2" repo="$3" envs_csv="$4"
     local -a envs; envs=(${(s:,:)envs_csv})
-    local grp="$bu/applications/$app/configurations"
+    local grp leaf
+    grp=$(_work_cfg_repo_group "$bu" "$app" "$repo")
+    leaf=$(_work_cfg_repo_leaf "$repo")
     local enc; enc=$(_work_cfg_enc "$grp")
 
     # Ne PAS ecrire `_work_cfg_json ... | jq ... || { ... }` : le code de sortie d un
@@ -936,7 +973,7 @@ _work_cfg_create() {
     # echappe deja correctement le contenu des README (jq -Rs) ; il n y a aucune
     # raison que la creation soit la seule exception.
     local body proj
-    body=$(jq -n --arg name "$repo" --arg path "$repo" \
+    body=$(jq -n --arg name "$leaf" --arg path "$leaf" \
                  --argjson nsid "$gid" --arg def "$default_env" \
         '{name:$name, path:$path, namespace_id:$nsid, visibility:"internal",
           default_branch:$def, initialize_with_readme:true}') \

--- a/modules/work/config_repos.zsh
+++ b/modules/work/config_repos.zsh
@@ -34,12 +34,22 @@ _work_cfg_parse_path() {
     local -a parts
     parts=(${(s:/:)rel})
 
-    (( ${#parts} == 5 )) || return 1
+    # Cinq segments pour un repo, six pour un sous-groupe companion. Ce dernier est
+    # hors perimetre, mais il doit etre RECONNU pour que _work_cfg_guard_target puisse
+    # le dire. Le refuser ici par l arite renverrait « BU inconnue » a quelqu un dont
+    # la BU est parfaitement valide — le message nommerait le mauvais probleme.
+    local repo
+    case ${#parts} in
+        5) repo="$parts[5]" ;;
+        6) [[ "$parts[5]" == companion ]] || return 1
+           repo="companion/$parts[6]" ;;
+        *) return 1 ;;
+    esac
     [[ "$parts[2]" == applications ]] || return 1
     [[ "$parts[4]" == configurations ]] || return 1
     (( ${_WORK_CFG_BU_ALL[(Ie)$parts[1]]} )) || return 1
 
-    print -r -- "$parts[1]	$parts[3]	$parts[5]"
+    print -r -- "$parts[1]	$parts[3]	$repo"
     return 0
 }
 
@@ -70,6 +80,17 @@ _work_cfg_guard_target() {
     fi
     if [[ "$repo" == companion || "$repo" == companion/* ]]; then
         _ui_msg_fail "le sous-groupe companion est hors perimetre"
+        return 1
+    fi
+    # Un nom de repo est un segment de chemin GitLab, pas une chaine libre. Le verifier
+    # ici ferme d un coup les noms qui n ont pas de sens (« . », « ../x ») et ceux qui
+    # fabriqueraient des cles dans un corps JSON — la construction par jq protege deja
+    # ce dernier cas, mais un refus en amont vaut mieux qu un echappement en aval.
+    # Forme volontairement sans `#` ni `(...)` : ces operateurs exigent EXTENDED_GLOB,
+    # qui n est pas garanti — sous `zsh -f` ils sont litteraux et le test rejetait
+    # « cls-bff ». Une classe negative et un prefixe suffisent, sans dependre d une option.
+    if [[ "$repo" == *[^A-Za-z0-9._-]* || "$repo" == .* ]]; then
+        _ui_msg_fail "nom de repo invalide : « $repo » (attendu : lettres, chiffres, . _ -)"
         return 1
     fi
     return 0
@@ -519,6 +540,10 @@ work_config_repo() {
             --fix)    do_fix=1; shift ;;
             -h|--help) _work_cfg_usage; return 0 ;;
             -*) _ui_msg_fail "option inconnue : $1"; _work_cfg_usage; return 1 ;;
+            # « . » et « ./ » veulent dire « ici », pas « un repo nomme point ». C est
+            # ce qu on tape spontanement, et le prendre au pied de la lettre construisait
+            # une cible .../configurations/. sans que rien ne proteste.
+            .|./) shift ;;
             *)  repo="$1"; shift ;;
         esac
     done

--- a/modules/work/config_repos.zsh
+++ b/modules/work/config_repos.zsh
@@ -463,8 +463,17 @@ _work_cfg_collect() {
 #
 # Rien n est ajoute si l arbre local porte des modifications : basculer de branche les
 # emporterait ailleurs, et ce n est pas a une commande de normalisation d en decider.
+#
+# Le troisieme argument, facultatif, porte les envs de la norme. Quand il est fourni, une
+# branche courante qui EST un env de la norme n est pas deplacee : sans cette exception,
+# `local_checkout` etait emis des que la branche differait du defaut, et un depot
+# parfaitement conforme dont le clone etait sur `prd` — parce qu on y editait la config de
+# production — etait rapporte non conforme, avec un code 2 et un plan d une action. Sous
+# `--fix`, la branche etait quittee sans que rien ne l ait demande. Le besoin reel ne
+# concerne que les branches que la norme ne garde pas : `main`, `master`, ou une branche
+# qui n existe plus en face.
 _work_cfg_local_plan() {
-    local dest="$1" want="$2"
+    local dest="$1" want="$2" envs_csv="${3:-}"
     [[ -d "$dest/.git" ]] || return 0
 
     if [[ -n "$(command git -C "$dest" status --porcelain 2>/dev/null)" ]]; then
@@ -473,7 +482,12 @@ _work_cfg_local_plan() {
     fi
 
     local cur; cur=$(command git -C "$dest" branch --show-current 2>/dev/null)
-    [[ "$cur" != "$want" ]] && print -r -- "local_checkout	$want	$dest"
+    local -a norme; norme=(${(s:,:)envs_csv})
+    # Un HEAD detache rend une chaine vide, qui n est dans aucune norme : la bascule est
+    # alors proposee, et c est bien ce qu on veut.
+    if [[ "$cur" != "$want" ]] && ! (( ${norme[(Ie)$cur]} )); then
+        print -r -- "local_checkout	$want	$dest"
+    fi
 
     # Les branches locales que la norme ne garde pas. `git branch -d` refusera celles
     # qui portent des commits non fusionnes : c est la garde, on ne la contourne pas.
@@ -662,7 +676,8 @@ _work_cfg_run() {
     # une branche que le plan vient de supprimer en amont.
     plan_local=$(_work_cfg_local_plan \
         "$(_work_cfg_local_path "$bu" "$app" "$repo")" \
-        "$(_work_cfg_expected_default "$envs_csv")")
+        "$(_work_cfg_expected_default "$envs_csv")" \
+        "$envs_csv")
     [[ -n "$plan_local" ]] && plan="${plan:+$plan$'\n'}$plan_local"
 
     echo ""
@@ -678,7 +693,8 @@ _work_cfg_run() {
     (( n == 0 )) && return 2
     (( do_fix )) || return 2
 
-    _work_cfg_confirm_and_apply "$repo" "$envs_csv" "$readme_optin" "$plan"
+    _work_cfg_confirm_and_apply "$repo" "$envs_csv" "$readme_optin" "$plan" \
+        "$(_work_cfg_local_path "$bu" "$app" "$repo")"
 }
 
 # --- Dialogue de confirmation ---
@@ -700,8 +716,12 @@ _work_cfg_read_answer() {
 
 # Boucle de confirmation. `u` recalcule le plan avec une nouvelle liste d envs et
 # repropose : le sous-ensemble n est jamais persiste nulle part.
+#
+# Le cinquieme argument, facultatif, porte le chemin du clone local. Il sert au recalcul du
+# volet local par `u` : ce chemin ne depend pas des envs, contrairement au defaut attendu,
+# donc l appelant le calcule une fois et le passe.
 _work_cfg_confirm_and_apply() {
-    local repo="$1" envs_csv="$2" readme_optin="$3" plan="$4"
+    local repo="$1" envs_csv="$2" readme_optin="$3" plan="$4" local_dest="${5:-}"
 
     while true; do
         echo ""
@@ -714,7 +734,7 @@ _work_cfg_confirm_and_apply() {
             u)
                 print -n -- "Quels envs ? (${(j:,:)_WORK_CFG_ENVS_ALL}) "
                 local raw; read -r raw || raw=""
-                local new_envs
+                local new_envs=
                 # _ui_msg_fail ecrit sur stdout, donc la capture avale la plainte.
                 # Sans ce reemis, une saisie fautive fait juste reapparaitre le
                 # prompt, muet : l utilisateur ne sait pas ce qu on lui reproche.
@@ -728,6 +748,18 @@ _work_cfg_confirm_and_apply() {
                 plan=$(_work_cfg_build_plan "$repo" "$envs_csv" "$readme_optin" \
                         "$_work_cfg_default" "$_work_cfg_branches" "$_work_cfg_rules" \
                         "$_work_cfg_readmes")
+                # Le volet local, RECALCULE et non recopie : la nouvelle liste d envs
+                # change le defaut attendu, donc les anciennes lignes viseraient la
+                # mauvaise branche. Sans ce bloc, `--fix` puis `u` normalisait le distant
+                # et laissait le clone sur la branche qui venait d etre supprimee — le
+                # defaut meme que ce volet existe pour corriger, atteint par le chemin
+                # interactif.
+                if [[ -n "$local_dest" ]]; then
+                    local plan_local_u=
+                    plan_local_u=$(_work_cfg_local_plan "$local_dest" \
+                        "$(_work_cfg_expected_default "$envs_csv")" "$envs_csv")
+                    [[ -n "$plan_local_u" ]] && plan="${plan:+$plan$'\n'}$plan_local_u"
+                fi
                 echo ""
                 _work_cfg_render "$repo" "$plan"
                 (( $(_work_cfg_count_actions "$plan") == 0 )) && \
@@ -822,7 +854,7 @@ _work_cfg_apply() {
                 # Corps construit par jq, comme les autres : $a est un nom de branche
                 # normalise par ce module, mais rien ne justifie que ce corps reste le
                 # seul construit par interpolation brute.
-                local _body_defset
+                local _body_defset=
                 _body_defset=$(jq -n --arg br "$a" '{default_branch:$br}') \
                     || { _ui_msg_fail "construction du corps de bascule sur $a"; return 1 }
                 _work_cfg_json PUT "projects/$pid" "$_body_defset" \
@@ -1010,7 +1042,11 @@ _work_cfg_create() {
     # n existe sur la forge.
     echo ""
     print -r -- "${_ui_bold}Plan de creation${_ui_nc}"
-    _ui_section "Chemin distant" "$grp/$repo"
+    # `$grp/$leaf` et non `$grp/$repo` : `$grp` descend deja dans le sous-groupe, et
+    # `$repo` le porte encore. Les concatener affichait
+    # « configurations/companion/companion/api » — un chemin qui n existe pas, sur le seul
+    # ecran qui sert a reperer une cible erronee avant que quoi que ce soit ne soit cree.
+    _ui_section "Chemin distant" "$grp/$leaf"
     _ui_section "Envs" "$envs_csv"
     _ui_section "Visibilite" "internal"
     _ui_section "Branche defaut" "$default_env"
@@ -1040,7 +1076,7 @@ _work_cfg_create() {
     proj="$_work_cfg_body"
 
     typeset -g _work_cfg_pid; _work_cfg_pid=$(print -r -- "$proj" | jq -r '.id')
-    _ui_msg_ok "projet $grp/$repo cree"
+    _ui_msg_ok "projet $grp/$leaf cree"
 
     # A partir d ici, le projet EXISTE sur la forge. Toute sortie en erreur doit le
     # dire : sinon l utilisateur lit « HTTP 403 » et ignore qu un projet a ete cree,
@@ -1097,10 +1133,15 @@ _work_cfg_create() {
 # distant, mais elle ne clonera jamais — le clone n existe que dans la creation.
 _work_cfg_create_partiel() {
     local grp="$1" repo="$2" url="$3" dest="$4"
+    # Meme raison qu au plan de creation : `$grp` descend deja dans le sous-groupe. Ce
+    # helper recoit `grp` et `repo`, pas la feuille, donc il la derive lui-meme — le
+    # chemin qu il imprime sert a retrouver le projet sur la forge, et un chemin double
+    # n y menerait pas.
+    local leaf; leaf=$(_work_cfg_repo_leaf "$repo")
     # Volontairement neutre sur l etat d avancement : ce helper sert aussi bien apres
     # un echec distant qu apres un echec de mkdir ou de clone, ou le distant est
     # complet. Annoncer « incomplet » serait faux dans la moitie des cas.
-    _ui_msg_info "le projet $grp/$repo existe desormais sur la forge"
+    _ui_msg_info "le projet $grp/$leaf existe desormais sur la forge"
     _ui_msg_info "verifier ou terminer la mise aux normes : work_config_repo --fix $repo"
     _ui_msg_info "recuperer le clone local   : git -c \"http.extraheader=PRIVATE-TOKEN: \$GITLAB_TOKEN\" clone $url $dest"
 }

--- a/modules/work/config_repos.zsh
+++ b/modules/work/config_repos.zsh
@@ -453,6 +453,38 @@ _work_cfg_collect() {
     return 0
 }
 
+# --- Volet local du plan ---
+
+# Ajoute au plan ce qu il faut faire au clone local. Le planificateur reste pur : ces
+# lignes viennent d ici, ou l I/O a deja droit de cite.
+#
+# Sans ce volet, une mise aux normes laisse le clone sur une branche que la commande
+# vient de supprimer en amont — c est le cas de tous les depots mono-main d aujourd hui.
+#
+# Rien n est ajoute si l arbre local porte des modifications : basculer de branche les
+# emporterait ailleurs, et ce n est pas a une commande de normalisation d en decider.
+_work_cfg_local_plan() {
+    local dest="$1" want="$2"
+    [[ -d "$dest/.git" ]] || return 0
+
+    if [[ -n "$(command git -C "$dest" status --porcelain 2>/dev/null)" ]]; then
+        print -r -- "warn	clone local non synchronise : $dest porte des modifications"
+        return 0
+    fi
+
+    local cur; cur=$(command git -C "$dest" branch --show-current 2>/dev/null)
+    [[ "$cur" != "$want" ]] && print -r -- "local_checkout	$want	$dest"
+
+    # Les branches locales que la norme ne garde pas. `git branch -d` refusera celles
+    # qui portent des commits non fusionnes : c est la garde, on ne la contourne pas.
+    local b
+    for b in ${(f)"$(command git -C "$dest" branch --format='%(refname:short)' 2>/dev/null)"}; do
+        [[ "$b" == master || "$b" == main ]] || continue
+        print -r -- "local_prune	$b	$dest"
+    done
+    return 0
+}
+
 # --- Rendu ---
 
 # Compte les actions reelles d un plan : ni `warn` ni `ecart` n en sont.
@@ -517,6 +549,8 @@ _work_cfg_render() {
             rule_delete_orphan) print -r -- "  - supprimer la regle orpheline « $a »" ;;
             readme_write)  print -r -- "  ~ README de $a → « $(_work_cfg_readme_content "$repo" "$a") »" ;;
             master_delete) print -r -- "  - supprimer $a (sa protection sera retiree), sous reserve du merge-base" ;;
+            local_checkout) print -r -- "  ~ clone local : fetch --prune puis basculer sur $a" ;;
+            local_prune)   print -r -- "  - clone local : supprimer la branche $a (refuse si non fusionnee)" ;;
             ecart)         print -r -- "  ${_ui_yellow}!${_ui_nc} $a" ;;
             warn)          print -r -- "  ${_ui_yellow}!${_ui_nc} $a" ;;
         esac
@@ -620,9 +654,16 @@ _work_cfg_run() {
         return $?
     fi
 
-    local plan
+    local plan plan_local
     plan=$(_work_cfg_build_plan "$repo" "$envs_csv" "$readme_optin" "$_work_cfg_default" \
             "$_work_cfg_branches" "$_work_cfg_rules" "$_work_cfg_readmes")
+
+    # Le clone local fait partie de la mise aux normes : sans lui, le depot reste sur
+    # une branche que le plan vient de supprimer en amont.
+    plan_local=$(_work_cfg_local_plan \
+        "$(_work_cfg_local_path "$bu" "$app" "$repo")" \
+        "$(_work_cfg_expected_default "$envs_csv")")
+    [[ -n "$plan_local" ]] && plan="${plan:+$plan$'\n'}$plan_local"
 
     echo ""
     _work_cfg_render "$repo" "$plan"
@@ -740,7 +781,8 @@ _work_cfg_is_merged() {
 _work_cfg_sort_plan() {
     local -a order
     order=(branch_create default_set unprotect readme_write protect_create
-           protect_replace protect_patch rule_delete_orphan master_delete ecart warn)
+           protect_replace protect_patch rule_delete_orphan master_delete
+           local_checkout local_prune ecart warn)
     local kind line
     for kind in $order; do
         for line in ${(f)${1:-}}; do
@@ -846,6 +888,20 @@ _work_cfg_apply() {
                     return 1
                 fi
                 _ui_msg_ok "$a supprimee (contenu repris dans $target)" ;;
+            local_checkout)
+                command git -C "$b" fetch --prune --quiet \
+                    || { _ui_msg_fail "fetch dans $b"; return 1 }
+                command git -C "$b" checkout --quiet "$a" \
+                    || { _ui_msg_fail "bascule du clone local sur $a"; return 1 }
+                _ui_msg_ok "clone local sur $a" ;;
+            local_prune)
+                # `-d` et non `-D` : git refuse une branche portant des commits non
+                # fusionnes, et ce refus est la garde. On le rapporte au lieu de forcer.
+                if command git -C "$b" branch -d "$a" >/dev/null 2>&1; then
+                    _ui_msg_ok "branche locale $a supprimee"
+                else
+                    _ui_msg_warn "branche locale $a conservee : git la dit non fusionnee"
+                fi ;;
             ecart|warn)
                 _ui_msg_warn "$a" ;;
         esac

--- a/scripts/tests/work-config-repos.test.sh
+++ b/scripts/tests/work-config-repos.test.sh
@@ -209,14 +209,14 @@ echo "== volet local du plan : le clone suit la norme =="
 # Un clone mono-main resterait sur une branche que le plan supprime en amont.
 zc 'd="$WORK_DIR/clone"; mkdir -p "$d"
     command git -C "$d" init -q -b main
-    command git -C "$d" commit -q --allow-empty -m x
+    command git -C "$d" -c user.email=t@t.invalide -c user.name=t commit -q --allow-empty -m x
     _work_cfg_local_plan "$d" dev | cut -f1 | sort | tr "\n" " "' \
     | assert_equals "clone sur main : bascule et elagage prevus" "local_checkout local_prune "
 
 # Un arbre sale ne se fait pas deplacer par une commande de normalisation.
 zc 'd="$WORK_DIR/sale"; mkdir -p "$d"
     command git -C "$d" init -q -b main
-    command git -C "$d" commit -q --allow-empty -m x
+    command git -C "$d" -c user.email=t@t.invalide -c user.name=t commit -q --allow-empty -m x
     print modif > "$d/fichier"
     _work_cfg_local_plan "$d" dev | cut -f1' \
     | assert_equals "arbre sale : aucune action locale, un avertissement" "warn"
@@ -224,13 +224,60 @@ zc 'd="$WORK_DIR/sale"; mkdir -p "$d"
 # Deja sur la bonne branche : rien a basculer.
 zc 'd="$WORK_DIR/bon"; mkdir -p "$d"
     command git -C "$d" init -q -b dev
-    command git -C "$d" commit -q --allow-empty -m x
+    command git -C "$d" -c user.email=t@t.invalide -c user.name=t commit -q --allow-empty -m x
     _work_cfg_local_plan "$d" dev | cut -f1 | tr "\n" " "' \
     | assert_equals "deja sur dev : rien a basculer" ""
 
 # Pas de clone local : le volet est vide, pas en erreur.
 zc '_work_cfg_local_plan "$WORK_DIR/absent" dev | wc -l | tr -d " "' \
     | assert_equals "sans clone local : aucune ligne" "0"
+
+# Une branche d env de la norme n est pas une anomalie. Sans le troisieme argument, le
+# volet emettait local_checkout des que la branche differait du defaut : un depot conforme
+# dont le clone etait sur prd — parce qu on y editait la config de production — etait
+# rapporte non conforme, et --fix l en sortait sans que rien ne l ait demande.
+zc 'd="$WORK_DIR/sur-prd"; mkdir -p "$d"
+    command git -C "$d" init -q -b prd
+    command git -C "$d" -c user.email=t@t.invalide -c user.name=t commit -q --allow-empty -m x
+    _work_cfg_local_plan "$d" dev "dev,qlf,pprd,prd" | cut -f1 | tr "\n" " "' \
+    | assert_equals "clone sur une branche d env de la norme : rien a basculer" ""
+
+# Le meme clone, mais prd HORS de la norme demandee : la bascule redevient legitime.
+zc 'd="$WORK_DIR/prd-hors-norme"; mkdir -p "$d"
+    command git -C "$d" init -q -b prd
+    command git -C "$d" -c user.email=t@t.invalide -c user.name=t commit -q --allow-empty -m x
+    _work_cfg_local_plan "$d" dev "dev,qlf" | cut -f1 | tr "\n" " "' \
+    | assert_equals "clone sur un env hors norme : bascule prevue" "local_checkout "
+
+# main reste a quitter, norme ou pas : c est la branche que le plan vient de supprimer.
+zc 'd="$WORK_DIR/main-avec-norme"; mkdir -p "$d"
+    command git -C "$d" init -q -b main
+    command git -C "$d" -c user.email=t@t.invalide -c user.name=t commit -q --allow-empty -m x
+    _work_cfg_local_plan "$d" dev "dev,qlf,pprd,prd" | cut -f1 | sort | tr "\n" " "' \
+    | assert_equals "clone sur main : bascule et elagage, meme avec la norme fournie" \
+        "local_checkout local_prune "
+
+echo
+echo "== chemin distant affiche : le sous-groupe ne double pas =="
+
+# `$grp` descend deja dans le sous-groupe et `$repo` le porte encore : les concatener
+# affichait « configurations/companion/companion/api », un chemin qui n existe pas — sur le
+# seul ecran qui sert a reperer une cible erronee avant creation.
+zc '_work_cfg_create_partiel "blg/applications/demoapp/configurations/companion" \
+        "companion/api" "https://forge.invalide/x.git" "/tmp/x" \
+    | grep -c "companion/companion"' \
+    | assert_equals "aucun sous-groupe double dans le chemin annonce" "0"
+
+zc '_work_cfg_create_partiel "blg/applications/demoapp/configurations/companion" \
+        "companion/api" "https://forge.invalide/x.git" "/tmp/x" \
+    | grep -c "configurations/companion/api"' \
+    | assert_equals "le chemin annonce est celui du projet" "1"
+
+# Un repo de premier niveau n a pas de sous-groupe a doubler : il ne doit pas regresser.
+zc '_work_cfg_create_partiel "blg/applications/demoapp/configurations" \
+        "demo-front" "https://forge.invalide/x.git" "/tmp/x" \
+    | grep -c "configurations/demo-front"' \
+    | assert_equals "repo de premier niveau : chemin inchange" "1"
 
 # Le local vient APRES le distant : basculer sur dev avant de l avoir creee echouerait.
 # La fixture porte une ligne `warn` a dessein : sans elle, deplacer le volet local

--- a/scripts/tests/work-config-repos.test.sh
+++ b/scripts/tests/work-config-repos.test.sh
@@ -58,8 +58,26 @@ zc '_work_cfg_parse_path "$WORK_DIR/blg/applications/demoapp/components/demo-fro
 zc '_work_cfg_parse_path "$WORK_DIR/blg/applications/demoapp/configurations/companion/app"' \
     | assert_equals "chemin companion reconnu, pas rejete par l arite" "$(printf 'blg\tdemoapp\tcompanion/app')"
 
-zc '_work_cfg_guard_target blg demoapp companion/app 2>&1 | grep -o "companion est hors perimetre"' \
-    | assert_equals "le garde nomme le sous-groupe companion" "companion est hors perimetre"
+zc '_work_cfg_guard_target blg demoapp companion/app && print ok' \
+    | assert_equals "un repo de sous-groupe est dans le perimetre" "ok"
+
+zc '_work_cfg_guard_target blg demoapp a/b/c >/dev/null 2>&1 || print refuse' \
+    | assert_equals "trois niveaux : refuse" "refuse"
+
+zc '_work_cfg_repo_group blg demoapp companion/api' \
+    | assert_equals "le groupe porteur descend dans le sous-groupe" \
+"blg/applications/demoapp/configurations/companion"
+
+zc '_work_cfg_repo_group blg demoapp demo-front' \
+    | assert_equals "un repo de premier niveau reste dans configurations" \
+"blg/applications/demoapp/configurations"
+
+zc '_work_cfg_repo_leaf companion/api' \
+    | assert_equals "le nom du projet perd son sous-groupe" "api"
+
+zc '_work_cfg_parse_path "$(_work_cfg_local_path blg demoapp companion/api)"' \
+    | assert_equals "aller-retour chemin sur un repo de sous-groupe" \
+"$(printf 'blg\tdemoapp\tcompanion/api')"
 
 zc '_work_cfg_parse_path "$WORK_DIR/blg/applications/demoapp/configurations/pasompanion/app" || print refuse' \
     | assert_equals "six segments hors companion : toujours refuse" "refuse"
@@ -76,8 +94,8 @@ zc '_work_cfg_guard_target blg demoapp demo-front && print ok' \
 zc '_work_cfg_guard_target blg demoapp technical-assets >/dev/null 2>&1 || print refuse' \
     | assert_equals "technical-assets refuse" "refuse"
 
-zc '_work_cfg_guard_target blg demoapp companion >/dev/null 2>&1 || print refuse' \
-    | assert_equals "companion refuse" "refuse"
+zc '_work_cfg_guard_target blg demoapp companion 2>&1 | grep -o "un sous-groupe, pas un repo"' \
+    | assert_equals "companion seul : un sous-groupe n est pas un repo" "un sous-groupe, pas un repo"
 
 zc '_work_cfg_guard_target xxx demoapp demo-front >/dev/null 2>&1 || print refuse' \
     | assert_equals "BU inconnue refusee au garde" "refuse"
@@ -180,6 +198,10 @@ zc '_work_cfg_readme_content demo-front dev' \
 
 zc '_work_cfg_readme_content demo-front prd | wc -l | tr -d " "' \
     | assert_equals "README fait exactement une ligne" "1"
+
+# Le nom du repo, pas son chemin : « companion/api » se lit « # api » dans son README.
+zc '_work_cfg_readme_content companion/api dev' \
+    | assert_equals "un repo de sous-groupe porte son nom seul dans son README" "# api dev"
 
 echo
 echo "== planificateur : repo conforme =="
@@ -831,6 +853,23 @@ zc '_work_cfg_json() { [[ "$2" == projects ]] && print -r -u2 -- "$3"; typeset -
     print -r -- "$out" | jq -r ".name"' \
     | assert_equals "un nom hostile arrive entier, non tronque par l interpolation" \
 'x","visibility":"public'
+
+# GitLab n accepte pas de / dans un `path` de projet : un repo de sous-groupe se cree
+# avec son nom seul, dans le groupe qui le porte.
+zc '_work_cfg_json() {
+        case "$2" in
+            groups/*) typeset -g _work_cfg_body="{\"id\":7}" ;;
+            projects) print -r -u2 -- "$3"; typeset -g _work_cfg_body="{\"id\":42,\"http_url_to_repo\":\"https://e.test/x.git\"}" ;;
+            *)        typeset -g _work_cfg_body="{}" ;;
+        esac
+        return 0
+    }
+    _work_cfg_write_readme() { return 0 }; _work_cfg_protect() { return 0 }
+    _work_cfg_read_answer() { print y }
+    git() { return 0 }; cd() { return 0 }
+    out=$(_work_cfg_create blg demoapp companion/api dev 2>&1 >/dev/null)
+    print -r -- "$out" | jq -r ".path"' \
+    | assert_equals "un repo de sous-groupe se cree avec son nom seul" "api"
 
 echo
 echo "== creation : la confirmation qui manquait avant le premier POST =="

--- a/scripts/tests/work-config-repos.test.sh
+++ b/scripts/tests/work-config-repos.test.sh
@@ -204,6 +204,43 @@ zc '_work_cfg_readme_content companion/api dev' \
     | assert_equals "un repo de sous-groupe porte son nom seul dans son README" "# api dev"
 
 echo
+echo "== volet local du plan : le clone suit la norme =="
+
+# Un clone mono-main resterait sur une branche que le plan supprime en amont.
+zc 'd="$WORK_DIR/clone"; mkdir -p "$d"
+    command git -C "$d" init -q -b main
+    command git -C "$d" commit -q --allow-empty -m x
+    _work_cfg_local_plan "$d" dev | cut -f1 | sort | tr "\n" " "' \
+    | assert_equals "clone sur main : bascule et elagage prevus" "local_checkout local_prune "
+
+# Un arbre sale ne se fait pas deplacer par une commande de normalisation.
+zc 'd="$WORK_DIR/sale"; mkdir -p "$d"
+    command git -C "$d" init -q -b main
+    command git -C "$d" commit -q --allow-empty -m x
+    print modif > "$d/fichier"
+    _work_cfg_local_plan "$d" dev | cut -f1' \
+    | assert_equals "arbre sale : aucune action locale, un avertissement" "warn"
+
+# Deja sur la bonne branche : rien a basculer.
+zc 'd="$WORK_DIR/bon"; mkdir -p "$d"
+    command git -C "$d" init -q -b dev
+    command git -C "$d" commit -q --allow-empty -m x
+    _work_cfg_local_plan "$d" dev | cut -f1 | tr "\n" " "' \
+    | assert_equals "deja sur dev : rien a basculer" ""
+
+# Pas de clone local : le volet est vide, pas en erreur.
+zc '_work_cfg_local_plan "$WORK_DIR/absent" dev | wc -l | tr -d " "' \
+    | assert_equals "sans clone local : aucune ligne" "0"
+
+# Le local vient APRES le distant : basculer sur dev avant de l avoir creee echouerait.
+# La fixture porte une ligne `warn` a dessein : sans elle, deplacer le volet local
+# apres `ecart warn` dans l ordre ne changerait pas la sortie, et l assertion serait
+# aveugle a la regression qu elle pretend surveiller.
+zc '_work_cfg_sort_plan "$(printf "warn\tbla\nlocal_checkout\tdev\t/d\nbranch_create\tdev\tmain\nmaster_delete\tmain")" | cut -f1' \
+    | assert_equals "le volet local s applique apres le distant, avant les avis" \
+"$(printf 'branch_create\nmaster_delete\nlocal_checkout\nwarn')"
+
+echo
 echo "== planificateur : repo conforme =="
 
 # demo-front conforme : 4 branches, defaut dev, pprd et prd protegees 40/40/false.

--- a/scripts/tests/work-config-repos.test.sh
+++ b/scripts/tests/work-config-repos.test.sh
@@ -52,8 +52,17 @@ zc '_work_cfg_parse_path "$WORK_DIR/xxx/applications/demoapp/configurations/demo
 zc '_work_cfg_parse_path "$WORK_DIR/blg/applications/demoapp/components/demo-front" || print refuse' \
     | assert_equals "hors groupe configurations refuse" "refuse"
 
-zc '_work_cfg_parse_path "$WORK_DIR/blg/applications/demoapp/configurations/companion/app" || print refuse' \
-    | assert_equals "chemin companion refuse" "refuse"
+# Un chemin companion est RECONNU, pas rejete par l arite. Le rejeter ici renverrait
+# « BU inconnue » a quelqu un dont la BU est valide : le message nommerait le mauvais
+# probleme. C est _work_cfg_guard_target qui refuse, et qui sait dire pourquoi.
+zc '_work_cfg_parse_path "$WORK_DIR/blg/applications/demoapp/configurations/companion/app"' \
+    | assert_equals "chemin companion reconnu, pas rejete par l arite" "$(printf 'blg\tdemoapp\tcompanion/app')"
+
+zc '_work_cfg_guard_target blg demoapp companion/app 2>&1 | grep -o "companion est hors perimetre"' \
+    | assert_equals "le garde nomme le sous-groupe companion" "companion est hors perimetre"
+
+zc '_work_cfg_parse_path "$WORK_DIR/blg/applications/demoapp/configurations/pasompanion/app" || print refuse' \
+    | assert_equals "six segments hors companion : toujours refuse" "refuse"
 
 zc '_work_cfg_parse_path "/ailleurs/blg/applications/demoapp/configurations/demo-front" || print refuse' \
     | assert_equals "hors WORK_DIR refuse" "refuse"
@@ -78,6 +87,36 @@ zc '_work_cfg_guard_target blg "" demo-front >/dev/null 2>&1 || print refuse' \
 
 zc '_work_cfg_guard_target blg demoapp "" >/dev/null 2>&1 || print refuse' \
     | assert_equals "repo vide refuse" "refuse"
+
+echo
+echo "== un nom de repo est un segment de chemin, pas une chaine libre =="
+
+zc '_work_cfg_guard_target blg demoapp "../x" >/dev/null 2>&1 || print refuse' \
+    | assert_equals "un nom avec une barre est refuse" "refuse"
+
+zc '_work_cfg_guard_target blg demoapp "a b" >/dev/null 2>&1 || print refuse' \
+    | assert_equals "un nom avec une espace est refuse" "refuse"
+
+# Ferme en amont ce que la construction jq echappe en aval : mieux vaut refuser
+# un nom porteur de guillemets que de compter sur l echappement seul.
+zc '_work_cfg_guard_target blg demoapp '"'"'x","visibility":"public'"'"' >/dev/null 2>&1 || print refuse' \
+    | assert_equals "un nom porteur de guillemets est refuse" "refuse"
+
+# Le motif ne doit pas dependre d EXTENDED_GLOB : sous zsh -f les operateurs # et (...)
+# sont litteraux, et une forme qui en depend rejetait « cls-bff ».
+zc '_work_cfg_guard_target blg demoapp demo-front && print ok' \
+    | assert_equals "un nom legitime avec tiret passe" "ok"
+
+zc '_work_cfg_guard_target blg demoapp demo_front.v2 && print ok' \
+    | assert_equals "un nom legitime avec _ et . passe" "ok"
+
+# « . » veut dire « ici ». Le prendre au pied de la lettre construisait une cible
+# .../configurations/. sans que rien ne proteste.
+zc 'd="$WORK_DIR/blg/applications/demoapp/configurations/demo-front"
+    mkdir -p "$d"; cd "$d"
+    GITLAB_BASE_DOMAIN=127.0.0.1:9 GITLAB_TOKEN=x
+    work_config_repo . 2>&1 | grep -o "configurations/demo-front"' \
+    | assert_equals "« . » vaut ici, pas un repo nomme point" "configurations/demo-front"
 
 # Le refus doit tomber AVANT tout appel reseau. Un curl factice depose un marqueur :
 # comparer la sortie ne suffirait pas, _ui_msg_fail ecrit sur stdout (core/ui.zsh:202)


### PR DESCRIPTION
Deux défauts trouvés en usage réel une minute après la fusion de #113, puis une correction de périmètre que ces défauts ont mise au jour.

## 1. Le message nommait le mauvais problème

Depuis `.../configurations/companion/api` :

```
❯ work_config_repo .
✗ BU inconnue : « <vide> » (attendu : blg edt udb tsc shared)
```

La BU est pourtant valide. `_work_cfg_parse_path` exigeait cinq segments, un chemin `companion` en compte six : le parse échouait et ne transmettait **rien** au garde. Le commentaire de la fonction affirmait l'inverse — *« l'arité stricte écarte d'elle-même les chemins sous companion, le message dédié est rendu par le garde »*. Il ne l'était jamais.

## 2. `.` était pris pour un nom de repo

`work_config_repo .` construisait une cible `.../configurations/.` sans protester. `.` et `./` valent maintenant « ici ».

## 3. Et surtout : `companion` n'aurait jamais dû être exclu

En corrigeant le message, la vraie question est apparue. Les trois projets du sous-groupe portent la même topologie que les autres :

```
companion/app     main  prot=true  def=true
companion/api     main  prot=true  def=true
companion/loader  main  prot=true  def=true
```

`main` unique et protégée — **hors norme**, exactement comme `cls-docs` l'était. Ce sont des candidats naturels à la mise aux normes.

La consigne d'origine — *« si dossier companion, à exclure »* — portait sur la **lecture des règles de référence**, pas sur le périmètre. La généralisation en exclusion complète était une sur-interprétation.

Ce que l'ouverture demande :

- le garde valide chaque segment du nom et refuse au-delà de deux niveaux ;
- **`companion` seul reste refusé**, mais pour la bonne raison : c'est un sous-groupe, pas un dépôt. Quelqu'un debout dedans obtiendrait ce nom par déduction et auditerait un groupe comme un projet. Le message indique où descendre ;
- deux helpers séparent le groupe porteur du nom du projet — GitLab n'accepte pas de `/` dans un `path`, donc `companion/api` se crée sous `.../configurations/companion` avec le path `api` ;
- le README porte le **nom** du repo, pas son chemin : `# api dev`, pas `# companion/api dev`.

Résultat en usage réel :

```
❯ work_config_repo          (dans companion/api)
Cible    blg/applications/frontlibreservice/configurations/companion/api
  + creer branche dev depuis main
  + creer branche qlf depuis main
  ~ README de dev → « # api dev »

❯ work_config_repo          (dans companion)
✗ companion est un sous-groupe, pas un repo
ℹ descendre dans l un de ses projets, ou le nommer : companion/<repo>
```

## Garde de forme sur le nom

Un nom de repo est un segment de chemin GitLab, pas une chaîne libre : `../x`, `a b` et les noms porteurs de guillemets sont refusés en amont — ce que la construction par `jq` échappait en aval, mais mieux vaut refuser que compter sur l'échappement seul.

Le motif évite `#` et `(...)`, qui exigent `EXTENDED_GLOB` : sous `zsh -f` ils sont littéraux, et une première version rejetait `cls-bff`.

## Tests

L'assertion « chemin companion refuse » **encodait le défaut** — elle exigeait du parse qu'il rejette.

**119 → 134 assertions.** Chaque changement validé par mutation. L'une d'elles n'a d'abord **rien fait tomber** — créer un projet avec le chemin au lieu du nom — révélant qu'aucune assertion ne couvrait le corps de création pour un repo de sous-groupe. Le trou est comblé, et la mutation tombe désormais.

🤖 Generated with [Claude Code](https://claude.com/claude-code)