### PR TITLE
fix(ci): une expression vide dans un commentaire arretait toutes les releases

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -72,7 +72,14 @@ jobs:
           sed -i 's/export ZANVIL_VERSION="v[^"]*"/export ZANVIL_VERSION="${{ steps.version.outputs.tag }}"/' core/ui.zsh
           # Le tag porte un « v » que Cargo n'accepte pas dans un champ version. Le
           # retrait passe par une variable intermediaire : ${VAR#v} est du bash, et
-          # l'imbriquer dans une expression ${{ }} de GitHub ne l'est pas.
+          # l'imbriquer dans une expression GitHub ne l'est pas.
+          #
+          # Ne PAS ecrire cette expression en clair ici, meme derriere un diese. Le diese
+          # commente pour le shell, pas pour GitHub : les expressions sont substituees dans
+          # tout le bloc `run` avant qu'aucun shell ne le lise. Une expression vide est
+          # invalide, elle fait rejeter le fichier ENTIER, et le workflow ne tourne plus du
+          # tout — il n'echoue pas dans un job, il n'en cree aucun. C'est arrive le
+          # 2026-08-03 et plus aucune release n'est sortie pendant neuf jours.
           TAG="${{ steps.version.outputs.tag }}"
           CARGO_VERSION="${TAG#v}"
           # python3 plutot que sed : la premiere version de cette etape utilisait

--- a/tests/bin/workflow-expressions
+++ b/tests/bin/workflow-expressions
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Imprime les expressions GitHub vides ecrites dans un fichier de workflow.
+#
+# Une expression vide fait rejeter le fichier ENTIER par GitHub. Le workflow ne tourne alors
+# plus du tout : il n'echoue pas dans un job, il n'en cree AUCUN. L'interface affiche « This
+# run likely failed because of a workflow file issue », sans log a lire, et `gh run view
+# --log-failed` repond « log not found ».
+#
+# C'est arrive le 2026-08-03 a auto-release.yml, et personne ne l'a vu pendant neuf jours :
+#
+#   # l'imbriquer dans une expression ${'{'}{ } } de GitHub ne l'est pas.
+#
+# Le commentaire qui expliquait qu'on ne peut pas imbriquer du bash dans une expression
+# GitHub en a ecrit une, vide. Le diese n'y change rien : il commente pour le SHELL, alors
+# que les expressions sont substituees dans tout le bloc `run` avant qu'aucun shell ne le
+# lise. Aucune release n'est sortie pendant ces neuf jours, et rien ne le signalait — les
+# runs en echec portaient l'evenement `push` sur un workflow declenche par `pull_request`,
+# ce qui ressemblait a un bruit d'infrastructure plutot qu'a une panne.
+#
+# Deux signes qui trahissent cette panne, si elle revient malgre ce controle :
+#   - `gh workflow list` affiche le CHEMIN du fichier au lieu de son `name:` ;
+#   - les runs ont 0 job et l'evenement ne correspond pas au declencheur declare.
+#
+# actionlint couvre ce defaut et bien d'autres, mais il faudrait l'ajouter au CI et au poste
+# de chacun. Ce controle ne demande rien : il ne verifie qu'un cas, celui qui a mordu.
+set -uo pipefail
+
+ROOT="${ZANVIL_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+
+if ! git -C "$ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+    echo "workflow-expressions: $ROOT n'est pas un depot git — controle impossible" >&2
+    exit 2
+fi
+
+# Une ouverture, des espaces facultatifs, une fermeture. Les accolades sont echappees parce
+# qu'en ERE `{` ouvre un quantificateur. Pas de `\s` ni de `\b` : POSIX ERE ne les connait
+# pas, et `git grep -E` rendrait zero resultat en silence — c'est le piege qui a deja coute
+# une iteration a tests/bin/internal-hostnames.
+PATTERN='\$\{\{[[:space:]]*\}\}'
+
+# Ce fichier se decrit lui-meme sans se signaler : l'exemple du commentaire ci-dessus coupe
+# la sequence par une chaine, donc il ne forme pas le motif. Un controle qui doit s'exclure
+# du scan cree un angle mort a l'endroit meme ou il regarde.
+git -C "$ROOT" grep -nIoE "$PATTERN" -- '.github/workflows/*.yml' '.github/workflows/*.yaml' \
+    || true

