### PR TITLE
feat(work): un produit merch se cherche par l un de ses quatre identifiants

### DIFF
--- a/examples/env.d/work.zsh
+++ b/examples/env.d/work.zsh
@@ -15,6 +15,18 @@ export ES_USER="${ES_USER:-}"
 # ES_PASSWORD a definir dans ~/.secrets ou via SOPS, jamais ici en clair
 # export ES_PASSWORD=""
 
+# API produits merch (work_merch_product / get_merch_product)
+# Les hotes restent vides ici : ce depot est public, et un nom d hote d entreprise en dur y
+# serait de la nomenclature d infrastructure. Les renseigner dans env.d/work.zsh, qui est
+# gitignore. Sans eux, la commande refuse au lieu de deviner.
+export ZANVIL_WORK_MERCH_HOST_PROD="${ZANVIL_WORK_MERCH_HOST_PROD:-}"
+export ZANVIL_WORK_MERCH_HOST_QLF="${ZANVIL_WORK_MERCH_HOST_QLF:-}"
+export ZANVIL_WORK_MERCH_ORG="${ZANVIL_WORK_MERCH_ORG:-OCFR}"
+# Une cle par environnement, sans repli de l une sur l autre — a definir dans ~/.secrets ou
+# via SOPS, jamais ici en clair.
+# export ZANVIL_WORK_MERCH_API_KEY_PROD=""
+# export ZANVIL_WORK_MERCH_API_KEY_QLF=""
+
 # PKI entreprise — URL du bundle de certificats (certificates_unix.sh)
 export ZANVIL_WORK_PKI_URL="${ZANVIL_WORK_PKI_URL:-}"
 

--- a/modules/work/.lazy
+++ b/modules/work/.lazy
@@ -8,3 +8,5 @@ work_es_apps
 work_es_count
 work_es_tail
 work_config_repo
+work_merch_product
+get_merch_product

--- a/modules/work/completions.zsh
+++ b/modules/work/completions.zsh
@@ -79,3 +79,19 @@ _work_config_repo() {
         '1:repo de configuration:'
 }
 compdef _work_config_repo work_config_repo
+
+# Les quatre criteres s excluent l un l autre : l API n en prend qu un, donc la completion
+# cesse de proposer les trois autres des qu un est frappe.
+_work_merch_product() {
+    local excl='(-e --ean -o --offerId -s --sapId -p --pimId)'
+    _arguments \
+        "${excl}"{-e,--ean}'[Code EAN]:ean:' \
+        "${excl}"{-o,--offerId}'[Identifiant d offre]:offerId:' \
+        "${excl}"{-s,--sapId}'[Identifiant SAP]:sapId:' \
+        "${excl}"{-p,--pimId}'[Identifiant PIM]:pimId:' \
+        '(--qlf)--prod[Production (defaut)]' \
+        '(--prod)--qlf[Qualification]' \
+        '(-h --help)'{-h,--help}'[Afficher l aide]'
+}
+compdef _work_merch_product work_merch_product
+compdef _work_merch_product get_merch_product

--- a/modules/work/init.zsh
+++ b/modules/work/init.zsh
@@ -1,3 +1,4 @@
 source "$ZANVIL_DIR/modules/work/work_context.zsh"
 source "$ZANVIL_DIR/modules/work/elasticsearch.zsh"
 source "$ZANVIL_DIR/modules/work/config_repos.zsh"
+source "$ZANVIL_DIR/modules/work/merch.zsh"

