### PR TITLE
fix(zsh): une declaration locale nue dans une boucle imprimait la variable

### DIFF
--- a/core/commands/admin.zsh
+++ b/core/commands/admin.zsh
@@ -411,7 +411,7 @@ zanvil-restore() {
 
     for f in "$src"/*; do
         local name="$(basename "$f")"
-        local target
+        local target=
 
         case "$name" in
             config.zsh|completions.zsh)

--- a/core/commands/commands.zsh
+++ b/core/commands/commands.zsh
@@ -357,7 +357,7 @@ zanvil-doctor-conflicts() {
         | sed "s/alias \([^=]*\)=.*/\1/" | sort | uniq -d)"
     if [[ -n "$alias_dups" ]]; then
         while IFS= read -r a; do
-            local files
+            local files=
             files="$(grep -rl "^alias ${a}=" "$ZANVIL_DIR/modules" "$ZANVIL_DIR/core" --include="*.zsh" 2>/dev/null | sed "s|$ZANVIL_DIR/||" | tr '\n' '  ')"
             _ui_msg_warn "'${a}' → ${files}"
             ((issues++))
@@ -377,7 +377,7 @@ zanvil-doctor-conflicts() {
         | sed -e "s/^function //" -e "s/\([^(]*\)() {.*/\1/" | sort | uniq -d)"
     if [[ -n "$fn_dups" ]]; then
         while IFS= read -r f; do
-            local files
+            local files=
             files="$(grep -rlE "^(function )?${f}\(\) \{" "$ZANVIL_DIR/modules" "$ZANVIL_DIR/core" --include="*.zsh" 2>/dev/null | sed "s|$ZANVIL_DIR/||" | tr '\n' '  ')"
             _ui_msg_warn "'${f}' → ${files}"
             ((issues++))
@@ -418,7 +418,7 @@ zanvil-doctor-conflicts() {
         | sed "s/export \([^=]*\)=.*/\1/" | sort | uniq -d)"
     if [[ -n "$export_dups" ]]; then
         while IFS= read -r e; do
-            local files
+            local files=
             files="$(grep -rl "^export ${e}=" "$ZANVIL_DIR/modules" --include="*.zsh" 2>/dev/null | sed "s|$ZANVIL_DIR/||" | tr '\n' '  ')"
             _ui_msg_warn "'${e}' → ${files}"
             ((issues++))

--- a/modules/git/git_bulk.zsh
+++ b/modules/git/git_bulk.zsh
@@ -305,7 +305,7 @@ _git_bulk_pull() {
         local name=$(basename "$repo")
         printf "  %-24s " "$name"
 
-        local output
+        local output=
         output=$(git -C "$repo" pull 2>&1)
         local rc=$?
 
@@ -356,7 +356,7 @@ _git_bulk_push() {
             continue
         fi
 
-        local output
+        local output=
         output=$(git -C "$repo" push 2>/dev/null)
         local rc=$?
 
@@ -392,7 +392,7 @@ _git_bulk_fetch() {
         local name=$(basename "$repo")
         printf "  %-24s " "$name"
 
-        local output
+        local output=
         output=$(git -C "$repo" fetch --all --prune 2>&1)
         local rc=$?
 
@@ -520,7 +520,7 @@ _git_bulk_commit() {
             printf "  %-24s " "$name"
         fi
 
-        local output
+        local output=
         output=$(git -C "$repo" commit -m "$msg" 2>&1)
         local rc=$?
 
@@ -580,7 +580,7 @@ _git_bulk_pull_dry() {
             continue
         fi
 
-        local behind_n
+        local behind_n=
         behind_n=$(git -C "$repo" rev-list --count HEAD..@{u} 2>/dev/null || echo "0")
 
         if [[ $behind_n -gt 0 ]]; then
@@ -613,7 +613,7 @@ _git_bulk_push_dry() {
         local name=$(basename "$repo")
         printf "  %-24s " "$name"
 
-        local ahead_n
+        local ahead_n=
         ahead_n=$(git -C "$repo" rev-list --count @{u}..HEAD 2>/dev/null)
         local rc=$?
 
@@ -654,7 +654,7 @@ _git_bulk_commit_dry() {
         local name=$(basename "$repo")
         printf "  %-24s " "$name"
 
-        local changes
+        local changes=
         changes=$(git -C "$repo" status --porcelain 2>/dev/null)
         local file_count=$(echo "$changes" | grep -c '.' 2>/dev/null || echo "0")
 
@@ -716,7 +716,7 @@ _git_bulk_checkout() {
             continue
         fi
 
-        local output rc
+        local output= rc=
         if [[ "$create" == "true" ]]; then
             if [[ -n "$base" ]]; then
                 output=$(git -C "$repo" checkout -b "$branch" "$base" 2>&1)
@@ -864,7 +864,7 @@ _git_bulk_stash_push() {
             continue
         fi
 
-        local output rc
+        local output= rc=
         if [[ -n "$msg" ]]; then
             output=$(git -C "$repo" stash push -m "$msg" 2>&1)
         else
@@ -909,7 +909,7 @@ _git_bulk_stash_pop() {
             continue
         fi
 
-        local output
+        local output=
         output=$(git -C "$repo" stash pop 2>&1)
         local rc=$?
 
@@ -1111,7 +1111,7 @@ _git_bulk_branch_delete() {
         fi
 
         if [[ "$do_apply" == "true" ]]; then
-            local output
+            local output=
             output=$(git -C "$repo" branch -d "$target" 2>&1)
             local rc=$?
             if [[ $rc -eq 0 ]]; then
@@ -1164,7 +1164,7 @@ _git_bulk_log() {
         [[ -n "$since" ]] && log_args+=("--since=$since")
         [[ -n "$author" ]] && log_args+=("--author=$author")
 
-        local output
+        local output=
         output=$(git -C "$repo" "${log_args[@]}" 2>/dev/null)
 
         if [[ -z "$output" ]]; then
@@ -1201,7 +1201,7 @@ _git_bulk_merge() {
         for repo in "${repos[@]}"; do
             local name=$(basename "$repo")
             printf "  %-24s " "$name"
-            local output
+            local output=
             output=$(git -C "$repo" merge --abort 2>&1)
             if [[ $? -eq 0 ]]; then
                 _ui_ok "" "abort"
@@ -1244,7 +1244,7 @@ _git_bulk_merge() {
             continue
         fi
 
-        local output
+        local output=
         output=$(git -C "$repo" merge "$branch" 2>&1)
         local rc=$?
 
@@ -1317,7 +1317,7 @@ _git_bulk_merge_dry() {
         fi
 
         # Tenter le merge sans commit
-        local output
+        local output=
         output=$(git -C "$repo" merge --no-commit --no-ff "$branch" 2>&1)
         local rc=$?
 
@@ -1370,7 +1370,7 @@ _git_bulk_clean() {
         local name=$(basename "$repo")
         printf "  %-24s " "$name"
 
-        local output
+        local output=
         if [[ "$do_apply" == "true" ]]; then
             output=$(git -C "$repo" clean -fd 2>&1)
         else
@@ -1431,7 +1431,7 @@ _git_bulk_reset() {
         printf "  %-24s " "$name"
 
         # Verifier upstream
-        local upstream
+        local upstream=
         upstream=$(git -C "$repo" rev-parse --abbrev-ref "@{upstream}" 2>/dev/null)
         if [[ -z "$upstream" ]]; then
             _ui_skip "pas d'upstream"
@@ -1457,7 +1457,7 @@ _git_bulk_reset() {
         ((total_dirty++))
 
         if [[ "$do_apply" == "true" ]]; then
-            local output
+            local output=
             output=$(git -C "$repo" reset --hard "@{upstream}" 2>&1)
             local rc=$?
             if [[ $rc -eq 0 ]]; then
@@ -1517,13 +1517,13 @@ _git_bulk_prune() {
         git -C "$repo" fetch --prune 2>/dev/null
 
         # Detecter la branche par defaut
-        local default_branch
+        local default_branch=
         default_branch=$(git -C "$repo" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
         [[ -z "$default_branch" ]] && default_branch="main"
 
         # Collecter les branches gone
         local gone_branches=()
-        local line
+        local line=
         while IFS= read -r line; do
             [[ -z "$line" ]] && continue
             local br=$(echo "$line" | awk '{print $1}')
@@ -1582,7 +1582,7 @@ _git_bulk_prune() {
                 local delete_flag="-d"
                 [[ "$reason" == "gone" ]] && delete_flag="-D"
 
-                local output
+                local output=
                 output=$(git -C "$repo" branch "$delete_flag" "$br" 2>&1)
                 local rc=$?
 

--- a/modules/gitlab/pipeline_bulk.zsh
+++ b/modules/gitlab/pipeline_bulk.zsh
@@ -159,7 +159,7 @@ _pipeline_bulk_scan() {
         fi
 
         # Verifier que la remote pointe vers GitLab
-        local remote_url
+        local remote_url=
         remote_url=$(git -C "$sub" remote get-url origin 2>/dev/null)
         if [[ "$remote_url" == *gitlab* ]]; then
             echo "${sub%/}"
@@ -199,7 +199,7 @@ _pipeline_bulk_status() {
         printf "  %-24s ${_ui_cyan}%-14s${_ui_nc} " "$name" "$current_branch"
 
         # Recuperer le dernier pipeline via glab
-        local pipeline_info
+        local pipeline_info=
         pipeline_info=$(_pipeline_bulk_glab "$repo" ci list -F json 2>/dev/null | _pipeline_bulk_parse_first 2>/dev/null)
 
         if [[ -z "$pipeline_info" || "$pipeline_info" == "none" ]]; then
@@ -208,7 +208,7 @@ _pipeline_bulk_status() {
             continue
         fi
 
-        local p_id p_status p_duration
+        local p_id= p_status= p_duration=
         p_id=$(echo "$pipeline_info" | cut -d'|' -f1)
         p_status=$(echo "$pipeline_info" | cut -d'|' -f2)
         p_duration=$(echo "$pipeline_info" | cut -d'|' -f3)
@@ -292,12 +292,12 @@ _pipeline_bulk_trigger() {
         fi
 
         # Trigger le pipeline
-        local output
+        local output=
         output=$(_pipeline_bulk_glab "$repo" ci run -b "$target_branch" 2>&1)
         local rc=$?
 
         if [[ $rc -eq 0 ]]; then
-            local pipeline_id
+            local pipeline_id=
             pipeline_id=$(echo "$output" | grep -oE '[0-9]+' | tail -1)
             if [[ -n "$pipeline_id" ]]; then
                 _ui_ok "" "#${pipeline_id} on ${target_branch}"
@@ -309,7 +309,7 @@ _pipeline_bulk_trigger() {
             triggered_repos+=("$repo")
         else
             # Extraire un message d'erreur propre
-            local err_msg
+            local err_msg=
             err_msg=$(echo "$output" | grep -v -E '^\s*$|^\s*ERROR\s*$' | head -1 | sed 's/^[[:space:]]*//' | cut -c1-40)
             _ui_fail "" "${err_msg:-erreur inconnue}"
             echo ""
@@ -363,10 +363,10 @@ _pipeline_bulk_watch() {
             local name=$(_ui_truncate "$(basename "$repo")" 22)
 
             # Recuperer le dernier pipeline
-            local pipeline_info
+            local pipeline_info=
             pipeline_info=$(_pipeline_bulk_glab "$repo" ci list -F json 2>/dev/null | _pipeline_bulk_parse_first 2>/dev/null)
 
-            local p_id p_status p_duration
+            local p_id= p_status= p_duration=
             p_id=$(echo "$pipeline_info" | cut -d'|' -f1)
             p_status=$(echo "$pipeline_info" | cut -d'|' -f2)
             p_duration=$(echo "$pipeline_info" | cut -d'|' -f3)
@@ -507,7 +507,7 @@ _pipeline_bulk_get_stages() {
     local summary=""
     while IFS= read -r line; do
         if echo "$line" | grep -qE '(passed|failed|running|pending|created|skipped)'; then
-            local status_icon
+            local status_icon=
             if echo "$line" | grep -q 'failed'; then
                 status_icon="${_ui_red}${_ui_cross}${_ui_nc}"
             elif echo "$line" | grep -q 'passed\|success'; then
@@ -517,7 +517,7 @@ _pipeline_bulk_get_stages() {
             else
                 status_icon="${_ui_dim}${_ui_circle}${_ui_nc}"
             fi
-            local job
+            local job=
             job=$(echo "$line" | sed -E 's/[[:space:]]*(.*)[[:space:]]*[-:].*/\1/' | xargs)
             if [[ -n "$job" ]]; then
                 [[ -n "$summary" ]] && summary+=" ${_ui_arrow} "

--- a/modules/kube/kube_config.zsh
+++ b/modules/kube/kube_config.zsh
@@ -188,7 +188,7 @@ kube_init() {
 
             local basename="${sops_file:t}"
             # Retire l'extension .sops.yml ou .sops.yaml
-            local dest_name
+            local dest_name=
             if [[ "$basename" == *.sops.yml ]]; then
                 dest_name="${basename%.sops.yml}.yml"
             elif [[ "$basename" == *.sops.yaml ]]; then

--- a/modules/tools/mise_hooks.zsh
+++ b/modules/tools/mise_hooks.zsh
@@ -414,7 +414,7 @@ _mise_chpwd_hook() {
         for tool in java maven; do
             version=$(command mise current "$tool" 2>/dev/null)
             if [[ -z "$version" ]]; then
-                local requested
+                local requested=
                 requested=$(command mise ls --missing "$tool" 2>/dev/null | head -1 | awk '{print $2}')
                 if [[ -n "$requested" ]]; then
                     missing_tools="${missing_tools:+$missing_tools, }${tool}@${requested}"

--- a/modules/work/config_repos.zsh
+++ b/modules/work/config_repos.zsh
@@ -628,7 +628,7 @@ _work_cfg_confirm_and_apply() {
             u)
                 print -n -- "Quels envs ? (${(j:,:)_WORK_CFG_ENVS_ALL}) "
                 local raw; read -r raw || raw=""
-                local new_envs
+                local new_envs=
                 # _ui_msg_fail ecrit sur stdout, donc la capture avale la plainte.
                 # Sans ce reemis, une saisie fautive fait juste reapparaitre le
                 # prompt, muet : l utilisateur ne sait pas ce qu on lui reproche.
@@ -735,7 +735,7 @@ _work_cfg_apply() {
                 # Corps construit par jq, comme les autres : $a est un nom de branche
                 # normalise par ce module, mais rien ne justifie que ce corps reste le
                 # seul construit par interpolation brute.
-                local _body_defset
+                local _body_defset=
                 _body_defset=$(jq -n --arg br "$a" '{default_branch:$br}') \
                     || { _ui_msg_fail "construction du corps de bascule sur $a"; return 1 }
                 _work_cfg_json PUT "projects/$pid" "$_body_defset" \

--- a/modules/work/merch.zsh
+++ b/modules/work/merch.zsh
@@ -132,12 +132,15 @@ EOF
 # --- Fonction publique ---
 
 work_merch_product() {
-    local env=prod param="" value="" crit_opt=""
+    # `p` est declaree ici, avec les autres, et non dans la boucle : en zsh, un `local`
+    # NU sur une variable qui a deja une valeur IMPRIME « nom=valeur » sur stdout. A la
+    # deuxieme passe de cette boucle, `local p` affichait donc « p=ean » au milieu de la
+    # sortie. Voir tests/bin/bare-local-in-loop.
+    local env=prod param="" value="" crit_opt="" p=""
 
     while (( $# )); do
         case "$1" in
             -e|--ean|-o|--offerId|-s|--sapId|-p|--pimId)
-                local p
                 case "$1" in
                     -e|--ean)     p=ean     ;;
                     -o|--offerId) p=offerId ;;
@@ -249,7 +252,7 @@ _work_merch_status_section() {
     _ui_separator 44
     local env
     for env in prod qlf; do
-        local h k
+        local h= k=
         h="$(_work_merch_host "$env")"
         k="$(_work_merch_api_key "$env")"
         if [[ -n "$h" && -n "$k" ]]; then

--- a/tests/bin/bare-local-in-loop
+++ b/tests/bin/bare-local-in-loop
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Imprime les declarations `local` NUES faites a l'interieur d'une boucle zsh.
+#
+# En zsh — et pas en bash — `local v` sur une variable qui a DEJA une valeur imprime
+# « v=valeur » sur stdout. A la deuxieme passe d'une boucle, une declaration nue affiche
+# donc le contenu de la variable au milieu de la sortie de la commande :
+#
+#   f() { for i in 1 2; do local v; v="x$i"; done; }   # affiche « v=x1 »
+#   f() { for i in 1 2; do local v=; v="x$i"; done; }  # n'affiche rien
+#
+# Ce que ca a coute, trouve le 2026-08-12 :
+#
+#   - `_work_merch_status_section` affichait « k=<cle API> ». La cle etait tenue hors de
+#     `ps` par `curl --config -`, et `work_status` la mettait a l'ecran.
+#   - `_git_bulk_pull` affichait « output=$'There is no tracking information...' » a partir
+#     du deuxieme depot, au milieu de son tableau.
+#
+# Quarante et une declarations etaient concernees, dans huit fichiers.
+#
+# La correction est d'ajouter `=` a la declaration, ou de sortir celle-ci de la boucle. Ne
+# PAS fusionner en `local v=$(cmd)` : `$?` deviendrait celui de `local`, donc toujours 0, et
+# le code retour de la commande serait perdu en silence.
+#
+# python3 plutot que grep : savoir si une ligne est DANS une boucle demande de suivre les
+# `do`/`done`, ce qu'une expression reguliere ne fait pas. python3 est deja requis par
+# .github/workflows/auto-release.yml, et present sur les deux images de la CI.
+set -uo pipefail
+
+ROOT="${ZANVIL_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+
+if ! git -C "$ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+    echo "bare-local-in-loop: $ROOT n'est pas un depot git — controle impossible" >&2
+    exit 2
+fi
+
+cd "$ROOT" || exit 2
+git ls-files '*.zsh' | python3 -c '
+import re, sys
+
+def strip_comment(s):
+    # Un `#` ne commence pas toujours un commentaire : `$#` est le nombre d arguments, et
+    # `${v#prefixe}` retire un prefixe. Les confondre supprimait le `do` de
+    # `while (( $# )); do`, la profondeur retombait a zero, et le controle manquait la
+    # declaration qui suivait — c est arrive a la premiere version de ce script.
+    prot = s.replace("$#", "\x01")
+    prot = re.sub(r"(\$\{[^}]*?)#", lambda m: m.group(1) + "\x02", prot)
+    prot = re.split(r"(?:^|\s)#", prot)[0]
+    return prot.replace("\x01", "$#").replace("\x02", "#")
+
+OPEN  = re.compile(r"(?:^|;|\s)do(?:\s*$|\s*;)")
+CLOSE = re.compile(r"(?:^|;|\s)done(?:\s*$|\s*;|\s)")
+DECL  = re.compile(r"^(local|typeset)\s+(.*)$")
+NAME  = re.compile(r"[A-Za-z_][A-Za-z0-9_]*$")
+
+for path in (p.strip() for p in sys.stdin if p.strip()):
+    try:
+        lines = open(path, encoding="utf-8").read().split("\n")
+    except OSError:
+        continue
+    depth = 0
+    for n, line in enumerate(lines, 1):
+        s = line.strip()
+        if s.startswith("#"):
+            continue
+        code = strip_comment(s)
+        m = DECL.match(code) if depth > 0 else None
+        if m:
+            body = m.group(2).rstrip()
+            # Les declarations avec option (-a, -A, -g) ont une autre semantique et ne
+            # sont pas visees. Une declaration deja porteuse de `=` est correcte.
+            if body and "=" not in body and not body.startswith("-"):
+                if all(NAME.fullmatch(x) for x in body.split()):
+                    print(f"{path}:{n}:{s}")
+        depth += len(OPEN.findall(code)) - len(CLOSE.findall(code))
+        if depth < 0:
+            depth = 0
+' || true

--- a/tests/cases/docs/no-bare-local-in-a-loop.yaml
+++ b/tests/cases/docs/no-bare-local-in-a-loop.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Dr0drigues/gaveldrop/main/docs/case.schema.json
+#
+# Le garde-fou imprime les declarations `local` nues faites dans une boucle, et ce cas exige
+# qu il n en imprime aucune.
+#
+# Motif : en zsh — et PAS en bash — `local v` sur une variable qui a deja une valeur imprime
+# « v=valeur » sur stdout. Dans une boucle, la deuxieme passe affiche donc le contenu de la
+# variable au milieu de la sortie de la commande. Quarante et une declarations etaient
+# concernees le 2026-08-12, dans huit fichiers, dont deux aux consequences visibles :
+#
+#   - `work_status` affichait « k=<cle API> ». La cle etait tenue hors de `ps` par
+#     `curl --config -`, et l affichage d etat la mettait a l ecran.
+#   - `git_bulk` affichait « output=$'There is no tracking information...' » a partir du
+#     deuxieme depot, au milieu de son tableau.
+#
+# CE DEFAUT NE SE VOIT QUE SUR LA DEUXIEME ITERATION, ce qui explique qu il ait survecu :
+# un essai sur un seul depot, ou sur un seul environnement, ne montre rien. Il ne casse rien
+# non plus — aucun code retour ne change, seule la sortie se salit, ce qui le rend invisible
+# a un test qui ne verifie que le code de sortie.
+#
+# La correction est d ajouter `=` a la declaration, ou de la sortir de la boucle. Fusionner
+# en `local v=$(cmd)` serait pire : `$?` deviendrait celui de `local`, donc toujours 0.
+name: no-bare-local-in-a-loop
+weight: 7
+setup:
+  run: ["$GAVELDROP_PROJECT/tests/bin/bare-local-in-loop"]
+  env:
+    ZANVIL_DIR: "$GAVELDROP_PROJECT"
+expect:
+  exit_code: 0
+  stdout:
+    # Une ligne par occurrence : rien a dire, rien a imprimer.
+    equals: ""


### PR DESCRIPTION
## Le défaut

En zsh — et **pas** en bash — `local v` sur une variable qui a déjà une valeur imprime `v=valeur` sur stdout :

```zsh
f() { for i in 1 2; do local v;  v="x$i"; done; }   # affiche « v=x1 »
f() { for i in 1 2; do local v=; v="x$i"; done; }   # n'affiche rien
```

**41 déclarations** étaient dans ce cas, dans 8 fichiers. Deux conséquences constatées :

| Où | Ce qui s'affichait |
|---|---|
| `work_status` | **`k=<clé API merch>`** — la clé en clair à l'écran |
| `git_bulk` | `output=$'There is no tracking information...'` dès le 2ᵉ dépôt, au milieu du tableau |

La première est une fuite de secret que j'ai introduite dans #117 : la clé était soigneusement tenue hors de `ps` par `curl --config -`, et l'affichage d'état la mettait à l'écran.

## Pourquoi ça a échappé

Le défaut **ne se voit qu'à la deuxième itération** — un essai sur un seul dépôt ou un seul environnement ne montre rien. Et il ne casse rien : aucun code retour ne change, seule la sortie se salit. Aucun test vérifiant le code de sortie ne pouvait l'attraper.

## La correction

`local v` → `local v=`. Elle **n'a pas** été fusionnée en `local v=$(cmd)`, qui aurait été pire : `$?` deviendrait celui de `local`, donc toujours 0, et le code retour de la commande serait perdu en silence (vérifié : 3 devient 0). Dans `merch.zsh`, la variable rejoint la déclaration de tête, ce qui supprime la redéclaration au lieu de la taire.

Le risque de la forme retenue a été écarté **avant** de l'appliquer : `local v` laisse la variable *unset*, `local v=` la met à vide. Aucun site du dépôt ne distingue les deux — ni `${var-…}` sans deux-points, ni `[[ -v var ]]`, ni `(( $+var ))` sur un scalaire.

## Le garde-fou

`tests/bin/bare-local-in-loop` + son cas. Il suit les `do`/`done` en `python3` (déjà requis par `auto-release.yml`), parce qu'une expression régulière ne sait pas dire si une ligne est dans une boucle.

Sa première version manquait `local p` de `merch.zsh` : elle prenait le `#` de `while (( $# )); do` pour un commentaire, perdait le `do`, et la profondeur retombait à zéro. Le contrôle protège donc aussi contre `$#` et `${v#prefixe}`.

## Vérification

| Contrôle | Résultat |
|---|---|
| clé API dans `work_status` | présente avant, **absente après** |
| `output=` parasite dans `git_bulk` (3 dépôts) | présent avant, **absent après** |
| sondes de mutation (dont le cas `$#`) | toutes détectées |
| `local v=`, `local -a v` | aucun faux positif |
| `zsh -n` sur les 8 fichiers | correct |
| suite gaveldrop, `main` vs branche | **17 → 15 échecs, aucune régression** |

Les 15 restants emploient `not_written`, un champ que ma version locale de gaveldrop (0.1.8) ne connaît pas et que le CI accepte — `cases` est vert sur ubuntu et macos.

## Deux choses à savoir avant de merger

1. **`hotfix/*` déclenche un bump patch**, donc ce merge publiera `v4.4.1` — mais seulement après #118, sans laquelle `auto-release` ne tourne pas du tout.
2. Ta modification non commitée de `config/lazygit/config.yml` (`pagers:` → `diffRenderers:`) **casse le cas `delta-wires-itself-into-gitconfig-when-the-binary-is-there`**. Vérifié en la neutralisant : le cas repasse. Elle n'est pas dans cette PR, mais elle échouera en CI si tu la commites telle quelle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)