--- a/tests/cases/docs/no-empty-workflow-expression.yaml
+++ b/tests/cases/docs/no-empty-workflow-expression.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Le garde-fou imprime les expressions GitHub vides trouvees dans un fichier de workflow, et
+# ce cas exige qu il n en imprime aucune.
+#
+# Motif : le 2026-08-03, auto-release.yml a recu ce commentaire, cense expliquer qu on ne
+# peut pas imbriquer une substitution bash dans une expression GitHub :
+#
+#   # l imbriquer dans une expression ${'{'}{ } } de GitHub ne l est pas.
+#
+# En l ecrivant, il a produit une expression VIDE, et GitHub rejette alors le fichier
+# ENTIER. Le workflow n a plus tourne du tout : il n echouait pas dans un job, il n en
+# creait AUCUN. Aucune release n est sortie pendant neuf jours, jusqu au 2026-08-12.
+#
+# CE DEFAUT NE RESSEMBLE PAS A UNE PANNE, et c est ce qui l a rendu invisible. Les runs
+# portaient l evenement `push` sur un workflow declenche par `pull_request`, ce qui passait
+# pour un bruit d infrastructure. L interface disait « This run likely failed because of a
+# workflow file issue » sans log, et `gh run view --log-failed` repondait « log not found ».
+# La correlation etait pourtant nette : 13 runs `pull_request` tous en succes, 47 runs
+# `push` tous en echec.
+#
+# Le diese ne protege pas : il commente pour le SHELL, alors que les expressions sont
+# substituees dans tout le bloc `run` avant qu aucun shell ne le lise.
+name: no-empty-workflow-expression
+weight: 7
+setup:
+  run: ["$GAVELDROP_PROJECT/tests/bin/workflow-expressions"]
+  env:
+    ZANVIL_DIR: "$GAVELDROP_PROJECT"
+expect:
+  exit_code: 0
+  stdout:
+    # Une ligne par occurrence : rien a dire, rien a imprimer.
+    equals: ""


### PR DESCRIPTION
## Le défaut

`auto-release.yml` portait ce commentaire depuis le 2026-08-03, censé expliquer qu'on ne peut pas imbriquer une substitution bash dans une expression GitHub :

```yaml
# l'imbriquer dans une expression ${{ }} de GitHub ne l'est pas.
```

En l'écrivant, il a produit une expression **vide**. GitHub rejette alors le fichier **entier** : le workflow n'a plus tourné du tout — il n'échouait pas dans un job, il n'en créait **aucun**.

**Aucune release n'est sortie pendant neuf jours**, alors que plusieurs branches `feat/` ont été mergées. La dernière est `v4.4.0` du 2026-08-03 ; `core/ui.zsh` et `cli/Cargo.toml` sont restés figés sur cette version.

Le dièse ne protège de rien : il commente pour le **shell**, alors que les expressions sont substituées dans tout le bloc `run` avant qu'aucun shell ne le lise.

## Pourquoi ça a tenu neuf jours

Le défaut ne ressemblait pas à une panne. Les runs en échec portaient l'événement `push` sur un workflow déclenché par `pull_request` — un workflow qui ne concerne pas les pushes semblait échouer sur des pushes, ce qui passe pour du bruit d'infrastructure. L'interface affichait « This run likely failed because of a workflow file issue » sans log, et `gh run view --log-failed` répondait `log not found`.

La corrélation était nette une fois les runs comptés :

| Déclencheur | Runs | Résultat |
|---|---|---|
| `pull_request` (celui déclaré) | 13 | **tous en succès** |
| `push` (fantôme) | 47 | **tous en échec** |

Bascule au `2026-08-03T17:12`, une minute après le commit `9f5df79` qui a introduit la ligne. Deux autres signes : `gh workflow list` affichait le **chemin** du fichier au lieu de son `name: Auto Release`, et les runs avaient zéro job.

## Le garde-fou

`tests/bin/workflow-expressions` + son cas dans `tests/cases/docs/`. Il ne vérifie qu'une chose, celle qui a mordu, et ne demande aucun outil — `actionlint` couvre ce défaut et bien d'autres, mais il faudrait l'ajouter au CI et au poste de chacun.

Le motif échappe les accolades (en ERE, `{` ouvre un quantificateur) et se passe de `\s` et `\b`, que POSIX ERE ne connaît pas : leur absence rendrait le contrôle **muet plutôt que faux**, ce qui vient précisément d'arriver à `internal-hostnames`.

## Vérification

| Contrôle | Résultat |
|---|---|
| `actionlint` 1.7.12 avant | `69:426: unexpected end of input while parsing … [expression]` |
| `actionlint` après | aucun signalement |
| sonde de mutation (défaut exact du 2026-08-03) | détectée, `actionlint` confirme la même position |
| variantes sans espace et à espaces multiples | détectées |
| expression valide (`${{ steps.x.outputs.y }}`) | non signalée |
| les 7 cas de `tests/cases/docs/` | 7/7, score 47/47 |

## Après le merge

La branche est préfixée `fix/`, qui ne correspond à aucun motif de bump (`breaking/`, `feature/`, `feat/`, `hotfix/`) : le workflow tournera et fera `skip`, donc **aucune release ne sera créée** par ce merge. Ce sera la preuve qu'il se déclenche à nouveau sur `pull_request`.

Les releases manquées ne se rattraperont pas d'elles-mêmes — la prochaine PR `feat/` produira `v4.5.0`. À noter que #117 (`feat/work-merch-product`) aurait dû la produire si le workflow avait fonctionné.

🤖 Generated with [Claude Code](https://claude.com/claude-code)