--- a/modules/work/merch.zsh
+++ b/modules/work/merch.zsh
@@ -1,0 +1,264 @@
+# ==============================================================================
+# Work Merch — interrogation de l API produits merch
+# ==============================================================================
+# Un produit se cherche par l un de quatre identifiants : EAN, offre, SAP ou PIM.
+# L API en prend un seul a la fois, et le nom long de chaque option EST le nom du
+# parametre de requete — il n y a donc aucune table de correspondance a maintenir, et
+# `--offerId` garde son camelCase pour cette raison.
+
+# --- Configuration (env.d/work.zsh ou ~/.secrets, jamais versionnee) ---
+#
+# Aucune valeur par defaut, delibere : ce depot est public, et un nom d hote d entreprise
+# en dur y est de la nomenclature d infrastructure offerte a qui lit le code. C est la meme
+# regle que pour ZANVIL_WORK_ES_URL, et `tests/bin/internal-hostnames` la fait respecter.
+# Sans reglage, les commandes refusent au lieu d interroger une instance qui n est pas la
+# leur — le bon sens du refus : un poste non configure ne doit pas deviner.
+
+_work_merch_host() {
+    case "${1:-prod}" in
+        prod) echo "${ZANVIL_WORK_MERCH_HOST_PROD:-}" ;;
+        qlf)  echo "${ZANVIL_WORK_MERCH_HOST_QLF:-}"  ;;
+    esac
+}
+
+# Une cle par environnement, sans repli de l une sur l autre. Un repli silencieux
+# enverrait la cle de production a la qualification le jour ou celle de qlf manque : le
+# refus dit ou est le trou, le repli le cache.
+_work_merch_api_key() {
+    case "${1:-prod}" in
+        prod) echo "${ZANVIL_WORK_MERCH_API_KEY_PROD:-}" ;;
+        qlf)  echo "${ZANVIL_WORK_MERCH_API_KEY_QLF:-}"  ;;
+    esac
+}
+
+# L organisation garde un defaut, contrairement aux hotes : c est un code metier, pas une
+# adresse, et il ne mene nulle part seul. Meme statut que ZANVIL_WORK_ES_INDEX.
+_work_merch_org() {
+    echo "${ZANVIL_WORK_MERCH_ORG:-OCFR}"
+}
+
+_WORK_MERCH_PATH_TMPL='offer/merch-v3/organizations/%s/products'
+
+# --- Garde commune : outils et configuration avant tout appel reseau ---
+
+_work_merch_require() {
+    local env=$1
+    if ! command -v curl &>/dev/null; then
+        _ui_msg_fail "curl requis"
+        return 1
+    fi
+    if [[ -z "$(_work_merch_host "$env")" ]]; then
+        _ui_msg_fail "ZANVIL_WORK_MERCH_HOST_${env:u} non definie (voir examples/env.d/work.zsh)"
+        return 1
+    fi
+    if [[ -z "$(_work_merch_api_key "$env")" ]]; then
+        _ui_msg_fail "ZANVIL_WORK_MERCH_API_KEY_${env:u} non definie"
+        _ui_msg_info "la cle va dans ~/.secrets ou env.d/work.zsh — jamais dans un fichier versionne"
+        return 1
+    fi
+    return 0
+}
+
+# --- Appel ---
+
+# Usage : _work_merch_curl <env> <param> <valeur>
+# Sortie : 1ere ligne = code HTTP, reste = corps.
+# Return : code de sortie curl (0 = reponse recue, meme en erreur HTTP).
+_work_merch_curl() {
+    local env=$1 param=$2 value=$3
+    local host org url
+    host="$(_work_merch_host "$env")"
+    org="$(_work_merch_org)"
+    url="https://${host}/$(printf "$_WORK_MERCH_PATH_TMPL" "$org")"
+
+    local -a opts
+    opts=(-s --connect-timeout 5 --max-time 30)
+    # Le host de qualification vit derriere la PKI d entreprise : sans ce cacert, la
+    # negociation TLS echoue avec un code 60 qui ressemble a une panne reseau.
+    [[ -n "${SSL_CERT_FILE:-}" ]] && opts+=(--cacert "$SSL_CERT_FILE")
+    opts+=(-H 'Accept-Language: fr_FR')
+    # `--get --data-urlencode` plutot qu une query concatenee : la valeur est encodee par
+    # curl, donc un identifiant contenant & ou = ne peut pas fabriquer un second parametre.
+    opts+=(--get --data-urlencode "${param}=${value}")
+    opts+=(-w $'\n%{http_code}')
+
+    # La cle passe par un fichier de configuration lu sur stdin, pas par argv : un `-H` en
+    # ligne de commande est lisible dans `ps` par tout processus du meme utilisateur.
+    # `_work_es_curl` met ES_PASSWORD en argv ; c est une dette, pas un modele a copier.
+    local out
+    out=$(printf 'header = "x-api-key: %s"\n' "$(_work_merch_api_key "$env")" \
+        | command curl "${opts[@]}" --config - "$url" 2>/dev/null)
+    local ret=$?
+    (( ret != 0 )) && return $ret
+
+    print -r -- "${out##*$'\n'}"
+    local body="${out%$'\n'*}"
+    [[ "$body" != "$out" && -n "$body" ]] && print -r -- "$body"
+    return 0
+}
+
+# --- Aide ---
+
+_work_merch_usage() {
+    cat <<'EOF'
+Usage : work_merch_product <critere> [--prod|--qlf]
+        get_merch_product  <critere> [--prod|--qlf]
+
+Critere (exactement un) :
+  -e, --ean <ean>          Code EAN
+  -o, --offerId <id>       Identifiant d offre
+  -s, --sapId <id>         Identifiant SAP
+  -p, --pimId <id>         Identifiant PIM
+
+Environnement :
+  --prod                   Production (defaut)
+  --qlf                    Qualification
+  -h, --help               Cette aide
+
+Sortie : indentee par jq sur un terminal, JSON brut dans un pipe ou un fichier.
+
+Configuration (env.d/work.zsh ou ~/.secrets, jamais versionnee) :
+  ZANVIL_WORK_MERCH_HOST_PROD / _HOST_QLF
+  ZANVIL_WORK_MERCH_API_KEY_PROD / _API_KEY_QLF
+  ZANVIL_WORK_MERCH_ORG        (defaut OCFR)
+
+Exemples :
+  work_merch_product -e 3660000000000
+  work_merch_product --offerId 12345 --qlf
+  work_merch_product -s 987654 | jq '.products[0].label'
+EOF
+}
+
+# --- Fonction publique ---
+
+work_merch_product() {
+    local env=prod param="" value="" crit_opt=""
+
+    while (( $# )); do
+        case "$1" in
+            -e|--ean|-o|--offerId|-s|--sapId|-p|--pimId)
+                local p
+                case "$1" in
+                    -e|--ean)     p=ean     ;;
+                    -o|--offerId) p=offerId ;;
+                    -s|--sapId)   p=sapId   ;;
+                    -p|--pimId)   p=pimId   ;;
+                esac
+                # Deux criteres dans la meme ligne de commande ne sont pas une preference a
+                # arbitrer : l API n en prend qu un, et deviner lequel produirait une
+                # reponse qui ne repond pas a la question posee.
+                if [[ -n "$param" ]]; then
+                    _ui_msg_fail "deux criteres a la fois : --$param et --$p"
+                    _ui_msg_info "l API n en accepte qu un — n en garder qu un"
+                    return 1
+                fi
+                if [[ -z "${2:-}" || "${2}" == -* ]]; then
+                    _ui_msg_fail "valeur manquante apres $1"
+                    return 1
+                fi
+                param=$p; value=$2; crit_opt=$1
+                # `shift 2` non garde boucle a l infini quand le flag est le dernier
+                # argument — piege zsh releve en review sur work_es_count.
+                if (( $# >= 2 )); then shift 2; else shift; fi
+                ;;
+            --prod) env=prod; shift ;;
+            --qlf)  env=qlf;  shift ;;
+            -h|--help) _work_merch_usage; return 0 ;;
+            *)
+                _ui_msg_fail "option inconnue : $1"
+                _ui_msg_info "work_merch_product --help"
+                return 1
+                ;;
+        esac
+    done
+
+    if [[ -z "$param" ]]; then
+        _ui_msg_fail "aucun critere — passer -e, -o, -s ou -p"
+        echo ""
+        _work_merch_usage
+        return 1
+    fi
+
+    _work_merch_require "$env" || return 1
+
+    local out code curl_rc
+    out=$(_work_merch_curl "$env" "$param" "$value")
+    curl_rc=$?
+    if (( curl_rc != 0 )); then
+        # Les codes qu on rencontre vraiment ici. Le reste est rendu tel quel : inventer
+        # une phrase pour chacun des quatre-vingts vaudrait moins que le numero, qui se
+        # cherche. Meme raisonnement que _work_es_json.
+        local why
+        case $curl_rc in
+            6)  why="hote introuvable (DNS) — VPN actif ?" ;;
+            7)  why="connexion refusee — instance joignable ?" ;;
+            28) why="delai depasse" ;;
+            35|60) why="echec TLS — certificat d entreprise installe ? (SSL_CERT_FILE)" ;;
+            *)  why="curl a rendu $curl_rc" ;;
+        esac
+        _ui_msg_fail "appel merch en echec ($env) : $why"
+        return 1
+    fi
+
+    code="${out%%$'\n'*}"
+    if [[ "$code" != <-> ]]; then
+        _ui_msg_fail "reponse sans code HTTP — un proxy s est interpose ?"
+        return 1
+    fi
+
+    local body=""
+    [[ "$out" == *$'\n'* ]] && body="${out#*$'\n'}"
+
+    if (( code >= 400 )); then
+        case $code in
+            401|403) _ui_msg_fail "HTTP $code — ZANVIL_WORK_MERCH_API_KEY_${env:u} refusee" ;;
+            404) _ui_msg_fail "HTTP 404 — aucun produit pour $crit_opt $value" ;;
+            *)   _ui_msg_fail "HTTP $code" ;;
+        esac
+        # Le corps d une erreur porte souvent le motif exact ; le taire obligerait a
+        # rejouer la requete a la main pour le lire.
+        [[ -n "$body" ]] && print -r -- "$body" >&2
+        return 1
+    fi
+
+    # jq sur un terminal, brut ailleurs : le pipe en dur empecherait de rediriger vers un
+    # fichier ou de rejouer avec un autre filtre.
+    if [[ -t 1 ]] && command -v jq &>/dev/null; then
+        print -r -- "$body" | jq
+    else
+        print -r -- "$body"
+    fi
+    return 0
+}
+
+# Le nom court demande. C est une fonction et non un alias, et le lazy loader l impose :
+# `.lazy` remplace chaque nom publie par un stub qui source le module puis appelle
+# `"$func"`. Or l expansion d alias n a pas lieu sur un mot issu d une variable — un alias
+# ne serait donc jamais atteint avant le premier appel, et l inscrire dans `.lazy` ferait
+# du stub un appel a lui-meme, en boucle. Une vraie fonction, redefinie par le source,
+# ferme les deux cas.
+get_merch_product() {
+    work_merch_product "$@"
+}
+
+# --- Volet de work_status ---
+
+_work_merch_status_section() {
+    echo ""
+    echo -e "${_ui_bold}Merch${_ui_nc}"
+    _ui_separator 44
+    local env
+    for env in prod qlf; do
+        local h k
+        h="$(_work_merch_host "$env")"
+        k="$(_work_merch_api_key "$env")"
+        if [[ -n "$h" && -n "$k" ]]; then
+            _ui_section "${env:u}" "${_ui_green}configure${_ui_nc}"
+        elif [[ -n "$h" || -n "$k" ]]; then
+            _ui_section "${env:u}" "${_ui_yellow}incomplet ($([[ -z "$h" ]] && echo 'hote' || echo 'cle') manquant)${_ui_nc}"
+        else
+            _ui_section "${env:u}" "${_ui_dim}non configure${_ui_nc}"
+        fi
+    done
+    _ui_section "Organisation" "$(_work_merch_org)"
+}

--- a/modules/work/work_context.zsh
+++ b/modules/work/work_context.zsh
@@ -206,6 +206,9 @@ work_status() {
 
     # Volet Elasticsearch (defini dans elasticsearch.zsh)
     (( $+functions[_work_es_status_section] )) && _work_es_status_section
+
+    # Volet Merch (defini dans merch.zsh)
+    (( $+functions[_work_merch_status_section] )) && _work_merch_status_section
 }
 
 # --- Auto-initialisation au chargement ---

--- a/web/site/src/content/docs/commandes.md
+++ b/web/site/src/content/docs/commandes.md
@@ -136,6 +136,26 @@ l'environnement — voir `env.d/` et le chiffrement sops.
 
 Les plages s'écrivent `Xs`, `Xm`, `Xh` ou `Xd`. `work_es_apps --refresh` ignore le cache.
 
+## API produits merch (module work)
+
+Recherche un produit par l'un de quatre identifiants. Les hôtes et les clés sont attendus
+dans l'environnement — voir `examples/env.d/work.zsh` ; les clés vont dans `~/.secrets` ou
+sous sops, jamais dans un fichier versionné.
+
+| Commande | Description |
+|----------|-------------|
+| `work_merch_product <critère>` | Interroge l'API produits ; `get_merch_product` est le même |
+
+Un seul critère à la fois, l'API n'en accepte pas davantage : `-e/--ean`, `-o/--offerId`,
+`-s/--sapId`, `-p/--pimId`. L'environnement se choisit avec `--prod` (défaut) ou `--qlf`.
+La sortie est indentée par `jq` sur un terminal et brute dans un pipe, donc composable :
+
+```bash
+get_merch_product -e 3660000000000
+get_merch_product --offerId 12345 --qlf
+get_merch_product -s 987654 | jq '.products[0].label'
+```
+
 ## Git Hooks
 
 | Commande | Description |


### PR DESCRIPTION
## Ce que ça ajoute

`work_merch_product` interroge l'API produits merch par EAN, offre, SAP ou PIM, sur la production ou la qualification. `get_merch_product` est le même, sous le nom court.

```bash
get_merch_product -e 3660000000000
get_merch_product --offerId 12345 --qlf
get_merch_product -s 987654 | jq '.products[0].label'
```

Le nom long de chaque option **est** le nom du paramètre de requête — aucune table de correspondance à maintenir, et c'est pourquoi `--offerId` garde son camelCase, inhabituel pour une CLI.

## Décisions qui méritent un mot

**Les hôtes n'ont pas de valeur par défaut.** Ce dépôt est public, et un nom d'hôte d'entreprise en dur y serait la nomenclature d'une infrastructure offerte à qui le lit. Même traitement que `ZANVIL_WORK_ES_URL`, tenu par `tests/bin/internal-hostnames`. Sans réglage, la commande refuse au lieu d'interroger une instance qui n'est pas la sienne.

**Une clé par environnement, sans repli de l'une sur l'autre.** Un repli enverrait la clé de production à la qualification le jour où celle de qlf manque ; le refus dit où est le trou que le repli cacherait.

**La clé transite par `curl --config -` sur stdin, pas par `argv`**, où un `-H` est lisible dans `ps` par tout processus du même utilisateur. `_work_es_curl` met `ES_PASSWORD` en argv : c'est une dette, pas un modèle à copier.

**`--env` n'existe pas.** `-e` était demandé deux fois, pour `--ean` et pour `--env`. Les drapeaux `--prod` / `--qlf` lèvent la collision et ne peuvent pas se confondre avec un critère.

**La valeur du critère passe par `--get --data-urlencode`**, donc curl l'encode : un identifiant contenant `&` ou `=` ne peut pas fabriquer un second paramètre.

**La sortie est indentée par `jq` sur un terminal, brute ailleurs**, pour rester composable dans un pipe ou une redirection.

## Le piège du lazy loading

`get_merch_product` est une **fonction**, pas un alias, et le lazy loader l'impose : `.lazy` remplace chaque nom publié par un stub qui appelle `"$func"`, or l'expansion d'alias n'a pas lieu sur un mot issu d'une variable. Un alias ne serait jamais atteint avant le premier appel, et l'inscrire dans `.lazy` ferait du stub un appel à lui-même, en boucle infinie. Une vraie fonction, redéfinie par le `source`, ferme les deux ordres d'appel.

## Vérification

Pas de shellspec (supprimé du projet en mars 2026). Ce qui a été exécuté :

| Contrôle | Résultat |
|---|---|
| `zsh -n` sur les 5 fichiers touchés | ✓ |
| chargement en `zsh -f`, deux fonctions définies | ✓ |
| 11 sondes de refus et de messages, **sans réseau** | 11/11 |
| comportement borné hors réseau (`127.0.0.1:9`) | « connexion refusée » immédiat |
| lazy loading reproduit depuis `core/loader.zsh` | pas de récursion, sous timeout |
| faux `curl` en tête de `PATH` | URL conforme, **clé absente d'`argv`** |
| `tests/bin/internal-hostnames` | muet |
| valeurs d'hôte ou de clé dans les fichiers suivis | aucune |

## Configuration à renseigner, hors dépôt

```zsh
# env.d/work.zsh (gitignored) ou ~/.secrets
export ZANVIL_WORK_MERCH_HOST_PROD="…"
export ZANVIL_WORK_MERCH_HOST_QLF="…"
export ZANVIL_WORK_MERCH_API_KEY_PROD="…"
export ZANVIL_WORK_MERCH_API_KEY_QLF="…"
```

`work_status` affiche désormais l'état de cette configuration pour les deux environnements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)